### PR TITLE
Align dashboard and coach language with design strategy gate

### DIFF
--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -42,7 +42,7 @@ type Conversation = {
 const defaultAssistantMessage = {
   role: "assistant" as const,
   content:
-    "Hey! I’m your AI coach. Ask me to review your recent training, suggest a week plan, or adapt sessions around your schedule."
+    "Performance briefing ready. Ask for load adjustments, session prioritization, or schedule changes based on your latest training data."
 };
 
 function parseStructuredResponse(content: string, summary: CoachSummary | null): StructuredCoachResponse {
@@ -280,8 +280,8 @@ export function CoachChat() {
         <div className="surface p-5">
           <div className="flex items-center justify-between gap-3">
             <div>
-              <p className="text-xs font-semibold uppercase tracking-wide text-[hsl(var(--ai-accent-core))]">This Week Decisions</p>
-              <h3 className="mt-1 text-base font-semibold">Pre-populated from your completion context</h3>
+              <p className="text-xs font-semibold uppercase tracking-wide text-[hsl(var(--ai-accent-core))]">This Week Decision Board</p>
+              <h3 className="mt-1 text-base font-semibold">Generated from completion signals and current load</h3>
             </div>
             <span className={`signal-chip ${urgencySignal.tone}`}>Urgency: {urgencySignal.label}</span>
           </div>
@@ -305,7 +305,7 @@ export function CoachChat() {
         <div className="surface overflow-hidden">
         <div className="border-b border-[hsl(var(--border))] bg-gradient-to-r from-[hsl(var(--surface-1))] to-[hsl(var(--surface-2))] px-5 py-4">
           <p className="text-sm font-medium uppercase tracking-wide text-[hsl(var(--ai-accent-core))]">Coach Console</p>
-          <h2 className="text-lg font-semibold">Chat module: adaptive triathlon guidance</h2>
+          <h2 className="text-lg font-semibold">Operational coaching console</h2>
         </div>
 
         <div className="max-h-[460px] space-y-3 overflow-y-auto p-5">
@@ -371,7 +371,7 @@ export function CoachChat() {
               id="coach-input"
               value={input}
               onChange={(event) => setInput(event.target.value)}
-              placeholder="Ask for workout analysis, weekly suggestions, or plan tweaks..."
+              placeholder="Ask for load analysis, risk checks, or session-level changes..."
               className="input-base"
             />
             <button type="submit" disabled={isLoading} className="btn-primary disabled:opacity-70">
@@ -403,7 +403,7 @@ export function CoachChat() {
         </div>
 
         <div className="surface p-5">
-          <h3 className="text-sm font-semibold">Workout analysis snapshot</h3>
+          <h3 className="text-sm font-semibold">Performance snapshot</h3>
           <p className="mt-2 text-sm text-muted">
             Dominant sport: <span className="font-medium capitalize">{summary?.dominantSport ?? "n/a"}</span>
           </p>

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -6,7 +6,7 @@ export default function CoachPage() {
     <section className="space-y-4">
       <PageHeader
         title="Coach"
-        objective="Get concise guidance from your recent plan and workout data so your next session is clear and actionable."
+        objective="Get concise, evidence-linked guidance from your plan and workout data so your next decision is clear and actionable."
         actions={[
           { href: "/dashboard", label: "Review dashboard" },
           { href: "/calendar", label: "Open calendar", variant: "secondary" }

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -244,7 +244,7 @@ export default async function DashboardPage({
     ? `Prioritize ${getDisciplineMeta(keyTodaySession.sport).label.toLowerCase()} ${keyTodaySession.type.toLowerCase()} (${keyTodaySession.duration_minutes} min) today.`
     : biggestGap && biggestGap.planned > 0
       ? `Your biggest weekly gap is ${getDisciplineMeta(biggestGap.sport).label} (${biggestGap.completed}/${biggestGap.planned} min).`
-      : "Start the week by locking one short session today to build momentum.";
+      : "Start with one short session today to establish execution rhythm.";
 
   const raceName = profile?.race_name?.trim() || "Target race";
   const daysToRace = profile?.race_date
@@ -256,7 +256,7 @@ export default async function DashboardPage({
       <section className="space-y-4">
         <PageHeader
           title="Dashboard"
-          objective="Orient your week at a glance, spot what is at risk, and choose the highest-impact next session."
+          objective="Orient the week at a glance, identify risk early, and execute the highest-impact next session."
           actions={[
             { href: "/plan", label: "Create a plan" },
             { href: "/coach", label: "Ask tri.ai", variant: "secondary" }
@@ -282,7 +282,7 @@ export default async function DashboardPage({
           <p className="text-xs uppercase tracking-[0.16em] text-cyan-300">Get started</p>
           <h1 className="mt-2 text-2xl font-semibold">Build your first week</h1>
           <p className="mt-2 text-sm text-muted">
-            Create a plan to unlock Today, Week Progress, and Coach Focus. You can also connect Garmin to backfill completed sessions.
+            Create a plan to unlock Today, Week Progress, and Coach Focus. Connect Garmin to reconcile completed work against scheduled sessions.
           </p>
           <div className="mt-5 flex flex-wrap gap-2">
             <Link href="/plan" className="btn-primary">Create a plan</Link>
@@ -298,7 +298,7 @@ export default async function DashboardPage({
     <section className="space-y-4">
       <PageHeader
         title="Dashboard"
-        objective="Stay oriented on this training week, keep completion momentum, and surface where coaching attention is needed."
+        objective="Stay oriented on this training week, maintain completion discipline, and surface where coaching attention is needed."
         actions={[
           { href: "/calendar", label: "Open calendar" },
           { href: "/coach", label: "Ask tri.ai", variant: "secondary" }
@@ -454,7 +454,7 @@ export default async function DashboardPage({
             <details className="mt-3">
               <summary className="cursor-pointer text-xs text-cyan-300">Why?</summary>
               <div className="mt-2 surface-subtle p-3 text-sm text-muted">
-                <p>Insight uses today&apos;s longest pending session or the largest weekly discipline gap in planned vs completed minutes.</p>
+                <p>Insight is generated from today&apos;s highest-load pending session or the largest weekly gap between planned and completed minutes.</p>
                 <Link href="/calendar" className="mt-2 inline-block text-xs text-cyan-300 underline-offset-2 hover:underline">View details</Link>
               </div>
             </details>


### PR DESCRIPTION
### Motivation
- Bring Dashboard and Coach UI copy into alignment with `docs/design-strategy-gate.md` by shifting tone toward operational, performance-intelligence language that is confident, focused, and calm under load.

### Description
- Update Dashboard messaging to be more execution- and risk-focused by refining the main objectives, onboarding copy, fallback coach focus text, and the rationale shown in the Coach Focus detail.(changed strings only)
- Update Coach page objective to emphasize concise, evidence-linked guidance rather than casual coaching phrasing.(changed string only)
- Reframe Coach chat surface by replacing the default assistant intro, renaming the decision area to a decision board, tightening the console heading, changing the input placeholder, and renaming the workout snapshot to a performance snapshot.(changed strings only)
- Modified files: `app/(protected)/dashboard/page.tsx`, `app/(protected)/coach/page.tsx`, `app/(protected)/coach/coach-chat.tsx`.

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors (pass).
- Ran `npm run typecheck` which failed due to existing repo test typing issues (missing Jest globals referenced by test files resulting in type errors).
- Ran `npm test` but the `jest` binary was not available in this environment so the unit test suite could not be executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f5070b7f0833284af0eebfbcb8e4c)