### PR TITLE
Add training plan schema, RLS, server actions, and plan UI

### DIFF
--- a/app/(protected)/plan/actions.ts
+++ b/app/(protected)/plan/actions.ts
@@ -1,0 +1,144 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { z } from "zod";
+import { createClient } from "@/lib/supabase/server";
+
+const uuidSchema = z.string().uuid();
+
+const createPlanSchema = z.object({
+  name: z.string().trim().min(1, "Plan name is required."),
+  startDate: z.string().date(),
+  durationWeeks: z.coerce.number().int().min(1).max(52)
+});
+
+const sessionSchema = z.object({
+  planId: uuidSchema,
+  date: z.string().date(),
+  sport: z.enum(["swim", "bike", "run", "strength", "other"]),
+  sessionType: z.string().trim().min(1, "Session type is required."),
+  durationMinutes: z.coerce.number().int().min(1).max(1440),
+  notes: z.string().trim().max(1000).optional()
+});
+
+const updateSessionSchema = sessionSchema.extend({
+  sessionId: uuidSchema
+});
+
+const deleteSessionSchema = z.object({
+  sessionId: uuidSchema
+});
+
+async function getAuthedClient() {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    throw new Error("You must be signed in.");
+  }
+
+  return { supabase, user };
+}
+
+export async function createPlanAction(formData: FormData) {
+  const parsed = createPlanSchema.parse({
+    name: formData.get("name"),
+    startDate: formData.get("startDate"),
+    durationWeeks: formData.get("durationWeeks")
+  });
+
+  const { supabase, user } = await getAuthedClient();
+
+  const { error } = await supabase.from("training_plans").insert({
+    user_id: user.id,
+    name: parsed.name,
+    start_date: parsed.startDate,
+    duration_weeks: parsed.durationWeeks
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/plan");
+}
+
+export async function createSessionAction(formData: FormData) {
+  const parsed = sessionSchema.parse({
+    planId: formData.get("planId"),
+    date: formData.get("date"),
+    sport: formData.get("sport"),
+    sessionType: formData.get("sessionType"),
+    durationMinutes: formData.get("durationMinutes"),
+    notes: formData.get("notes")
+  });
+
+  const { supabase, user } = await getAuthedClient();
+
+  const { error } = await supabase.from("planned_sessions").insert({
+    user_id: user.id,
+    plan_id: parsed.planId,
+    date: parsed.date,
+    sport: parsed.sport,
+    type: parsed.sessionType,
+    duration: parsed.durationMinutes,
+    notes: parsed.notes ?? null
+  });
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/plan");
+}
+
+export async function updateSessionAction(formData: FormData) {
+  const parsed = updateSessionSchema.parse({
+    sessionId: formData.get("sessionId"),
+    planId: formData.get("planId"),
+    date: formData.get("date"),
+    sport: formData.get("sport"),
+    sessionType: formData.get("sessionType"),
+    durationMinutes: formData.get("durationMinutes"),
+    notes: formData.get("notes")
+  });
+
+  const { supabase, user } = await getAuthedClient();
+
+  const { error } = await supabase
+    .from("planned_sessions")
+    .update({
+      plan_id: parsed.planId,
+      date: parsed.date,
+      sport: parsed.sport,
+      type: parsed.sessionType,
+      duration: parsed.durationMinutes,
+      notes: parsed.notes ?? null,
+      user_id: user.id
+    })
+    .eq("id", parsed.sessionId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/plan");
+}
+
+export async function deleteSessionAction(formData: FormData) {
+  const parsed = deleteSessionSchema.parse({
+    sessionId: formData.get("sessionId")
+  });
+
+  const { supabase } = await getAuthedClient();
+
+  const { error } = await supabase.from("planned_sessions").delete().eq("id", parsed.sessionId);
+
+  if (error) {
+    throw new Error(error.message);
+  }
+
+  revalidatePath("/plan");
+}

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -1,8 +1,209 @@
-export default function PlanPage() {
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import {
+  createPlanAction,
+  createSessionAction,
+  deleteSessionAction,
+  updateSessionAction
+} from "./actions";
+
+type Plan = {
+  id: string;
+  name: string;
+  start_date: string;
+  duration_weeks: number;
+};
+
+type Session = {
+  id: string;
+  plan_id: string;
+  date: string;
+  sport: string;
+  type: string;
+  duration: number;
+  notes: string | null;
+};
+
+function getWeekLabel(date: string) {
+  const start = new Date(date);
+  const day = start.getUTCDay();
+  const distanceFromMonday = day === 0 ? 6 : day - 1;
+  start.setUTCDate(start.getUTCDate() - distanceFromMonday);
+
+  const end = new Date(start);
+  end.setUTCDate(end.getUTCDate() + 6);
+
+  return `${start.toLocaleDateString()} - ${end.toLocaleDateString()}`;
+}
+
+export default async function PlanPage({
+  searchParams
+}: {
+  searchParams?: {
+    plan?: string;
+  };
+}) {
+  const supabase = await createClient();
+
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return null;
+  }
+
+  const { data: plansData } = await supabase
+    .from("training_plans")
+    .select("id,name,start_date,duration_weeks")
+    .order("start_date", { ascending: false });
+
+  const plans = (plansData ?? []) as Plan[];
+
+  const selectedPlan = plans.find((plan: Plan) => plan.id === searchParams?.plan) ?? plans[0];
+
+  const { data: sessionsData } = selectedPlan
+    ? await supabase
+        .from("planned_sessions")
+        .select("id,plan_id,date,sport,type,duration,notes")
+        .eq("plan_id", selectedPlan.id)
+        .order("date", { ascending: true })
+    : { data: [] as Session[] };
+
+  const sessions = (sessionsData ?? []) as Session[];
+
+  const sessionsByWeek = sessions.reduce<Record<string, Session[]>>((groups, session: Session) => {
+    const weekLabel = getWeekLabel(session.date);
+    groups[weekLabel] = [...(groups[weekLabel] ?? []), session as Session];
+    return groups;
+  }, {});
+
   return (
-    <section className="space-y-2">
-      <h1 className="text-2xl font-semibold">Plan</h1>
-      <p className="text-slate-600">Create and edit multi-week triathlon plans here.</p>
+    <section className="space-y-8">
+      <header>
+        <h1 className="text-2xl font-semibold">Training Plan</h1>
+        <p className="text-slate-600">Create a plan and manage sessions by week.</p>
+      </header>
+
+      <div className="grid gap-6 lg:grid-cols-2">
+        <article className="rounded-lg border border-slate-200 bg-white p-4">
+          <h2 className="text-lg font-semibold">Plans</h2>
+          <form action={createPlanAction} className="mt-3 grid gap-3">
+            <input name="name" placeholder="Plan name" required className="rounded border px-3 py-2" />
+            <div className="grid grid-cols-2 gap-3">
+              <input name="startDate" type="date" required className="rounded border px-3 py-2" />
+              <input
+                name="durationWeeks"
+                type="number"
+                min={1}
+                max={52}
+                defaultValue={12}
+                required
+                className="rounded border px-3 py-2"
+              />
+            </div>
+            <button className="rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white">Create plan</button>
+          </form>
+
+          <ul className="mt-4 space-y-2">
+            {plans.map((plan: Plan) => {
+              const isActive = plan.id === selectedPlan?.id;
+              return (
+                <li key={plan.id}>
+                  <Link
+                    href={`/plan?plan=${plan.id}`}
+                    className={`block rounded border px-3 py-2 ${
+                      isActive ? "border-slate-900 bg-slate-100" : "border-slate-200"
+                    }`}
+                  >
+                    <p className="font-medium">{plan.name}</p>
+                    <p className="text-sm text-slate-600">
+                      Starts {plan.start_date} • {plan.duration_weeks} weeks
+                    </p>
+                  </Link>
+                </li>
+              );
+            })}
+            {plans.length === 0 ? <li className="text-sm text-slate-600">No plans yet.</li> : null}
+          </ul>
+        </article>
+
+        {selectedPlan ? (
+          <article className="rounded-lg border border-slate-200 bg-white p-4">
+            <h2 className="text-lg font-semibold">Add Session</h2>
+            <form action={createSessionAction} className="mt-3 grid gap-3">
+              <input type="hidden" name="planId" value={selectedPlan.id} />
+              <div className="grid grid-cols-2 gap-3">
+                <input name="date" type="date" required className="rounded border px-3 py-2" />
+                <input name="durationMinutes" type="number" min={1} required className="rounded border px-3 py-2" />
+              </div>
+              <div className="grid grid-cols-2 gap-3">
+                <select name="sport" required className="rounded border px-3 py-2">
+                  <option value="run">Run</option>
+                  <option value="bike">Bike</option>
+                  <option value="swim">Swim</option>
+                  <option value="strength">Strength</option>
+                  <option value="other">Other</option>
+                </select>
+                <input name="sessionType" placeholder="Intensity / type" required className="rounded border px-3 py-2" />
+              </div>
+              <textarea name="notes" placeholder="Notes" className="rounded border px-3 py-2" rows={3} />
+              <button className="rounded bg-slate-900 px-3 py-2 text-sm font-medium text-white">Add session</button>
+            </form>
+          </article>
+        ) : null}
+      </div>
+
+      {selectedPlan ? (
+        <article className="space-y-4">
+          <h2 className="text-lg font-semibold">Week / Session List</h2>
+          {sessions.length === 0 ? <p className="text-sm text-slate-600">No sessions for this plan.</p> : null}
+          {Object.entries(sessionsByWeek).map(([week, weekSessions]) => (
+            <div key={week} className="rounded-lg border border-slate-200 bg-white p-4">
+              <h3 className="mb-3 font-medium">Week of {week}</h3>
+              <div className="space-y-3">
+                {weekSessions.map((session: Session) => (
+                  <form key={session.id} action={updateSessionAction} className="rounded border border-slate-200 p-3">
+                    <input type="hidden" name="sessionId" value={session.id} />
+                    <input type="hidden" name="planId" value={selectedPlan.id} />
+                    <div className="grid gap-3 md:grid-cols-5">
+                      <input name="date" type="date" defaultValue={session.date} required className="rounded border px-2 py-1" />
+                      <select name="sport" defaultValue={session.sport} required className="rounded border px-2 py-1">
+                        <option value="run">Run</option>
+                        <option value="bike">Bike</option>
+                        <option value="swim">Swim</option>
+                        <option value="strength">Strength</option>
+                        <option value="other">Other</option>
+                      </select>
+                      <input
+                        name="durationMinutes"
+                        type="number"
+                        min={1}
+                        defaultValue={session.duration}
+                        required
+                        className="rounded border px-2 py-1"
+                      />
+                      <input
+                        name="sessionType"
+                        defaultValue={session.type}
+                        required
+                        className="rounded border px-2 py-1"
+                      />
+                      <input name="notes" defaultValue={session.notes ?? ""} className="rounded border px-2 py-1" />
+                    </div>
+                    <div className="mt-3 flex gap-2">
+                      <button className="rounded bg-slate-900 px-3 py-1 text-sm text-white">Save</button>
+                      <button formAction={deleteSessionAction} className="rounded border px-3 py-1 text-sm">
+                        Delete
+                      </button>
+                    </div>
+                  </form>
+                ))}
+              </div>
+            </div>
+          ))}
+        </article>
+      ) : null}
     </section>
   );
 }

--- a/supabase/migrations/202602190001_create_training_plan_tables.sql
+++ b/supabase/migrations/202602190001_create_training_plan_tables.sql
@@ -1,0 +1,96 @@
+create extension if not exists pgcrypto;
+
+create table if not exists public.training_plans (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  name text not null,
+  start_date date not null,
+  duration_weeks integer not null check (duration_weeks > 0),
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table if not exists public.planned_sessions (
+  id uuid primary key default gen_random_uuid(),
+  plan_id uuid not null references public.training_plans(id) on delete cascade,
+  user_id uuid not null references auth.users(id) on delete cascade,
+  date date not null,
+  sport text not null check (sport in ('swim', 'bike', 'run', 'strength', 'other')),
+  type text not null,
+  duration integer not null check (duration > 0),
+  notes text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists training_plans_user_id_idx on public.training_plans(user_id);
+create index if not exists planned_sessions_plan_id_idx on public.planned_sessions(plan_id);
+create index if not exists planned_sessions_user_id_idx on public.planned_sessions(user_id);
+create index if not exists planned_sessions_date_idx on public.planned_sessions(date);
+
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists set_training_plans_updated_at on public.training_plans;
+create trigger set_training_plans_updated_at
+before update on public.training_plans
+for each row
+execute procedure public.set_updated_at();
+
+drop trigger if exists set_planned_sessions_updated_at on public.planned_sessions;
+create trigger set_planned_sessions_updated_at
+before update on public.planned_sessions
+for each row
+execute procedure public.set_updated_at();
+
+alter table public.training_plans enable row level security;
+alter table public.planned_sessions enable row level security;
+
+create policy "training_plans_select_own"
+on public.training_plans
+for select
+using (auth.uid() = user_id);
+
+create policy "training_plans_insert_own"
+on public.training_plans
+for insert
+with check (auth.uid() = user_id);
+
+create policy "training_plans_update_own"
+on public.training_plans
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "training_plans_delete_own"
+on public.training_plans
+for delete
+using (auth.uid() = user_id);
+
+create policy "planned_sessions_select_own"
+on public.planned_sessions
+for select
+using (auth.uid() = user_id);
+
+create policy "planned_sessions_insert_own"
+on public.planned_sessions
+for insert
+with check (auth.uid() = user_id);
+
+create policy "planned_sessions_update_own"
+on public.planned_sessions
+for update
+using (auth.uid() = user_id)
+with check (auth.uid() = user_id);
+
+create policy "planned_sessions_delete_own"
+on public.planned_sessions
+for delete
+using (auth.uid() = user_id);


### PR DESCRIPTION
### Motivation

- Implement persistent training plan and planned session storage (date, sport, type, duration, notes) and enforce per-user ownership. 
- Provide server-side actions with validation to create/update/delete plans and sessions and expose a basic in-app UI for plan management. 
- Co-locate validation with actions using Zod to match existing patterns used for env validation.

### Description

- Added a Supabase migration `supabase/migrations/202602190001_create_training_plan_tables.sql` that creates `training_plans` and `planned_sessions` with UUID primary keys, ownership (`user_id`), constraints, indexes, timestamps, update triggers, and enabled Row Level Security policies scoped to `auth.uid() = user_id` for select/insert/update/delete. 
- Implemented server actions with colocated Zod schemas in `app/(protected)/plan/actions.ts` to `createPlanAction`, `createSessionAction`, `updateSessionAction`, and `deleteSessionAction`, including an auth check using the server Supabase client. 
- Replaced the placeholder plan page at `app/(protected)/plan/page.tsx` with a plan selector/creator, week-grouped session list, and session forms (fields: sport, duration, intensity/type, notes, date) wired to the server actions. 

### Testing

- Ran `npm run lint` which failed due to the repository ESLint config referencing `next/typescript` that cannot be resolved in this environment. 
- Ran `npm run typecheck` which failed because of pre-existing module/type resolution errors for `@supabase/ssr` outside the scope of these changes. 
- Started the dev server with `next dev` and captured an automated screenshot of the updated `/plan` page via Playwright, confirming the UI renders in the running dev server.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699788748b80833290b0563b49ba1c97)