### PR TITLE
Add lightweight motion system with reduced-motion guardrails

### DIFF
--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -689,12 +689,14 @@ function SortableSessionCard({
   const title = buildSessionTitle(session);
   const statusTone =
     session.status === "completed" ? "calendar-status-completed" : session.status === "skipped" ? "calendar-status-skipped" : "calendar-status-planned";
+  const statusMotion =
+    session.status === "completed" ? "status-card-completed" : session.status === "skipped" ? "status-card-skipped" : "status-card-planned";
 
   return (
     <article
       ref={setNodeRef}
       style={style}
-      className={`group relative surface-subtle p-2.5 pr-8 focus-within:ring-1 focus-within:ring-cyan-300/70 ${isDragging ? "opacity-60" : ""} ${session.status === "completed" ? "opacity-80" : ""} ${skipped ? "bg-slate-900/70" : ""}`}
+      className={`group relative surface-subtle status-card-transition ${statusMotion} p-2.5 pr-8 focus-within:ring-1 focus-within:ring-cyan-300/70 ${isDragging ? "opacity-60" : ""} ${skipped ? "bg-slate-900/70" : ""}`}
     >
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-2">

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -309,13 +309,17 @@ export function CoachChat() {
         </div>
 
         <div className="max-h-[460px] space-y-3 overflow-y-auto p-5">
-          {messages.map((message, index) => (
+          {messages.map((message, index) => {
+            const shouldAnimateAssistantInsert =
+              message.role === "assistant" && index === messages.length - 1 && !isLoading;
+
+            return (
             <div key={`${message.role}-${index}`} className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
               <div
                 className={`max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-3 text-sm transition ${
                   message.role === "user"
                     ? "bg-[hsl(var(--ai-accent-core))] text-white"
-                    : "space-y-3 border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))]"
+                    : `space-y-3 border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] ${shouldAnimateAssistantInsert ? "coach-response-insert" : ""}`
                 }`}
               >
                 <p>{message.content}</p>
@@ -348,7 +352,8 @@ export function CoachChat() {
                 ) : null}
               </div>
             </div>
-          ))}
+            );
+          })}
           {isLoading ? (
             <div className="space-y-2">
               <div className="h-4 w-4/5 animate-pulse rounded bg-[hsl(var(--bg-card))]" />

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -211,7 +211,7 @@ export default async function PlanPage({
   }
 
   return (
-    <section className="space-y-4">
+    <section className="plan-editor-motion-lock space-y-4">
       <PageHeader
         title="Plan"
         objective="Shape your training blocks, tune week intent, and publish sessions that keep race-day goals realistic."

--- a/app/globals.css
+++ b/app/globals.css
@@ -28,6 +28,11 @@
   --ring: var(--ai-accent-core);
   --accent: var(--ai-accent-core);
   --accent-soft: var(--ai-accent-glow);
+
+  --motion-fast: 180ms;
+  --motion-standard: 240ms;
+  --motion-ease: cubic-bezier(0.2, 0, 0, 1);
+  --motion-ambient-duration: 22s;
 }
 
 @layer base {
@@ -46,18 +51,60 @@
     outline-offset: 2px;
     border-radius: 0.75rem;
   }
+
+  @media (prefers-reduced-motion: reduce) {
+    *,
+    *::before,
+    *::after {
+      animation-duration: 1ms !important;
+      animation-iteration-count: 1 !important;
+      transition-duration: 1ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
 }
 
 @layer components {
   .app-shell {
-    @apply min-h-screen;
-    background: radial-gradient(circle at 20% -10%, hsl(198 96% 20% / 0.25), transparent 40%), hsl(var(--bg));
+    @apply relative min-h-screen overflow-hidden;
+    background: hsl(var(--bg));
+  }
+
+  .app-shell::before {
+    content: "";
+    position: absolute;
+    inset: -18%;
+    z-index: 0;
+    pointer-events: none;
+    background:
+      radial-gradient(circle at 24% 18%, hsl(var(--ai-accent-core) / 0.055), transparent 46%),
+      radial-gradient(circle at 70% 76%, hsl(var(--signal-recovery) / 0.035), transparent 48%),
+      radial-gradient(circle at 52% 44%, hsl(var(--surface-2) / 0.26), transparent 68%);
+    animation: ambient-gradient-drift var(--motion-ambient-duration) ease-in-out infinite alternate;
+    transform-origin: center;
+  }
+
+  .app-shell > * {
+    position: relative;
+    z-index: 1;
+  }
+
+  .app-shell:has(.plan-editor-motion-lock)::before {
+    animation: none;
   }
 
   .surface {
     background: hsl(var(--bg-elevated));
     border: 1px solid hsl(var(--border));
     @apply rounded-2xl shadow-[0_10px_40px_-24px_rgba(0,0,0,0.8)];
+    transition:
+      border-color var(--motion-standard) var(--motion-ease),
+      box-shadow var(--motion-standard) var(--motion-ease),
+      background-color var(--motion-standard) var(--motion-ease);
+  }
+
+  .surface:hover {
+    border-color: hsl(var(--ai-accent-core) / 0.26);
   }
 
   .surface-subtle {
@@ -67,7 +114,7 @@
   }
 
   .btn-primary {
-    @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white transition duration-200;
+    @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white;
     background: linear-gradient(130deg, hsl(var(--accent)) 0%, hsl(212 100% 62%) 100%);
   }
 
@@ -76,17 +123,46 @@
   }
 
   .btn-secondary {
-    @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium transition duration-200;
+    @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-medium;
     background: hsl(var(--bg-card));
     border: 1px solid hsl(var(--border));
     color: hsl(var(--fg));
   }
 
   .input-base {
-    @apply w-full rounded-xl px-3 py-2 text-sm transition;
+    @apply w-full rounded-xl px-3 py-2 text-sm;
     background: hsl(var(--bg-card));
     border: 1px solid hsl(var(--border));
     color: hsl(var(--fg));
+  }
+
+  .btn-primary,
+  .btn-secondary,
+  .input-base,
+  .surface {
+    transition:
+      transform var(--motion-fast) var(--motion-ease),
+      opacity var(--motion-fast) var(--motion-ease),
+      border-color var(--motion-fast) var(--motion-ease),
+      box-shadow var(--motion-fast) var(--motion-ease),
+      background-color var(--motion-fast) var(--motion-ease);
+  }
+
+  .btn-primary:hover,
+  .btn-secondary:hover {
+    transform: translateY(-1px);
+  }
+
+  .input-base:hover {
+    border-color: hsl(var(--ai-accent-core) / 0.3);
+  }
+
+  .input-base:focus-visible,
+  .btn-primary:focus-visible,
+  .btn-secondary:focus-visible,
+  .surface:focus-within {
+    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.35);
+    border-color: hsl(var(--ring) / 0.55);
   }
 
   .label-base {
@@ -142,6 +218,31 @@
     @apply signal-chip signal-risk;
   }
 
+  .status-card-transition {
+    transition:
+      opacity var(--motion-fast) var(--motion-ease),
+      transform var(--motion-fast) var(--motion-ease);
+  }
+
+  .status-card-planned {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  .status-card-completed {
+    opacity: 0.82;
+    transform: translateY(-2px);
+  }
+
+  .status-card-skipped {
+    opacity: 0.7;
+    transform: translateY(2px);
+  }
+
+  .coach-response-insert {
+    animation: coach-response-in var(--motion-fast) var(--motion-ease);
+  }
+
   .progress-track {
     background: hsl(var(--surface-2));
   }
@@ -187,5 +288,25 @@
     background: hsl(214 17% 21% / 0.6);
     border-color: hsl(214 14% 45% / 0.7);
     color: hsl(210 20% 85%);
+  }
+}
+
+@keyframes ambient-gradient-drift {
+  0% {
+    transform: translate3d(-1.5%, -1.25%, 0) scale(1);
+  }
+  100% {
+    transform: translate3d(1.5%, 1.5%, 0) scale(1.03);
+  }
+}
+
+@keyframes coach-response-in {
+  from {
+    opacity: 0;
+    transform: translateY(6px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
   }
 }

--- a/docs/motion-guidelines.md
+++ b/docs/motion-guidelines.md
@@ -1,0 +1,44 @@
+# Motion guidelines
+
+## Principles
+
+- Motion should support state clarity, not decoration.
+- Keep transitions short and predictable with no bounce/easing overshoot.
+- Respect user preference with `prefers-reduced-motion: reduce` by minimizing animation and transition time.
+
+## Pattern library
+
+### 1. Ambient shell motion
+
+- `.app-shell` uses a very low-contrast pseudo-element gradient drift.
+- Drift is slow (`~22s`) and subtle enough to avoid visual dominance.
+- The animation is disabled in high-focus workflows with `.plan-editor-motion-lock`.
+
+### 2. Status cards (planned/completed/skipped)
+
+- Apply `.status-card-transition` to status cards.
+- State classes are limited to opacity + vertical offset:
+  - `.status-card-planned`
+  - `.status-card-completed`
+  - `.status-card-skipped`
+- Do not introduce scaling, rotation, bounce, or looping effects for status-state changes.
+
+### 3. Coach stream insertion
+
+- New assistant responses use `.coach-response-insert`.
+- Animation budget is under 200ms.
+- Use opacity + upward y-shift only (no bounce).
+
+### 4. Shared interaction transitions
+
+- `.btn-primary`, `.btn-secondary`, `.input-base`, and `.surface` share timing/easing tokens:
+  - `--motion-fast: 180ms`
+  - `--motion-standard: 240ms`
+  - `--motion-ease: cubic-bezier(0.2, 0, 0, 1)`
+- Focus treatment is standardized with border + shadow ring states.
+- Hover is subtle (`translateY(-1px)` on buttons, border emphasis on inputs/surfaces).
+
+## Guardrails
+
+- Keep looping/decorative motion out of high-focus editing contexts (plan editing, data entry, dense forms).
+- In reduced-motion mode, avoid non-essential movement and rely on static visual affordances (color, contrast, hierarchy).


### PR DESCRIPTION
### Motivation

- Introduce a small, consistent micro-motion system to improve state clarity and liveliness without distracting users. 
- Provide explicit guardrails for high-focus workflows and reduced-motion preferences so motion never interferes with editing or accessibility.

### Description

- Added motion tokens, reduced-motion media rules, subtle ambient gradient drift, and keyframes in `app/globals.css` (variables: `--motion-fast`, `--motion-standard`, `--motion-ease`, `--motion-ambient-duration`).
- Implemented ambient low‑contrast gradient drift on `.app-shell` and a `.plan-editor-motion-lock` hook to disable decorative motion during plan editing. 
- Added status card state classes and transitions (`.status-card-transition`, `.status-card-planned`, `.status-card-completed`, `.status-card-skipped`) and wired them into `app/(protected)/calendar/week-calendar.tsx` to animate state changes via opacity + Y shift only. 
- Wired an assistant-response insertion animation (`.coach-response-insert`, <200ms, opacity + upward y-shift, no bounce) into `app/(protected)/coach/coach-chat.tsx` and standardized hover/focus transitions for `.btn-*`, `.input-base`, and `.surface` in `app/globals.css`.
- Added documentation of patterns and guardrails in `docs/motion-guidelines.md`.

### Testing

- `npm run lint` completed successfully with no ESLint warnings or errors. 
- `npm run typecheck` failed due to existing test typing configuration (missing test globals / jest typings) unrelated to the motion changes. 
- `npm test` could not run in this environment because the `jest` binary was unavailable.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f4ecbd9888332af2ec314af3c7b06)