### PR TITLE
Refactor global CSS into semantic design tokens and map signal-driven UI states

### DIFF
--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -687,6 +687,8 @@ function SortableSessionCard({
   const discipline = getDisciplineMeta(session.sport);
   const skipped = session.status === "skipped" || isSkipped(session.notes);
   const title = buildSessionTitle(session);
+  const statusTone =
+    session.status === "completed" ? "calendar-status-completed" : session.status === "skipped" ? "calendar-status-skipped" : "calendar-status-planned";
 
   return (
     <article
@@ -698,7 +700,7 @@ function SortableSessionCard({
         <div className="flex items-start justify-between gap-2">
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
             <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] ${discipline.className}`}>{discipline.label}</span>
-            <p className="rounded-full border border-[hsl(var(--border))] px-2 py-0.5 text-[11px] text-cyan-100">
+            <p className={statusTone}>
               {session.status === "planned" ? "Pending" : session.status === "completed" ? "Completed" : "Skipped"}
             </p>
           </div>
@@ -711,11 +713,11 @@ function SortableSessionCard({
           <p className={`truncate text-sm font-medium leading-tight ${skipped ? "line-through opacity-80" : ""}`}>{title}</p>
           <p className="mt-1 text-2xl font-semibold leading-none tracking-tight">{session.duration}<span className="ml-1 text-sm font-medium text-muted">min</span></p>
           {session.linkedActivityCount ? (
-            <p className="mt-1 text-xs text-emerald-300">
+            <p className="mt-1 text-xs text-[hsl(var(--signal-ready))]">
               Completed ✓ {session.linkedStats?.durationMin ?? 0}m{session.linkedStats?.distanceKm ? ` · ${session.linkedStats.distanceKm.toFixed(1)} km` : ""}
             </p>
           ) : session.unassignedSameDayCount ? (
-            <p className="mt-1 text-xs text-amber-200">{session.unassignedSameDayCount} unassigned activit{session.unassignedSameDayCount === 1 ? "y" : "ies"} on this day</p>
+            <p className="mt-1 text-xs text-[hsl(var(--signal-load))]">{session.unassignedSameDayCount} unassigned activit{session.unassignedSameDayCount === 1 ? "y" : "ies"} on this day</p>
           ) : null}
         </button>
       </div>

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -38,18 +38,50 @@ export function CoachChat() {
 
   const completionTone = useMemo(() => {
     if (!summary) {
-      return "from-slate-600 to-slate-700";
+      return "from-[hsl(var(--surface-2))] to-[hsl(var(--surface-1))]";
     }
 
     if (summary.completionPct >= 90) {
-      return "from-emerald-500 to-teal-500";
+      return "from-[hsl(var(--signal-ready))] to-[hsl(var(--signal-recovery))]";
     }
 
     if (summary.completionPct >= 70) {
-      return "from-cyan-500 to-blue-500";
+      return "from-[hsl(var(--signal-recovery))] to-[hsl(var(--ai-accent-core))]";
     }
 
-    return "from-amber-500 to-orange-500";
+    return "from-[hsl(var(--signal-load))] to-[hsl(var(--signal-risk))]";
+  }, [summary]);
+
+  const confidenceSignal = useMemo(() => {
+    if (!summary) {
+      return { label: "No data", tone: "signal-recovery" };
+    }
+
+    if (summary.completionPct >= 90) {
+      return { label: "High confidence", tone: "signal-ready" };
+    }
+
+    if (summary.completionPct >= 70) {
+      return { label: "Building confidence", tone: "signal-recovery" };
+    }
+
+    return { label: "Low confidence", tone: "signal-risk" };
+  }, [summary]);
+
+  const urgencySignal = useMemo(() => {
+    if (!summary) {
+      return { label: "Awaiting recommendation", tone: "signal-recovery" };
+    }
+
+    if (summary.completionPct >= 85) {
+      return { label: "Low urgency", tone: "signal-ready" };
+    }
+
+    if (summary.completionPct >= 65) {
+      return { label: "Moderate urgency", tone: "signal-load" };
+    }
+
+    return { label: "High urgency", tone: "signal-risk" };
   }, [summary]);
 
   async function loadConversations() {
@@ -145,8 +177,8 @@ export function CoachChat() {
   return (
     <div className="grid gap-6 lg:grid-cols-[1fr_320px]">
       <section className="surface overflow-hidden">
-        <div className="border-b border-[hsl(var(--border))] bg-gradient-to-r from-slate-900 to-slate-800 px-5 py-4">
-          <p className="text-sm font-medium uppercase tracking-wide text-cyan-300">Coach Console</p>
+        <div className="border-b border-[hsl(var(--border))] bg-gradient-to-r from-[hsl(var(--surface-1))] to-[hsl(var(--surface-2))] px-5 py-4">
+          <p className="text-sm font-medium uppercase tracking-wide text-[hsl(var(--ai-accent-core))]">Coach Console</p>
           <h2 className="text-lg font-semibold">Adaptive triathlon guidance</h2>
         </div>
 
@@ -156,7 +188,7 @@ export function CoachChat() {
               <div
                 className={`max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-3 text-sm transition ${
                   message.role === "user"
-                    ? "bg-cyan-600 text-white"
+                    ? "bg-[hsl(var(--ai-accent-core))] text-white"
                     : "border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))]"
                 }`}
               >
@@ -201,6 +233,16 @@ export function CoachChat() {
           </p>
         </div>
 
+
+
+        <div className="surface p-5">
+          <h3 className="text-sm font-semibold">Signal mapping</h3>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <span className={`signal-chip ${confidenceSignal.tone}`}>Coach confidence: {confidenceSignal.label}</span>
+            <span className={`signal-chip ${urgencySignal.tone}`}>Recommendation urgency: {urgencySignal.label}</span>
+          </div>
+        </div>
+
         <div className="surface p-5">
           <h3 className="text-sm font-semibold">Workout analysis snapshot</h3>
           <p className="mt-2 text-sm text-muted">
@@ -213,11 +255,11 @@ export function CoachChat() {
           </ul>
         </div>
 
-        <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
-          <h3 className="text-sm font-semibold text-slate-900">Recent conversations</h3>
+        <div className="surface p-5">
+          <h3 className="text-sm font-semibold">Recent conversations</h3>
           <ul className="mt-3 space-y-2">
             {conversations.length === 0 ? (
-              <li className="text-sm text-slate-500">No saved chats yet.</li>
+              <li className="text-sm text-muted">No saved chats yet.</li>
             ) : (
               conversations.map((conversation) => (
                 <li key={conversation.id}>
@@ -226,12 +268,12 @@ export function CoachChat() {
                     onClick={() => void handleConversationClick(conversation.id)}
                     className={`w-full rounded-lg border px-3 py-2 text-left text-sm ${
                       conversationId === conversation.id
-                        ? "border-cyan-400 bg-cyan-50 text-cyan-900"
-                        : "border-slate-200 bg-white text-slate-700 hover:bg-slate-50"
+                        ? "border-[hsl(var(--ai-accent-core)/0.5)] bg-[hsl(var(--ai-accent-core)/0.12)] text-[hsl(var(--text-primary))]"
+                        : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] text-[hsl(var(--text-secondary))] hover:bg-[hsl(var(--surface-1))]"
                     }`}
                   >
                     <p className="truncate font-medium">{conversation.title}</p>
-                    <p className="mt-1 text-xs text-slate-500">{new Date(conversation.updated_at).toLocaleString()}</p>
+                    <p className="mt-1 text-xs text-tertiary">{new Date(conversation.updated_at).toLocaleString()}</p>
                   </button>
                 </li>
               ))

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -364,7 +364,15 @@ export default async function DashboardPage({
                             <p className="text-xs text-muted">{session.duration_minutes} min</p>
                           </div>
                           <div className="flex items-center gap-2">
-                            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] px-2 py-1 text-[11px] font-medium capitalize text-muted">
+                            <span
+                              className={`capitalize ${
+                                session.status === "completed"
+                                  ? "calendar-status-completed"
+                                  : session.status === "skipped"
+                                    ? "calendar-status-skipped"
+                                    : "calendar-status-planned"
+                              }`}
+                            >
                               {session.status}
                             </span>
                             <details className="relative">

--- a/app/(protected)/dashboard/week-progress-card.tsx
+++ b/app/(protected)/dashboard/week-progress-card.tsx
@@ -83,10 +83,10 @@ export function WeekProgressCard({
           <div
             className="absolute inset-0 rounded-full"
             style={{
-              background: `conic-gradient(hsl(204 88% 62% / 0.62) ${percentCapped * 360}deg, hsl(var(--border) / 0.9) 0deg)`
+              background: `conic-gradient(hsl(var(--signal-recovery) / 0.72) ${percentCapped * 360}deg, hsl(var(--surface-2)) 0deg)`
             }}
           />
-          <div className="relative flex h-[62px] w-[62px] flex-col items-center justify-center rounded-full bg-[hsl(var(--bg-elevated))] text-center">
+          <div className="relative flex h-[62px] w-[62px] flex-col items-center justify-center rounded-full bg-[hsl(var(--surface-1))] text-center">
             <span className="text-lg font-semibold leading-none">{percentLabel}</span>
           </div>
         </div>
@@ -96,8 +96,8 @@ export function WeekProgressCard({
           <p className="text-sm text-muted">{hasNoPlannedSessions ? "Schedule sessions to start tracking progress." : `of ${toHoursAndMinutes(plannedTotalMinutes)} planned`}</p>
         </div>
 
-        <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${overMinutes > 0 ? "border-amber-400/40 bg-amber-500/10" : "border-[hsl(var(--border))] bg-[hsl(var(--bg-card))]"}`}>
-          {overMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-amber-300" /> : null}
+        <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${overMinutes > 0 ? "signal-chip signal-load" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"}`}>
+          {overMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--signal-load))]" /> : null}
           <span>{chipLabel}</span>
         </span>
       </div>
@@ -143,21 +143,20 @@ export function WeekProgressCard({
                         {Math.round(item.completedMinutes)} / {Math.round(item.plannedMinutes)} min
                       </div>
                       {chipLabel ? (
-                        <span className="inline-flex h-5 items-center rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] px-2.5 text-xs font-medium text-muted">
+                        <span className={`inline-flex h-5 items-center rounded-full border px-2.5 text-xs font-medium ${item.discGapMinutes > 0 ? "signal-load" : item.discOverMinutes > 0 ? "signal-risk" : "signal-ready"}`}>
                           {chipLabel}
                         </span>
                       ) : null}
                     </div>
                   </div>
-                  <div className="relative mt-1 h-2 overflow-hidden rounded-full bg-[hsl(var(--bg-card))]" aria-label={barAriaLabel} role="img">
-                    <div className="h-full rounded-full" style={{ width: `${item.discPercentCapped * 100}%`, backgroundColor: item.color }} />
+                  <div className="progress-track relative mt-1 h-2 overflow-hidden rounded-full" aria-label={barAriaLabel} role="img">
+                    <div className="progress-fill-recovery h-full rounded-full" style={{ width: `${item.discPercentCapped * 100}%` }} />
                     {item.discOverMinutes > 0 ? (
                       <div
-                        className="absolute inset-y-0 right-0 rounded-r-full"
+                        className="progress-fill-load absolute inset-y-0 right-0 rounded-r-full"
                         style={{
                           width: `${overTailWidthPx}px`,
-                          backgroundColor: item.color,
-                          opacity: 0.6,
+                          opacity: 0.8,
                           backgroundImage: "repeating-linear-gradient(45deg, rgba(255,255,255,0.22) 0px, rgba(255,255,255,0.22) 6px, rgba(255,255,255,0.05) 6px, rgba(255,255,255,0.05) 12px)"
                         }}
                       />

--- a/app/globals.css
+++ b/app/globals.css
@@ -4,15 +4,30 @@
 
 :root {
   color-scheme: dark;
-  --bg: 224 24% 8%;
-  --bg-elevated: 222 21% 12%;
-  --bg-card: 223 18% 15%;
-  --fg: 210 20% 96%;
-  --fg-muted: 215 14% 72%;
+  --surface-0: 224 24% 8%;
+  --surface-1: 222 21% 12%;
+  --surface-2: 223 18% 15%;
+  --text-primary: 210 20% 96%;
+  --text-secondary: 215 14% 72%;
+  --text-tertiary: 215 10% 56%;
+
+  --signal-ready: 151 62% 51%;
+  --signal-load: 38 92% 56%;
+  --signal-risk: 8 86% 62%;
+  --signal-recovery: 198 95% 63%;
+
+  --ai-accent-core: 198 100% 58%;
+  --ai-accent-glow: 204 70% 19%;
+
+  --bg: var(--surface-0);
+  --bg-elevated: var(--surface-1);
+  --bg-card: var(--surface-2);
+  --fg: var(--text-primary);
+  --fg-muted: var(--text-secondary);
   --border: 218 18% 25%;
-  --ring: 198 100% 62%;
-  --accent: 198 100% 58%;
-  --accent-soft: 204 70% 19%;
+  --ring: var(--ai-accent-core);
+  --accent: var(--ai-accent-core);
+  --accent-soft: var(--ai-accent-glow);
 }
 
 @layer base {
@@ -81,6 +96,62 @@
 
   .text-muted {
     color: hsl(var(--fg-muted));
+  }
+
+  .text-tertiary {
+    color: hsl(var(--text-tertiary));
+  }
+
+  .signal-chip {
+    @apply rounded-full border px-2 py-0.5 text-[11px] font-medium;
+  }
+
+  .signal-ready {
+    border-color: hsl(var(--signal-ready) / 0.45);
+    background: hsl(var(--signal-ready) / 0.16);
+    color: hsl(var(--signal-ready));
+  }
+
+  .signal-load {
+    border-color: hsl(var(--signal-load) / 0.45);
+    background: hsl(var(--signal-load) / 0.16);
+    color: hsl(var(--signal-load));
+  }
+
+  .signal-risk {
+    border-color: hsl(var(--signal-risk) / 0.45);
+    background: hsl(var(--signal-risk) / 0.16);
+    color: hsl(var(--signal-risk));
+  }
+
+  .signal-recovery {
+    border-color: hsl(var(--signal-recovery) / 0.45);
+    background: hsl(var(--signal-recovery) / 0.16);
+    color: hsl(var(--signal-recovery));
+  }
+
+  .calendar-status-planned {
+    @apply signal-chip signal-load;
+  }
+
+  .calendar-status-completed {
+    @apply signal-chip signal-ready;
+  }
+
+  .calendar-status-skipped {
+    @apply signal-chip signal-risk;
+  }
+
+  .progress-track {
+    background: hsl(var(--surface-2));
+  }
+
+  .progress-fill-recovery {
+    background: linear-gradient(90deg, hsl(var(--signal-recovery)), hsl(var(--signal-ready)));
+  }
+
+  .progress-fill-load {
+    background: linear-gradient(90deg, hsl(var(--signal-load) / 0.85), hsl(var(--signal-load)));
   }
 
   .discipline-swim {

--- a/docs/design-tokens.md
+++ b/docs/design-tokens.md
@@ -1,0 +1,21 @@
+# Design Tokens
+
+Semantic tokens are defined in `app/globals.css` and consumed through component-level classes.
+
+| Token | Purpose | Example usage |
+| --- | --- | --- |
+| `--surface-0`, `--surface-1`, `--surface-2` | App/background elevation stack | Base page, cards, and secondary panels across dashboard/calendar/coach. |
+| `--text-primary`, `--text-secondary`, `--text-tertiary` | Primary to tertiary text hierarchy | Main headings, helper copy, and conversation metadata text. |
+| `--signal-ready` | Positive/complete state | Calendar `Completed` chips and coach confidence high state. |
+| `--signal-load` | Load/attention state | Calendar `Pending` chips, unassigned activity hint text, and progression load overrun. |
+| `--signal-risk` | Risk/negative state | Calendar `Skipped` chips and high urgency recommendation state. |
+| `--signal-recovery` | Recovery/steady progress state | Week progress bar fill and medium coach confidence state. |
+| `--ai-accent-core`, `--ai-accent-glow` | AI brand accent | Coach console accent text, user bubble fill, and global CTA gradients. |
+
+## Component mapping examples
+
+| Area | Mapping rule | Implementation example |
+| --- | --- | --- |
+| `app/(protected)/calendar` | Calendar status chips consume signal tokens | `calendar-status-planned/completed/skipped` map to `signal-load/ready/risk` in session cards. |
+| `app/(protected)/coach` | Coach confidence and recommendation urgency consume signal tokens | `confidenceSignal` and `urgencySignal` render `signal-chip` pills using `signal-ready/load/risk/recovery`. |
+| `app/(protected)/dashboard` | Plan progression bars consume load/recovery tokens | Week progress bars use `progress-fill-recovery` for normal completion and `progress-fill-load` for overrun tails. |


### PR DESCRIPTION
### Motivation
- Provide semantic, reusable design tokens for surfaces, text hierarchy, signals, and AI accents to make UI state mapping consistent across components.
- Surface and signal tokens enable components (calendar, coach, dashboard) to consume intentful colors instead of ad-hoc palettes.

### Description
- Introduced semantic tokens in `app/globals.css`: `--surface-0/1/2`, `--text-primary/secondary/tertiary`, `--signal-ready/load/risk/recovery`, and `--ai-accent-core/glow`, with compatibility aliases for existing `--bg`/`--fg` variables.
- Added component-level utility classes in `app/globals.css`: `signal-*` chip styles, `calendar-status-*` mappings, and `progress-*` track/fill classes for progression visuals.
- Updated calendar session UI in `app/(protected)/calendar/week-calendar.tsx` to use the `calendar-status-*` classes and signal tokens for completion/unassigned helper text.
- Updated dashboard status chips and progression visuals in `app/(protected)/dashboard/page.tsx` and `app/(protected)/dashboard/week-progress-card.tsx` to use the semantic tokens and `progress-fill-*` classes.
- Updated coach UI in `app/(protected)/coach/coach-chat.tsx` to drive completion gradient from signal tokens and added coach `confidenceSignal` and `urgencySignal` chips that render using `signal-*` classes.
- Added documentation `docs/design-tokens.md` with a compact token table and mapping examples for `dashboard`, `calendar`, and `coach`.

### Testing
- Ran linter: `npm run lint` — succeeded with no ESLint warnings or errors.
- Ran typecheck: `npm run typecheck` (`tsc --noEmit`) — succeeded with no errors.
- Started local dev process (`npm run dev`) and attempted a UI render and screenshot of `/coach`; the page render hit a runtime 500 due to missing Supabase runtime environment variables in this environment, so visual verification was limited (artifact captured).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f0833497c8332bfb438978ea7a95a)