### PR TITLE
Add MVP Activity Details page with manual session linking

### DIFF
--- a/app/(protected)/activities/[activityId]/actions.ts
+++ b/app/(protected)/activities/[activityId]/actions.ts
@@ -1,0 +1,86 @@
+"use server";
+
+import { revalidatePath } from "next/cache";
+import { createClient } from "@/lib/supabase/server";
+
+export async function linkActivityAction(activityId: string, plannedSessionId: string) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { data: session } = await supabase.from("sessions").select("id").eq("id", plannedSessionId).eq("user_id", user.id).maybeSingle();
+  if (!session) return { error: "Session not found" };
+
+  await supabase.from("session_activity_links").delete().eq("user_id", user.id).eq("completed_activity_id", activityId);
+
+  const { error } = await supabase.from("session_activity_links").insert({
+    user_id: user.id,
+    planned_session_id: plannedSessionId,
+    completed_activity_id: activityId,
+    link_type: "manual",
+    confidence: 1,
+    match_reason: { source: "activity_details" }
+  });
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/activities/${activityId}`);
+  revalidatePath("/dashboard");
+  return { ok: true };
+}
+
+export async function unlinkActivityAction(activityId: string) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { error } = await supabase.from("session_activity_links").delete().eq("user_id", user.id).eq("completed_activity_id", activityId);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/activities/${activityId}`);
+  revalidatePath("/dashboard");
+  return { ok: true };
+}
+
+export async function markUnplannedAction(activityId: string) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  await supabase.from("session_activity_links").delete().eq("user_id", user.id).eq("completed_activity_id", activityId);
+  const { error } = await supabase.from("completed_activities").update({ is_unplanned: true }).eq("id", activityId).eq("user_id", user.id);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/activities/${activityId}`);
+  revalidatePath("/dashboard");
+  return { ok: true };
+}
+
+export async function updateActivityNotesAction(activityId: string, notes: string) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { error } = await supabase
+    .from("completed_activities")
+    .update({ notes: notes.trim() ? notes.trim() : null })
+    .eq("id", activityId)
+    .eq("user_id", user.id);
+
+  if (error) return { error: error.message };
+
+  revalidatePath(`/activities/${activityId}`);
+  return { ok: true };
+}
+
+export async function toggleRaceAction(activityId: string, isRace: boolean) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  const { error } = await supabase.from("completed_activities").update({ is_race: isRace }).eq("id", activityId).eq("user_id", user.id);
+  if (error) return { error: error.message };
+
+  revalidatePath(`/activities/${activityId}`);
+  return { ok: true };
+}

--- a/app/(protected)/activities/[activityId]/activity-linking-card.tsx
+++ b/app/(protected)/activities/[activityId]/activity-linking-card.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import type { SessionCandidate } from "@/lib/workouts/activity-details";
+import { linkActivityAction, markUnplannedAction, toggleRaceAction, unlinkActivityAction, updateActivityNotesAction } from "./actions";
+
+export function ActivityLinkingCard({
+  activityId,
+  linkedSession,
+  candidates,
+  isRace,
+  initialNotes,
+  isUnplanned
+}: {
+  activityId: string;
+  linkedSession: SessionCandidate | null;
+  candidates: SessionCandidate[];
+  isRace: boolean;
+  initialNotes: string | null;
+  isUnplanned: boolean;
+}) {
+  const [selectedSessionId, setSelectedSessionId] = useState(candidates[0]?.id ?? "");
+  const [notes, setNotes] = useState(initialNotes ?? "");
+  const [message, setMessage] = useState("");
+  const [pending, startTransition] = useTransition();
+
+  return (
+    <div className="space-y-4">
+      <article className="surface p-4">
+        {linkedSession ? (
+          <>
+            <h2 className="text-sm font-semibold">Linked planned session</h2>
+            <div className="surface-subtle mt-3 rounded-lg p-3 text-sm">
+              <p className="font-medium">{linkedSession.type}</p>
+              <p className="text-xs text-muted">{linkedSession.sport} · {linkedSession.date}</p>
+              <p className="mt-1 text-xs text-muted">Planned {linkedSession.duration_minutes ?? "—"} min</p>
+            </div>
+            <div className="mt-3 flex gap-2">
+              <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void unlinkActivityAction(activityId))}>Unlink</button>
+              <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void unlinkActivityAction(activityId))}>Change link…</button>
+            </div>
+          </>
+        ) : (
+          <>
+            <h2 className="text-sm font-semibold">Attach to planned session</h2>
+            {candidates.length === 0 ? (
+              <p className="mt-2 text-sm text-muted">No planned sessions found for this day.</p>
+            ) : (
+              <ul className="mt-3 space-y-2">
+                {candidates.slice(0, 3).map((candidate) => (
+                  <li key={candidate.id} className="surface-subtle rounded-lg p-3 text-sm">
+                    <label className="flex cursor-pointer items-start gap-2">
+                      <input
+                        type="radio"
+                        className="mt-0.5"
+                        name="candidate"
+                        value={candidate.id}
+                        checked={selectedSessionId === candidate.id}
+                        onChange={() => setSelectedSessionId(candidate.id)}
+                      />
+                      <span>
+                        <span className="font-medium">{candidate.type}</span>
+                        <span className="block text-xs text-muted">{candidate.sport} · {candidate.date}</span>
+                        <span className="block text-xs text-muted">{candidate.duration_minutes ?? "—"} min {candidate.isRecommended ? "· Recommended" : ""}</span>
+                      </span>
+                    </label>
+                  </li>
+                ))}
+              </ul>
+            )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <button
+                className="btn-primary text-xs"
+                disabled={pending || !selectedSessionId}
+                onClick={() => startTransition(async () => {
+                  const result = await linkActivityAction(activityId, selectedSessionId);
+                  if (result?.error) setMessage(result.error);
+                })}
+              >
+                Link activity
+              </button>
+              <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void markUnplannedAction(activityId))}>This wasn&apos;t planned</button>
+            </div>
+            {isUnplanned ? <p className="mt-2 text-xs text-muted">Marked as intentionally unplanned.</p> : null}
+          </>
+        )}
+      </article>
+
+      <article className="surface p-4">
+        <h3 className="text-sm font-semibold">Quick actions</h3>
+        <div className="mt-3 space-y-2">
+          <label className="block text-xs text-muted">Notes</label>
+          <textarea className="input-base min-h-24 w-full" value={notes} onChange={(event) => setNotes(event.target.value)} />
+          <button
+            className="btn-secondary text-xs"
+            disabled={pending}
+            onClick={() => startTransition(async () => {
+              const result = await updateActivityNotesAction(activityId, notes);
+              setMessage(result?.error ? result.error : "Saved");
+            })}
+          >
+            Add note
+          </button>
+        </div>
+        <button className="btn-secondary mt-3 text-xs" disabled={pending} onClick={() => startTransition(async () => void toggleRaceAction(activityId, !isRace))}>
+          {isRace ? "Unmark race" : "Mark as race"}
+        </button>
+        {message ? <p className="mt-2 text-xs text-muted">{message}</p> : null}
+      </article>
+    </div>
+  );
+}

--- a/app/(protected)/activities/[activityId]/page.tsx
+++ b/app/(protected)/activities/[activityId]/page.tsx
@@ -1,0 +1,122 @@
+import Link from "next/link";
+import { notFound } from "next/navigation";
+import { loadActivityDetails } from "@/lib/workouts/activity-details";
+import { ActivityLinkingCard } from "./activity-linking-card";
+
+function sportIcon(sport: string) {
+  if (sport === "run") return "🏃";
+  if (sport === "bike") return "🚴";
+  if (sport === "swim") return "🏊";
+  if (sport === "strength") return "🏋️";
+  return "🏅";
+}
+
+function formatDuration(sec: number) {
+  const h = Math.floor(sec / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m ${s}s`;
+}
+
+function formatDistance(distanceM?: number | null) {
+  if (!distanceM) return "—";
+  return `${(distanceM / 1000).toFixed(2)} km`;
+}
+
+function derivePaceOrSpeed(sport: string, durationSec: number, distanceM: number | null) {
+  if (!distanceM || distanceM <= 0) return "—";
+  const km = distanceM / 1000;
+  const speedKmh = (distanceM / durationSec) * 3.6;
+  if (sport === "bike") return `${speedKmh.toFixed(1)} km/h`;
+  if (sport === "swim") return `${Math.round((durationSec / distanceM) * 100)}s /100m`;
+  return `${Math.floor((durationSec / km) / 60)}:${String(Math.round((durationSec / km) % 60)).padStart(2, "0")} /km`;
+}
+
+export default async function ActivityDetailsPage({ params }: { params: { activityId: string } }) {
+  const payload = await loadActivityDetails(params.activityId);
+  if (!payload) notFound();
+
+  const { activity, linkedSession, candidates } = payload;
+  const dateLabel = new Date(activity.start_time_utc).toLocaleString(undefined, {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+
+  const laps = Array.isArray(activity.parse_summary?.laps) ? activity.parse_summary?.laps : [];
+
+  return (
+    <section className="space-y-4">
+      <Link href="/dashboard" className="text-sm text-cyan-300 underline-offset-2 hover:underline">← Back to Dashboard</Link>
+
+      <div className="grid gap-4 lg:grid-cols-[1.3fr_0.8fr]">
+        <div className="space-y-4">
+          <article className="surface p-5">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <h1 className="text-2xl font-semibold">{sportIcon(activity.sport_type)} Activity</h1>
+                <p className="mt-1 text-sm text-muted">{dateLabel}</p>
+                <div className="mt-2 flex gap-2 text-xs">
+                  <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">{activity.source === "upload" ? "Garmin upload" : "Synced"}</span>
+                  <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">{linkedSession ? "Linked" : "Unassigned"}</span>
+                </div>
+              </div>
+            </div>
+          </article>
+
+          <article className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
+            {[
+              ["Duration", formatDuration(activity.duration_sec)],
+              ["Distance", formatDistance(activity.distance_m)],
+              [activity.sport_type === "bike" ? "Speed" : "Pace", derivePaceOrSpeed(activity.sport_type, activity.duration_sec, activity.distance_m)],
+              ["Avg HR", activity.avg_hr ? `${activity.avg_hr} bpm` : "—"],
+              ["Avg Power", activity.avg_power ? `${activity.avg_power} w` : "—"]
+            ].map(([label, value]) => (
+              <div key={label} className="surface p-4">
+                <p className="text-xs text-muted">{label}</p>
+                <p className="mt-1 text-xl font-semibold tabular-nums">{value}</p>
+              </div>
+            ))}
+          </article>
+
+          <article className="surface p-5">
+            <h2 className="text-sm font-semibold">Key details</h2>
+            <dl className="mt-3 grid grid-cols-2 gap-2 text-sm">
+              <dt className="text-muted">Start time</dt><dd>{new Date(activity.start_time_utc).toLocaleString()}</dd>
+              <dt className="text-muted">End time</dt><dd>{activity.end_time_utc ? new Date(activity.end_time_utc).toLocaleString() : "—"}</dd>
+              <dt className="text-muted">Calories</dt><dd>{activity.calories ?? "—"}</dd>
+            </dl>
+          </article>
+
+          <article className="surface p-5">
+            <h2 className="text-sm font-semibold">Splits / intervals</h2>
+            {laps.length === 0 ? (
+              <p className="mt-3 text-sm text-muted">Splits coming soon.</p>
+            ) : (
+              <div className="mt-3 overflow-auto">
+                <table className="min-w-full text-sm">
+                  <thead><tr className="text-left text-xs uppercase text-muted"><th>Lap</th><th>Split time</th><th>Distance</th><th>Avg HR</th><th>Avg Power</th></tr></thead>
+                  <tbody>{laps.map((lap: any, index: number) => (
+                    <tr key={index} className="border-t border-white/10"><td className="py-2">{index + 1}</td><td>{String(lap.duration_sec ?? "—")}</td><td>{lap.distance_m ? `${(Number(lap.distance_m) / 1000).toFixed(2)} km` : "—"}</td><td>{lap.avg_hr ?? "—"}</td><td>{lap.avg_power ?? "—"}</td></tr>
+                  ))}</tbody>
+                </table>
+              </div>
+            )}
+          </article>
+        </div>
+
+        <ActivityLinkingCard
+          activityId={activity.id}
+          linkedSession={linkedSession}
+          candidates={candidates}
+          isRace={activity.is_race}
+          initialNotes={activity.notes}
+          isUnplanned={activity.is_unplanned}
+        />
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -323,6 +323,13 @@ export default async function DashboardPage({
               <p className="text-xs uppercase tracking-[0.12em] text-amber-200">Garmin uploads</p>
               <p className="mt-1 text-sm text-amber-100">{unassignedUploads.length} unassigned uploaded activit{unassignedUploads.length === 1 ? "y" : "ies"} this week ({unassignedMinutes} min).</p>
               <Link href="/settings/integrations" className="mt-2 inline-block text-xs text-cyan-200 underline">Attach uploads to planned sessions</Link>
+              <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                {unassignedUploads.slice(0, 3).map((item) => (
+                  <Link key={item.id} href={`/activities/${item.id}`} className="rounded-full border border-amber-200/30 px-2 py-1 text-amber-100">
+                    View {item.sport_type}
+                  </Link>
+                ))}
+              </div>
             </article>
           ) : null}
 

--- a/app/(protected)/settings/integrations/activity-uploads-panel.tsx
+++ b/app/(protected)/settings/integrations/activity-uploads-panel.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Link from "next/link";
 import { useMemo, useState, useTransition } from "react";
 
 type UploadRow = {
@@ -133,7 +134,7 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions }: { init
                   <td>{activity?.distance_m ? `${(Number(activity.distance_m) / 1000).toFixed(2)} km` : "—"}</td>
                   <td>{upload.status === "error" ? "Error" : linked ? "Linked" : "Unassigned"}</td>
                   <td className="space-x-2 text-xs">
-                    <button className="text-cyan-300 underline" onClick={() => setDetailId(upload.id)}>View details</button>
+                    {activity?.id ? <Link className="text-cyan-300 underline" href={`/activities/${activity.id}`}>View activity</Link> : <button className="text-cyan-300 underline" onClick={() => setDetailId(upload.id)}>View details</button>}
                     {!linked && upload.status !== "error" ? (
                       <button className="text-cyan-300 underline" onClick={() => setAttachFor(upload)}>Attach to planned session</button>
                     ) : null}

--- a/lib/workouts/activity-details.ts
+++ b/lib/workouts/activity-details.ts
@@ -1,0 +1,125 @@
+import { createClient } from "@/lib/supabase/server";
+import { scoreCandidate } from "@/lib/workouts/activity-matching";
+
+export type ActivityDetails = {
+  id: string;
+  user_id: string;
+  upload_id: string | null;
+  sport_type: string;
+  start_time_utc: string;
+  end_time_utc: string | null;
+  duration_sec: number;
+  distance_m: number | null;
+  avg_hr: number | null;
+  avg_power: number | null;
+  calories: number | null;
+  source: string;
+  parse_summary: { laps?: Array<Record<string, unknown>> } | null;
+  notes: string | null;
+  is_unplanned: boolean;
+  is_race: boolean;
+};
+
+export type SessionCandidate = {
+  id: string;
+  date: string;
+  sport: string;
+  type: string;
+  duration_minutes: number | null;
+  distance_m?: number | null;
+  start_time_utc?: string | null;
+  confidence: number;
+  isRecommended: boolean;
+};
+
+export type ActivityDetailsPayload = {
+  activity: ActivityDetails;
+  linkedSession: SessionCandidate | null;
+  candidates: SessionCandidate[];
+};
+
+function toIsoDay(value: string) {
+  return new Date(value).toISOString().slice(0, 10);
+}
+
+function toCandidateStartTime(session: { date: string; start_time_utc?: string | null }) {
+  return session.start_time_utc ?? `${session.date}T06:00:00.000Z`;
+}
+
+export async function loadActivityDetails(activityId: string): Promise<ActivityDetailsPayload | null> {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data: activity } = await supabase
+    .from("completed_activities")
+    .select("id,user_id,upload_id,sport_type,start_time_utc,end_time_utc,duration_sec,distance_m,avg_hr,avg_power,calories,source,parse_summary,notes,is_unplanned,is_race")
+    .eq("id", activityId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!activity) return null;
+
+  const { data: existingLinks } = await supabase
+    .from("session_activity_links")
+    .select("planned_session_id,confidence")
+    .eq("user_id", user.id)
+    .eq("completed_activity_id", activity.id)
+    .limit(1);
+
+  const link = existingLinks?.[0] ?? null;
+  const activityStart = new Date(activity.start_time_utc);
+  const windowStart = new Date(activityStart.getTime() - 6 * 3600 * 1000).toISOString();
+  const windowEnd = new Date(activityStart.getTime() + 6 * 3600 * 1000).toISOString();
+  const dayIso = toIsoDay(activity.start_time_utc);
+
+  const { data: rawSessions } = await supabase
+    .from("sessions")
+    .select("id,date,sport,type,duration_minutes,distance_m,start_time_utc")
+    .eq("user_id", user.id)
+    .or(`and(date.eq.${dayIso}),and(start_time_utc.gte.${windowStart},start_time_utc.lte.${windowEnd})`)
+    .order("date", { ascending: true })
+    .limit(12);
+
+  const scored = ((rawSessions ?? []) as Array<any>).map((session) => {
+    const scoredCandidate = scoreCandidate(
+      {
+        sportType: activity.sport_type,
+        startTimeUtc: activity.start_time_utc,
+        durationSec: activity.duration_sec,
+        distanceM: Number(activity.distance_m ?? 0)
+      },
+      {
+        id: session.id,
+        sport: session.sport,
+        startTimeUtc: toCandidateStartTime(session),
+        targetDurationSec: session.duration_minutes ? session.duration_minutes * 60 : null,
+        targetDistanceM: Number(session.distance_m ?? 0) || null
+      }
+    );
+
+    return {
+      id: session.id,
+      date: session.date,
+      sport: session.sport,
+      type: session.type,
+      duration_minutes: session.duration_minutes,
+      distance_m: session.distance_m,
+      start_time_utc: session.start_time_utc,
+      confidence: scoredCandidate.confidence,
+      isRecommended: scoredCandidate.confidence >= 0.75
+    } satisfies SessionCandidate;
+  });
+
+  const candidates = scored.sort((a, b) => b.confidence - a.confidence);
+  const linkedSession = link ? candidates.find((candidate) => candidate.id === link.planned_session_id) ?? null : null;
+
+  return {
+    activity: activity as ActivityDetails,
+    linkedSession,
+    candidates
+  };
+}

--- a/lib/workouts/activity-matching.test.ts
+++ b/lib/workouts/activity-matching.test.ts
@@ -27,3 +27,12 @@ test("pickAutoMatch accepts strong clear winner", () => {
   ]);
   assert.equal(result?.candidateId, "a");
 });
+
+test("score candidate tolerates missing distance", () => {
+  const score = scoreCandidate(
+    { sportType: "strength", startTimeUtc: "2026-02-22T10:00:00.000Z", durationSec: 2700 },
+    { id: "s1", sport: "strength", startTimeUtc: "2026-02-22T10:05:00.000Z", targetDurationSec: 3000 }
+  );
+
+  assert.ok(score.confidence > 0.7);
+});

--- a/lib/workouts/activity-matching.ts
+++ b/lib/workouts/activity-matching.ts
@@ -10,7 +10,7 @@ export type MatchInput = {
   sportType: string;
   startTimeUtc: string;
   durationSec: number;
-  distanceM: number;
+  distanceM?: number | null;
 };
 
 export type ScoredCandidate = {
@@ -35,7 +35,7 @@ export function scoreCandidate(activity: MatchInput, candidate: MatchingCandidat
     ? Math.abs(activity.durationSec - candidate.targetDurationSec) / candidate.targetDurationSec
     : null;
   const distanceDelta = candidate.targetDistanceM && candidate.targetDistanceM > 0
-    ? Math.abs(activity.distanceM - candidate.targetDistanceM) / candidate.targetDistanceM
+    ? Math.abs((activity.distanceM ?? 0) - candidate.targetDistanceM) / candidate.targetDistanceM
     : null;
 
   const durationScore = durationDelta === null ? 0.5 : clamp(1 - durationDelta);

--- a/supabase/migrations/202602220007_activity_details_fields.sql
+++ b/supabase/migrations/202602220007_activity_details_fields.sql
@@ -1,0 +1,11 @@
+alter table public.completed_activities
+  add column if not exists notes text,
+  add column if not exists is_unplanned boolean not null default false,
+  add column if not exists is_race boolean not null default false;
+
+alter table public.completed_activities
+  drop constraint if exists completed_activities_source_check;
+
+alter table public.completed_activities
+  add constraint completed_activities_source_check
+  check (source in ('upload', 'garmin', 'synced'));


### PR DESCRIPTION
### Motivation
- Provide a focused MVP Activity Details screen for completed activities so users can inspect core metrics and manage links to planned sessions. 
- Enable straightforward manual linking/unlinking and lightweight notes/flags without adding streaming charts yet, while adding the data model hooks needed for future features. 

### Description
- Added a protected route and UI at `/activities/[activityId]` with a two-column layout including header/status pills, hero metrics, key details, splits placeholder/table, and a linking/actions column. 
- Implemented server-side data loader `loadActivityDetails` to fetch the `completed_activities` row, any existing `session_activity_links`, and candidate planned sessions (same day or ±6h) scored by `scoreCandidate`. 
- Added server actions for `linkActivityAction`, `unlinkActivityAction`, `markUnplannedAction`, `updateActivityNotesAction`, and `toggleRaceAction` that enforce user ownership and revalidate relevant pages. 
- Wired navigation from existing surfaces (Uploads list and Dashboard unassigned uploads) to the new activity detail page, added a small matching tweak to tolerate missing distances, and included a DB migration to add `notes`, `is_unplanned`, `is_race` and expand `source` values. 

### Testing
- Type checking was run with `npm run typecheck` and completed successfully. 
- Linting was run with `npm run lint` and returned no ESLint errors. 
- Unit tests for the matching logic were run with `npx tsx --test lib/workouts/activity-matching.test.ts` and passed (4 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b6e56bed083329038c284810ac266)