### PR TITLE
Add UI design strategy gate (Bold Builder + Likeable Leader)

### DIFF
--- a/docs/design-strategy-gate.md
+++ b/docs/design-strategy-gate.md
@@ -1,0 +1,38 @@
+# Design Strategy Gate: Bold Builder + Likeable Leader
+
+## Target Archetype Blend
+- **Primary blend:** **Bold Builder + Likeable Leader**.
+- **Explicitly rejected for this product context:** Innocent, Explorer, Sage, Hero, Outlaw, Magician, Everyman, Lover, Jester, Caregiver, Creator, Ruler.
+
+## Brand Promise
+**Performance intelligence for athletes.**
+
+## Emotional Targets
+The product should leave athletes feeling:
+- **Confident** (clarity in decisions and next actions)
+- **Focused** (signal over noise)
+- **Calm under load** (composed when training stress is high)
+
+## Visual Direction from Report Trends
+### Keep
+- Restrained dark base
+- Controlled gradients
+- Technical micro-visuals (precise charts, metrics, subtle system cues)
+
+### Avoid
+- Whimsical mascots
+- Dreamy surreal scenes
+- Over-romantic humanist illustration
+
+## One-Page Before/After Moodboard Direction
+Use these as quick visual checks in reviews.
+
+| Surface | Before (move away from) | After (enforce) |
+|---|---|---|
+| **Dashboard** | Generic wellness vibes, decorative hero art, soft lifestyle photography | High-contrast performance command center; dense-but-readable KPIs; restrained gradient accents tied to training status |
+| **Plan** | Playful cards and coaching tone that feels casual or motivational-only | Structured training blocks with decisive hierarchy; coach voice that is supportive but operational |
+| **Calendar** | Cute iconography, over-illustrated empty states, novelty color coding | Technical schedule grid with clear load/recovery rhythm; calm status coding and minimal ornament |
+| **Coach** | Romanticized “life coach” framing, emotive illustrations, abstract inspiration scenes | Trusted performance partner framing; concise recommendations, evidence-linked insights, and precise confidence cues |
+
+## PR Gate Requirement
+This brief is the **design gate for all future UI PRs**. Any new UI must demonstrate alignment with **Bold Builder + Likeable Leader** and the keep/avoid rules above before approval.


### PR DESCRIPTION
### Motivation
- Introduce a single, reviewable design brief that sets the product archetype to **Bold Builder + Likeable Leader** and explicitly rejects other archetypes for this product context. 
- Provide clear visual and emotional constraints so future UI work aligns with the product's performance-focused brand and review standards.

### Description
- Add `docs/design-strategy-gate.md` containing the target archetype blend and an explicit list of rejected archetypes. 
- Include the brand promise `Performance intelligence for athletes`, emotional targets (confident, focused, calm under load), and a visual keep/avoid list mapped to report trends. 
- Provide a one-page before/after moodboard direction for `Dashboard`, `Plan`, `Calendar`, and `Coach`, and declare this brief as the gate for all future UI PRs.

### Testing
- Confirmed the new file `docs/design-strategy-gate.md` exists and contains the expected content via repository status and file listing checks (succeeded). 
- No unit or integration tests were changed by this documentation-only update; CI should run as part of the normal PR validation to verify repository-level checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f06a6d4fc8332ac982975135cd5c5)