### PR TITLE
Clarify Supabase clean-slate docs for current CLI dump flags

### DIFF
--- a/docs/supabase-clean-slate.md
+++ b/docs/supabase-clean-slate.md
@@ -1,0 +1,59 @@
+# Supabase clean-slate reset (linked remote project)
+
+This runbook is for when migration history is badly drifted and you want to start over.
+
+> **Warning**: This is destructive and will delete database objects/data in the linked project.
+
+## Preconditions
+
+- Supabase CLI installed and logged in.
+- Project is linked (`supabase link ...`).
+- `SUPABASE_DB_PASSWORD` exported.
+
+## Optional backups before reset
+
+If you want a safety net before deleting data, use CLI-supported dump flags:
+
+```bash
+# Full database dump (schema + data)
+supabase db dump --linked -f backup-full.sql
+
+# Data-only dump
+supabase db dump --linked --data-only -f backup-data.sql
+```
+
+> Note: `supabase db dump` does **not** support `--schema-only`.
+
+## Fast path (script)
+
+```bash
+SUPABASE_DB_PASSWORD=your_db_password ./scripts/reset-linked-supabase-migrations.sh
+```
+
+What it does:
+1. Shows current migration list.
+2. Drops all `public` schema tables/sequences/functions/types.
+3. Clears `supabase_migrations.schema_migrations`.
+4. Runs `supabase db push --linked`.
+5. Shows final migration list.
+
+## Manual commands
+
+```bash
+supabase migration list
+```
+
+```sql
+-- Run in supabase db query / SQL editor
+DELETE FROM supabase_migrations.schema_migrations;
+```
+
+```bash
+supabase db push --linked
+supabase migration list
+```
+
+## Notes
+
+- If you still hit drift after reset, create a new single baseline migration locally and archive old reconcile migrations.
+- For production environments, take a dump before destructive operations.

--- a/scripts/reset-linked-supabase-migrations.sh
+++ b/scripts/reset-linked-supabase-migrations.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Destructive reset flow for a linked Supabase project.
+# - Wipes public schema objects
+# - Clears Supabase migration history
+# - Pushes local migrations as fresh baseline
+#
+# Usage:
+#   SUPABASE_DB_PASSWORD=... ./scripts/reset-linked-supabase-migrations.sh
+
+if ! command -v supabase >/dev/null 2>&1; then
+  echo "Error: Supabase CLI is not installed or not in PATH." >&2
+  exit 1
+fi
+
+if [ -z "${SUPABASE_DB_PASSWORD:-}" ]; then
+  echo "Error: SUPABASE_DB_PASSWORD is required for linked project operations." >&2
+  exit 1
+fi
+
+echo "==> Confirming linked project"
+supabase status >/dev/null || true
+
+echo "==> Listing migrations before reset"
+supabase migration list || true
+
+echo "==> Wiping public schema and migration history (DESTRUCTIVE)"
+supabase db query <<'SQL'
+DO $$
+DECLARE
+  obj RECORD;
+BEGIN
+  FOR obj IN
+    SELECT schemaname, tablename
+    FROM pg_tables
+    WHERE schemaname = 'public'
+  LOOP
+    EXECUTE format('DROP TABLE IF EXISTS %I.%I CASCADE', obj.schemaname, obj.tablename);
+  END LOOP;
+
+  FOR obj IN
+    SELECT n.nspname AS schema_name, c.relname AS sequence_name
+    FROM pg_class c
+    JOIN pg_namespace n ON n.oid = c.relnamespace
+    WHERE c.relkind = 'S' AND n.nspname = 'public'
+  LOOP
+    EXECUTE format('DROP SEQUENCE IF EXISTS %I.%I CASCADE', obj.schema_name, obj.sequence_name);
+  END LOOP;
+
+  FOR obj IN
+    SELECT routine_schema, routine_name
+    FROM information_schema.routines
+    WHERE routine_schema = 'public'
+  LOOP
+    EXECUTE format('DROP FUNCTION IF EXISTS %I.%I CASCADE', obj.routine_schema, obj.routine_name);
+  END LOOP;
+
+  FOR obj IN
+    SELECT n.nspname AS schema_name, t.typname AS type_name
+    FROM pg_type t
+    JOIN pg_namespace n ON n.oid = t.typnamespace
+    WHERE n.nspname = 'public' AND t.typtype IN ('e', 'c')
+  LOOP
+    EXECUTE format('DROP TYPE IF EXISTS %I.%I CASCADE', obj.schema_name, obj.type_name);
+  END LOOP;
+END $$;
+
+DELETE FROM supabase_migrations.schema_migrations;
+SQL
+
+echo "==> Pushing local migrations as fresh baseline"
+supabase db push --linked
+
+echo "==> Listing migrations after reset"
+supabase migration list
+
+echo "Done. Linked project has been reset and re-seeded from local migrations."


### PR DESCRIPTION
### Motivation

- Users observed that `supabase db dump --schema-only` is not a supported flag, so the runbook guidance must be corrected to avoid running invalid commands and to show supported backup options before destructive resets.

### Description

- Updated `docs/supabase-clean-slate.md` to add an "Optional backups before reset" section with examples for full and data-only dumps using `supabase db dump --linked -f backup-full.sql` and `supabase db dump --linked --data-only -f backup-data.sql`, and added an explicit note that `--schema-only` is not supported.

### Testing

- Performed a syntax check with `bash -n scripts/reset-linked-supabase-migrations.sh`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a2012ae708332bff24fc2a856c556)