### PR TITLE
Redesign protected app shell with orientation rail, status strip, and mobile tabs

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -1,5 +1,6 @@
 import { createClient } from "@/lib/supabase/server";
 import { isValidIsoDate } from "@/lib/date/iso";
+import { PageHeader } from "../page-header";
 import { WeekCalendar } from "./week-calendar";
 
 type Session = {
@@ -215,12 +216,22 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     : null;
 
   return (
-    <WeekCalendar
-      weekDays={weekDays}
-      sessions={sessions}
-      weekStart={weekStart}
-      isCurrentWeek={weekStart === currentWeekStart}
-      raceCountdown={raceCountdown}
-    />
+    <section className="space-y-4">
+      <PageHeader
+        title="Calendar"
+        objective="Execute each day with confidence by dragging, logging, and resolving conflicts before they become missed work."
+        actions={[
+          { href: "/plan", label: "Edit plan" },
+          { href: "/dashboard", label: "View dashboard", variant: "secondary" }
+        ]}
+      />
+      <WeekCalendar
+        weekDays={weekDays}
+        sessions={sessions}
+        weekStart={weekStart}
+        isCurrentWeek={weekStart === currentWeekStart}
+        raceCountdown={raceCountdown}
+      />
+    </section>
   );
 }

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -1,16 +1,17 @@
+import { PageHeader } from "../page-header";
 import { CoachChat } from "./coach-chat";
 
 export default function CoachPage() {
   return (
-    <section className="space-y-6">
-      <header className="surface p-8">
-        <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">AI Coach</p>
-        <h1 className="mt-2 text-3xl font-semibold">Train smarter with real-time workout analysis</h1>
-        <p className="mt-2 max-w-2xl text-sm text-muted">
-          Ask for training feedback, missed-session adjustments, and focused recommendations generated from your recent
-          planned and completed workouts.
-        </p>
-      </header>
+    <section className="space-y-4">
+      <PageHeader
+        title="Coach"
+        objective="Get concise guidance from your recent plan and workout data so your next session is clear and actionable."
+        actions={[
+          { href: "/dashboard", label: "Review dashboard" },
+          { href: "/calendar", label: "Open calendar", variant: "secondary" }
+        ]}
+      />
 
       <CoachChat />
     </section>

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -2,6 +2,7 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { isValidIsoDate } from "@/lib/date/iso";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
+import { PageHeader } from "../page-header";
 import { markSkippedAction, moveSessionAction } from "./actions";
 import { WeekProgressCard } from "./week-progress-card";
 
@@ -253,6 +254,15 @@ export default async function DashboardPage({
   if (!hasActivePlan && !hasAnyPlan) {
     return (
       <section className="space-y-4">
+        <PageHeader
+          title="Dashboard"
+          objective="Orient your week at a glance, spot what is at risk, and choose the highest-impact next session."
+          actions={[
+            { href: "/plan", label: "Create a plan" },
+            { href: "/coach", label: "Ask tri.ai", variant: "secondary" }
+          ]}
+        />
+
         <header className="surface sticky top-3 z-10 flex flex-wrap items-center justify-between gap-3 px-4 py-3">
           <div className="flex items-center gap-2 text-sm">
             <span className="font-semibold">WEEK: {formatWeekRange(weekStart)}</span>
@@ -286,6 +296,15 @@ export default async function DashboardPage({
 
   return (
     <section className="space-y-4">
+      <PageHeader
+        title="Dashboard"
+        objective="Stay oriented on this training week, keep completion momentum, and surface where coaching attention is needed."
+        actions={[
+          { href: "/calendar", label: "Open calendar" },
+          { href: "/coach", label: "Ask tri.ai", variant: "secondary" }
+        ]}
+      />
+
       <header className="surface sticky top-3 z-10 flex flex-wrap items-center justify-between gap-3 px-4 py-3">
         <div className="flex flex-wrap items-center gap-2 text-sm">
           <span className="font-semibold">WEEK: {formatWeekRange(weekStart)}</span>

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -2,27 +2,48 @@ import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { signOutAction } from "./actions";
 import { AccountMenu } from "./account-menu";
+import { MobileBottomTabs, ShellNavRail } from "./shell-nav";
 
 export const dynamic = "force-dynamic";
-
-const navItems = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/plan", label: "Plan" },
-  { href: "/calendar", label: "Calendar" },
-  { href: "/coach", label: "AI Coach" }
-];
 
 type Profile = {
   display_name: string | null;
   avatar_url: string | null;
+  active_plan_id: string | null;
+  race_date: string | null;
+  race_name: string | null;
+};
+
+type Session = {
+  duration_minutes: number | null;
+  status: "planned" | "completed" | "skipped";
+};
+
+type TrainingWeek = {
+  week_index: number;
+  focus: "Build" | "Recovery" | "Taper" | "Race" | "Custom";
+  week_start_date: string;
+  target_minutes: number | null;
 };
 
 function getInitials(name: string) {
   const parts = name.trim().split(/\s+/).slice(0, 2);
-  if (parts.length === 0) {
-    return "A";
-  }
+  if (parts.length === 0) return "A";
   return parts.map((part) => part[0]?.toUpperCase() ?? "").join("");
+}
+
+function getMonday(date = new Date()) {
+  const day = date.getUTCDay();
+  const distanceFromMonday = day === 0 ? 6 : day - 1;
+  const monday = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  monday.setUTCDate(monday.getUTCDate() - distanceFromMonday);
+  return monday;
+}
+
+function addDays(isoDate: string, days: number) {
+  const date = new Date(`${isoDate}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
 }
 
 export default async function ProtectedLayout({
@@ -36,7 +57,7 @@ export default async function ProtectedLayout({
   } = await supabase.auth.getUser();
 
   const { data: profileData } = user
-    ? await supabase.from("profiles").select("display_name,avatar_url").eq("id", user.id).maybeSingle()
+    ? await supabase.from("profiles").select("display_name,avatar_url,active_plan_id,race_date,race_name").eq("id", user.id).maybeSingle()
     : { data: null };
 
   const profile = (profileData ?? null) as Profile | null;
@@ -44,27 +65,94 @@ export default async function ProtectedLayout({
   const email = user?.email ?? "Unknown user";
   const initials = getInitials(displayName);
 
+  const currentWeekStart = getMonday().toISOString().slice(0, 10);
+  const currentWeekEnd = addDays(currentWeekStart, 7);
+
+  const activePlanId = profile?.active_plan_id ?? null;
+
+  const [{ data: weekData }, { data: sessionsData }] = activePlanId
+    ? await Promise.all([
+        supabase
+          .from("training_weeks")
+          .select("week_index,focus,week_start_date,target_minutes")
+          .eq("plan_id", activePlanId)
+          .lte("week_start_date", currentWeekStart)
+          .order("week_start_date", { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+        supabase
+          .from("sessions")
+          .select("duration_minutes,status")
+          .eq("plan_id", activePlanId)
+          .gte("date", currentWeekStart)
+          .lt("date", currentWeekEnd)
+      ])
+    : [{ data: null }, { data: [] }];
+
+  const weekContext = (weekData ?? null) as TrainingWeek | null;
+  const sessions = (sessionsData ?? []) as Session[];
+
+  const plannedMinutes = sessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const completedMinutes = sessions
+    .filter((session) => session.status === "completed")
+    .reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const completionRate = plannedMinutes > 0 ? Math.round((completedMinutes / plannedMinutes) * 100) : 0;
+
+  const readiness = completionRate >= 70 ? "Ready" : completionRate >= 40 ? "Building" : "Needs focus";
+  const readinessClass = completionRate >= 70 ? "signal-ready" : completionRate >= 40 ? "signal-load" : "signal-risk";
+
+  const daysToRace = profile?.race_date
+    ? Math.max(0, Math.ceil((new Date(`${profile.race_date}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
+    : null;
+
   return (
     <div className="app-shell">
-      <header className="relative z-30 border-b border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.9] backdrop-blur">
-        <div className="mx-auto flex w-full max-w-6xl flex-wrap items-center justify-between gap-4 px-6 py-4">
-          <p className="text-lg uppercase tracking-[0.2em] text-cyan-300">tri.ai</p>
-          <nav className="flex flex-wrap gap-2">
-            {navItems.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className="rounded-lg px-3 py-2 text-sm font-medium text-[hsl(var(--fg-muted))] transition hover:bg-[hsl(var(--bg-card))] hover:text-[hsl(var(--fg))]"
-              >
-                {item.label}
-              </Link>
-            ))}
-          </nav>
-
+      <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.95] backdrop-blur">
+        <div className="mx-auto flex w-full max-w-[1200px] flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-6">
+          <p className="text-sm uppercase tracking-[0.2em] text-cyan-300">tri.ai</p>
+          <div className="flex items-center gap-2">
+            <span className={`signal-chip ${readinessClass}`}>Readiness: {readiness}</span>
+            <span className="signal-chip signal-recovery">
+              Race: {daysToRace !== null ? `${daysToRace}d` : "set date"}
+            </span>
+            <span className="signal-chip signal-load">Week: {completionRate}% complete</span>
+          </div>
           <AccountMenu avatarUrl={profile?.avatar_url ?? null} initials={initials} displayName={displayName} email={email} signOutAction={signOutAction} />
         </div>
-      </header>
-      <main className="mx-auto w-full max-w-6xl px-6 py-8">{children}</main>
+      </div>
+
+      <div className="mx-auto grid w-full max-w-[1200px] gap-4 px-4 pb-24 pt-5 md:px-6 lg:grid-cols-[260px_1fr] lg:pb-8">
+        <aside className="hidden lg:block">
+          <div className="surface sticky top-5 space-y-5 p-4">
+            <div>
+              <p className="text-xs uppercase tracking-[0.16em] text-cyan-300">Primary nav</p>
+              <div className="mt-2">
+                <ShellNavRail />
+              </div>
+            </div>
+
+            <div className="surface-subtle p-3">
+              <p className="text-xs uppercase tracking-[0.14em] text-muted">Training week</p>
+              {weekContext ? (
+                <>
+                  <p className="mt-2 text-sm font-semibold">Week {weekContext.week_index} · {weekContext.focus}</p>
+                  <p className="mt-1 text-xs text-muted">Starts {weekContext.week_start_date}</p>
+                  <p className="mt-1 text-xs text-muted">
+                    Target: {weekContext.target_minutes ? `${weekContext.target_minutes} min` : "not set"}
+                  </p>
+                </>
+              ) : (
+                <p className="mt-2 text-sm text-muted">Create or activate a plan to see week context.</p>
+              )}
+              <Link href="/plan" className="mt-3 inline-flex text-xs text-cyan-200 underline">Manage plan</Link>
+            </div>
+          </div>
+        </aside>
+
+        <main className="min-w-0 space-y-4">{children}</main>
+      </div>
+
+      <MobileBottomTabs />
     </div>
   );
 }

--- a/app/(protected)/page-header.tsx
+++ b/app/(protected)/page-header.tsx
@@ -1,0 +1,30 @@
+import Link from "next/link";
+
+type HeaderAction = {
+  href: string;
+  label: string;
+  variant?: "primary" | "secondary";
+};
+
+export function PageHeader({ title, objective, actions = [] }: { title: string; objective: string; actions?: HeaderAction[] }) {
+  return (
+    <header className="surface p-5 md:p-6">
+      <div className="flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <p className="text-xs uppercase tracking-[0.16em] text-cyan-300">{title}</p>
+          <p className="mt-2 max-w-3xl text-sm text-muted">{objective}</p>
+        </div>
+
+        {actions.length > 0 ? (
+          <div className="flex shrink-0 flex-wrap gap-2">
+            {actions.slice(0, 2).map((action) => (
+              <Link key={action.href + action.label} href={action.href} className={action.variant === "secondary" ? "btn-secondary" : "btn-primary"}>
+                {action.label}
+              </Link>
+            ))}
+          </div>
+        ) : null}
+      </div>
+    </header>
+  );
+}

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -1,4 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
+import { PageHeader } from "../page-header";
 import { PlanEditor } from "./plan-editor";
 
 type Plan = {
@@ -209,5 +210,17 @@ export default async function PlanPage({
     }
   }
 
-  return <PlanEditor plans={plans} weeks={weeksData} sessions={sessionsData} selectedPlanId={selectedPlan?.id} />;
+  return (
+    <section className="space-y-4">
+      <PageHeader
+        title="Plan"
+        objective="Shape your training blocks, tune week intent, and publish sessions that keep race-day goals realistic."
+        actions={[
+          { href: "/calendar", label: "Review week" },
+          { href: "/dashboard", label: "Back to dashboard", variant: "secondary" }
+        ]}
+      />
+      <PlanEditor plans={plans} weeks={weeksData} sessions={sessionsData} selectedPlanId={selectedPlan?.id} />
+    </section>
+  );
 }

--- a/app/(protected)/shell-nav.tsx
+++ b/app/(protected)/shell-nav.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const navItems = [
+  { href: "/dashboard", label: "Dashboard" },
+  { href: "/plan", label: "Plan" },
+  { href: "/calendar", label: "Calendar" },
+  { href: "/coach", label: "Coach" }
+];
+
+export function ShellNavRail() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="space-y-1">
+      {navItems.map((item) => {
+        const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+        return (
+          <Link
+            key={item.href}
+            href={item.href}
+            className={`block rounded-xl px-3 py-2 text-sm transition ${
+              active
+                ? "bg-cyan-500/15 text-cyan-100 ring-1 ring-cyan-400/30"
+                : "text-[hsl(var(--fg-muted))] hover:bg-[hsl(var(--bg-card))] hover:text-[hsl(var(--fg))]"
+            }`}
+          >
+            {item.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}
+
+export function MobileBottomTabs() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="fixed inset-x-0 bottom-0 z-40 border-t border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.96] px-2 py-2 backdrop-blur lg:hidden">
+      <div className="grid grid-cols-4 gap-1">
+        {navItems.map((item) => {
+          const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
+          return (
+            <Link
+              key={item.href}
+              href={item.href}
+              className={`rounded-lg px-2 py-2 text-center text-xs font-medium ${active ? "bg-cyan-500/15 text-cyan-100" : "text-muted"}`}
+            >
+              {item.label}
+            </Link>
+          );
+        })}
+      </div>
+    </nav>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a persistent shell that keeps users oriented to their training week and navigation while leaving page content as the primary workspace.
- Surface high-level readiness and race-week progress so coaches and athletes can quickly assess status without leaving the current route.
- Standardize per-route headers (title, one-line objective, 1–2 primary actions) for the main protected routes to improve consistency and make actions discoverable.

### Description
- Reworked `app/(protected)/layout.tsx` into a persistent shell that renders a compact top status strip (readiness, race countdown, weekly completion), a left rail with primary navigation and current training-week context, and a main workspace area for route content; the shell queries `profiles`, `training_weeks`, and `sessions` to populate indicators.
- Added `app/(protected)/shell-nav.tsx` implementing `ShellNavRail` for desktop nav and `MobileBottomTabs` for mobile fallback to keep navigation usable when the rail collapses.
- Added `app/(protected)/page-header.tsx` exporting `PageHeader` (title, objective, 1–2 actions) and applied it to `/dashboard`, `/plan`, `/calendar`, and `/coach` by updating their pages to include the header component and appropriate actions.
- Kept existing page content and behaviors intact; the header is a composable wrapper and the left-rail is visually sticky with a link to plan management.

### Testing
- Ran `npm run lint` (`next lint`) and it completed successfully.
- Ran `npm run typecheck` (`tsc --noEmit`) which failed due to existing repository Jest globals/type definitions in test files and is unrelated to the UI changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4b5651808332a8ded47e93cd45df)