### PR TITLE
Reorganize dashboard/plan/calendar into shared priority hierarchy

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -210,6 +210,14 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     };
   });
 
+
+  const completedCount = sessions.filter((session) => session.status === "completed").length;
+  const pendingCount = sessions.filter((session) => session.status === "planned").length;
+  const skippedCount = sessions.filter((session) => session.status === "skipped").length;
+  const unmatchedUploads = [...unassignedByDate.values()].reduce((sum, count) => sum + count, 0);
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const nextTodaySession = sessions.find((session) => session.date === todayIso && session.status === "planned") ?? null;
+
   const raceDate = process.env.NEXT_PUBLIC_RACE_DATE;
   const raceCountdown = raceDate
     ? Math.max(0, Math.ceil((new Date(`${raceDate}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
@@ -225,6 +233,56 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
           { href: "/dashboard", label: "View dashboard", variant: "secondary" }
         ]}
       />
+
+      <div className="priority-layout">
+        <article className="priority-card-primary">
+          <p className="priority-kicker">Today&apos;s priority session</p>
+          <h2 className="priority-title">Execute your next key workout.</h2>
+          <p className="priority-subtitle">Keep focus on one clear session, then tidy the rest of the day.</p>
+          <p className="mt-3 text-sm text-muted">
+            {nextTodaySession
+              ? `Next up: ${nextTodaySession.type} (${nextTodaySession.duration} min).`
+              : "No planned session today. Pull one forward to keep confidence high."}
+          </p>
+        </article>
+
+        <article className="priority-card-secondary">
+          <p className="priority-kicker">On track this week</p>
+          <h2 className="priority-title">Monitor execution confidence daily.</h2>
+          <p className="priority-subtitle">Use completion and pending counts to prevent last-minute backlog.</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Completed</p>
+              <p className="mt-1 text-lg font-semibold">{completedCount}</p>
+            </div>
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Planned</p>
+              <p className="mt-1 text-lg font-semibold">{pendingCount}</p>
+            </div>
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Skipped</p>
+              <p className="mt-1 text-lg font-semibold">{skippedCount}</p>
+            </div>
+          </div>
+        </article>
+
+        <article className="priority-card-secondary">
+          <p className="priority-kicker">Supporting analytics</p>
+          <h2 className="priority-title">Resolve upload and scheduling drift.</h2>
+          <p className="priority-subtitle">Catch unmatched activities early so your plan and execution stay aligned.</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Unmatched uploads</p>
+              <p className="mt-1 text-lg font-semibold">{unmatchedUploads}</p>
+            </div>
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Current week view</p>
+              <p className="mt-1 text-sm font-semibold">{weekStart === currentWeekStart ? "Current" : "Historical / Future"}</p>
+            </div>
+          </div>
+        </article>
+      </div>
+
       <WeekCalendar
         weekDays={weekDays}
         sessions={sessions}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -326,34 +326,86 @@ export default async function DashboardPage({
       </header>
 
       {hasActivePlan && !hasWeekSessions ? (
-        <article className="surface p-6">
-          <h1 className="text-xl font-semibold">No sessions planned for this week.</h1>
-          <p className="mt-2 text-sm text-muted">Schedule this week to start tracking execution and coaching insights.</p>
+        <article className="priority-card-primary">
+          <p className="priority-kicker">Today&apos;s priority session</p>
+          <h1 className="priority-title">Set one key workout and execute it.</h1>
+          <p className="priority-subtitle">Add sessions for this week so your next best workout is always clear.</p>
           <div className="mt-4 flex flex-wrap gap-2">
             <Link href="/plan" className="btn-primary">Add session</Link>
             <Link href="/plan" className="btn-secondary">Duplicate last week</Link>
-            <Link href="/plan" className="btn-secondary">Go to Plan</Link>
+            <Link href="/plan" className="btn-secondary">Go to plan</Link>
           </div>
         </article>
       ) : (
-        <>
-          {unassignedUploads.length > 0 ? (
-            <article className="surface border border-amber-400/30 bg-amber-500/10 p-4">
-              <p className="text-xs uppercase tracking-[0.12em] text-amber-200">Garmin uploads</p>
-              <p className="mt-1 text-sm text-amber-100">{unassignedUploads.length} unassigned uploaded activit{unassignedUploads.length === 1 ? "y" : "ies"} this week ({unassignedMinutes} min).</p>
-              <Link href="/settings/integrations" className="mt-2 inline-block text-xs text-accent underline">Attach uploads to planned sessions</Link>
-              <div className="mt-2 flex flex-wrap gap-2 text-xs">
-                {unassignedUploads.slice(0, 3).map((item) => (
-                  <Link key={item.id} href={`/activities/${item.id}`} className="rounded-full border border-amber-200/30 px-2 py-1 text-amber-100">
-                    View {item.sport_type}
-                  </Link>
-                ))}
+        <div className="priority-layout">
+          <article className="priority-card-primary">
+            <div className="flex flex-wrap items-start justify-between gap-3">
+              <div>
+                <p className="priority-kicker">Today&apos;s priority session</p>
+                <h1 className="priority-title">Lock in your next workout now.</h1>
+                <p className="priority-subtitle">Focus on the highest-impact session first, then clear supporting work.</p>
               </div>
-            </article>
-          ) : null}
+              <p className="text-xs text-muted">{shortDateFormatter.format(new Date(`${todayIso}T00:00:00.000Z`))}</p>
+            </div>
 
-          <div className="grid gap-4 lg:grid-cols-[1.15fr_1fr]">
-            <div className="lg:order-1">
+            {todaySessions.length === 0 ? (
+              <p className="surface-subtle mt-4 p-3 text-sm text-muted">No sessions for today. Pull one workout forward to keep momentum.</p>
+            ) : (
+              <ul className="mt-4 space-y-2">
+                {todaySessions.map((session) => {
+                  const discipline = getDisciplineMeta(session.sport);
+                  return (
+                    <li key={session.id} className="surface-subtle p-3">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${discipline.className}`}>
+                            {discipline.label}
+                          </span>
+                          <p className="mt-1 text-sm font-medium">{session.type}</p>
+                          <p className="text-xs text-muted">{session.duration_minutes} min</p>
+                        </div>
+                        <div className="flex items-center gap-2">
+                          <span
+                            className={`capitalize ${
+                              session.status === "completed"
+                                ? "calendar-status-completed"
+                                : session.status === "skipped"
+                                  ? "calendar-status-skipped"
+                                  : "calendar-status-planned"
+                            }`}
+                          >
+                            {session.status}
+                          </span>
+                          <details className="relative">
+                            <summary aria-label="Session actions" className="list-none cursor-pointer rounded-lg border border-[hsl(var(--border))] px-2 py-1 text-xs">⋯</summary>
+                            <div className="absolute right-0 z-10 mt-1 w-40 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] p-2">
+                              <form action={markSkippedAction}>
+                                <input type="hidden" name="sessionId" value={session.id} />
+                                <button className="w-full rounded-md px-2 py-1 text-left text-xs hover:bg-[hsl(var(--bg-card))]">Mark skipped</button>
+                              </form>
+                            </div>
+                          </details>
+                        </div>
+                      </div>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+
+            <div className="mt-4 flex flex-wrap gap-2">
+              <Link href={nextPendingTodaySession ? `/calendar?focus=${nextPendingTodaySession.id}` : "/calendar"} className="btn-primary px-3 py-1.5 text-xs">
+                Open next session
+              </Link>
+              <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">Log completed work</Link>
+            </div>
+          </article>
+
+          <article className="priority-card-secondary">
+            <p className="priority-kicker">On track this week</p>
+            <h2 className="priority-title">Confirm your confidence trend.</h2>
+            <p className="priority-subtitle">Check completion pace and close the largest discipline gap before week end.</p>
+            <div className="mt-4">
               <WeekProgressCard
                 plannedTotalMinutes={totals.planned}
                 completedTotalMinutes={totals.completed}
@@ -366,70 +418,12 @@ export default async function DashboardPage({
                 }))}
               />
             </div>
+          </article>
 
-            <article className="surface p-4 lg:order-2">
-              <div className="mb-3 flex items-center justify-between">
-                <h1 className="text-xl font-semibold">Today + Next up</h1>
-                <p className="text-xs text-muted">{shortDateFormatter.format(new Date(`${todayIso}T00:00:00.000Z`))}</p>
-              </div>
-
-              {todaySessions.length === 0 ? (
-                <p className="surface-subtle p-3 text-sm text-muted">No sessions for today.</p>
-              ) : (
-                <ul className="space-y-2">
-                  {todaySessions.map((session) => {
-                    const discipline = getDisciplineMeta(session.sport);
-                    return (
-                      <li key={session.id} className="surface-subtle p-3">
-                        <div className="flex items-start justify-between gap-3">
-                          <div>
-                            <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${discipline.className}`}>
-                              {discipline.label}
-                            </span>
-                            <p className="mt-1 text-sm font-medium">{session.type}</p>
-                            <p className="text-xs text-muted">{session.duration_minutes} min</p>
-                          </div>
-                          <div className="flex items-center gap-2">
-                            <span
-                              className={`capitalize ${
-                                session.status === "completed"
-                                  ? "calendar-status-completed"
-                                  : session.status === "skipped"
-                                    ? "calendar-status-skipped"
-                                    : "calendar-status-planned"
-                              }`}
-                            >
-                              {session.status}
-                            </span>
-                            <details className="relative">
-                              <summary aria-label="Session actions" className="list-none cursor-pointer rounded-lg border border-[hsl(var(--border))] px-2 py-1 text-xs">⋯</summary>
-                              <div className="absolute right-0 z-10 mt-1 w-40 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] p-2">
-                                <form action={markSkippedAction}>
-                                  <input type="hidden" name="sessionId" value={session.id} />
-                                  <button className="w-full rounded-md px-2 py-1 text-left text-xs hover:bg-[hsl(var(--bg-card))]">Mark skipped</button>
-                                </form>
-                              </div>
-                            </details>
-                          </div>
-                        </div>
-                      </li>
-                    );
-                  })}
-                </ul>
-              )}
-
-              <div className="mt-3 flex flex-wrap gap-2">
-                <Link href={nextPendingTodaySession ? `/calendar?focus=${nextPendingTodaySession.id}` : "/calendar"} className="btn-primary px-3 py-1.5 text-xs">
-                  Open next session
-                </Link>
-                <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">Log done</Link>
-              </div>
-            </article>
-          </div>
-
-          <article id="coach-focus" className="surface p-4 scroll-mt-24">
-            <h2 className="text-lg font-semibold">Coach Focus — Today</h2>
-            <p className="mt-2 text-sm">{focusText}</p>
+          <article className="priority-card-secondary scroll-mt-24" id="coach-focus">
+            <p className="priority-kicker">Coach focus</p>
+            <h2 className="priority-title">Keep today&apos;s decision simple.</h2>
+            <p className="priority-subtitle">{focusText}</p>
             <div className="mt-3 flex flex-wrap gap-2">
               {keyTodaySession ? (
                 <>
@@ -450,14 +444,46 @@ export default async function DashboardPage({
                 </>
               ) : null}
             </div>
+          </article>
 
-            <details className="mt-3">
-              <summary className="cursor-pointer text-xs text-accent">Why?</summary>
-              <div className="mt-2 surface-subtle p-3 text-sm text-muted">
-                <p>Insight is generated from today&apos;s highest-load pending session or the largest weekly gap between planned and completed minutes.</p>
-                <Link href="/calendar" className="mt-2 inline-block text-xs text-accent underline-offset-2 hover:underline">View details</Link>
+          <article className="priority-card-secondary">
+            <p className="priority-kicker">Supporting analytics</p>
+            <h2 className="priority-title">Review sport load and upload gaps.</h2>
+            <p className="priority-subtitle">Use supporting signals to adjust volume and keep your data aligned.</p>
+            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+              <div className="priority-card-supporting">
+                <h3 className="text-sm font-semibold">Sport breakdown</h3>
+                <ul className="mt-2 space-y-2">
+                  {progressBySport.map((sport) => (
+                    <li key={sport.sport} className="flex items-center justify-between gap-3 text-sm">
+                      <span className="font-medium">{sport.label}</span>
+                      <span className="text-muted">{sport.completed}/{sport.planned} min</span>
+                    </li>
+                  ))}
+                </ul>
               </div>
-            </details>
+
+              <div className="priority-card-supporting">
+                <h3 className="text-sm font-semibold">Unmatched uploads</h3>
+                {unassignedUploads.length > 0 ? (
+                  <>
+                    <p className="mt-2 text-sm text-muted">
+                      {unassignedUploads.length} upload{unassignedUploads.length === 1 ? "" : "s"} still need matching ({unassignedMinutes} min).
+                    </p>
+                    <Link href="/settings/integrations" className="mt-2 inline-block text-xs text-accent underline">Match uploads now</Link>
+                    <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                      {unassignedUploads.slice(0, 3).map((item) => (
+                        <Link key={item.id} href={`/activities/${item.id}`} className="rounded-full border border-[hsl(var(--border))] px-2 py-1">
+                          View {item.sport_type}
+                        </Link>
+                      ))}
+                    </div>
+                  </>
+                ) : (
+                  <p className="mt-2 text-sm text-muted">Great job—every uploaded activity is already matched to your plan.</p>
+                )}
+              </div>
+            </div>
           </article>
 
           <article className="surface p-3">
@@ -482,7 +508,7 @@ export default async function DashboardPage({
               ))}
             </div>
           </article>
-        </>
+        </div>
       )}
     </section>
   );

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -147,6 +147,7 @@ export default async function PlanPage({
   }
 
   let sessionsData: Session[] = [];
+
   if (selectedPlan) {
     const primaryQuery = await supabase
       .from("sessions")
@@ -210,6 +211,10 @@ export default async function PlanPage({
     }
   }
 
+  const totalPlannedMinutes = sessionsData.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const completeSessions = sessionsData.filter((session) => session.status === "completed").length;
+  const nextSession = sessionsData.find((session) => session.status === "planned") ?? null;
+
   return (
     <section className="plan-editor-motion-lock space-y-4">
       <PageHeader
@@ -220,6 +225,54 @@ export default async function PlanPage({
           { href: "/dashboard", label: "Back to dashboard", variant: "secondary" }
         ]}
       />
+
+      <div className="priority-layout">
+        <article className="priority-card-primary">
+          <p className="priority-kicker">Today&apos;s priority session</p>
+          <h2 className="priority-title">Build the next session your athlete needs.</h2>
+          <p className="priority-subtitle">Keep today&apos;s key workout clear, specific, and realistic to execute.</p>
+          <p className="mt-3 text-sm text-muted">
+            {nextSession ? `Next up: ${nextSession.type} (${nextSession.duration_minutes} min).` : "No planned session yet. Add one now to set direction."}
+          </p>
+        </article>
+
+        <article className="priority-card-secondary">
+          <p className="priority-kicker">On track this week</p>
+          <h2 className="priority-title">Audit confidence before you publish.</h2>
+          <p className="priority-subtitle">Ensure volume and completion trend match your current race objective.</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-3">
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Weeks mapped</p>
+              <p className="mt-1 text-lg font-semibold">{weeksData.length}</p>
+            </div>
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Sessions planned</p>
+              <p className="mt-1 text-lg font-semibold">{sessionsData.length}</p>
+            </div>
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Completed sessions</p>
+              <p className="mt-1 text-lg font-semibold">{completeSessions}</p>
+            </div>
+          </div>
+        </article>
+
+        <article className="priority-card-secondary">
+          <p className="priority-kicker">Supporting analytics</p>
+          <h2 className="priority-title">Check volume and plan coverage.</h2>
+          <p className="priority-subtitle">Use supporting signals to keep structure balanced and actionable.</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2">
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Total planned minutes</p>
+              <p className="mt-1 text-lg font-semibold">{totalPlannedMinutes}</p>
+            </div>
+            <div className="priority-card-supporting">
+              <p className="text-xs text-muted">Active plan</p>
+              <p className="mt-1 text-sm font-semibold">{selectedPlan?.name ?? "No active plan selected"}</p>
+            </div>
+          </div>
+        </article>
+      </div>
+
       <PlanEditor plans={plans} weeks={weeksData} sessions={sessionsData} selectedPlanId={selectedPlan?.id} />
     </section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -154,6 +154,39 @@
     @apply rounded-xl;
   }
 
+  .priority-layout {
+    @apply grid gap-4;
+  }
+
+  .priority-card-primary {
+    @apply surface p-6 md:p-7;
+    border-color: hsl(var(--accent-performance) / 0.45);
+    background:
+      linear-gradient(145deg, hsl(var(--bg-elevated)) 35%, hsl(var(--accent-performance) / 0.08) 100%),
+      hsl(var(--bg-elevated));
+    box-shadow: 0 20px 45px -30px hsl(var(--accent-performance) / 0.7);
+  }
+
+  .priority-card-secondary {
+    @apply surface p-5;
+  }
+
+  .priority-card-supporting {
+    @apply surface-subtle p-4;
+  }
+
+  .priority-title {
+    @apply text-lg font-semibold text-[hsl(var(--fg))];
+  }
+
+  .priority-subtitle {
+    @apply mt-1 text-sm text-muted;
+  }
+
+  .priority-kicker {
+    @apply text-[11px] uppercase tracking-[0.14em] text-accent;
+  }
+
   .btn-primary {
     @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white;
     border: 1px solid hsl(var(--accent-performance) / 0.65);


### PR DESCRIPTION
### Motivation

- Surface the single highest-impact action first on protected pages so athletes know the next best workout to execute.  
- Provide a consistent visual hierarchy across Dashboard, Plan, and Calendar with shared utility classes to enforce size, contrast, and spacing differences for primary vs secondary cards.  
- Standardize microcopy for card titles/subtitles to be short, actionable, and athlete-centered.

### Description

- Added shared priority layout and tiered card utilities to `app/globals.css`: `priority-layout`, `priority-card-primary`, `priority-card-secondary`, `priority-card-supporting`, and microcopy helpers `priority-kicker`, `priority-title`, `priority-subtitle`.  
- Reworked `app/(protected)/dashboard/page.tsx` into three logical blocks (primary action, progress confidence, supporting analytics) using the new utility classes and updated copy to be action-focused.  
- Applied the same hierarchy and microcopy pattern to `app/(protected)/plan/page.tsx` and `app/(protected)/calendar/page.tsx`, adding compact summary metrics (counts/minutes/next session) shown in supporting cards.  
- Fixed unescaped apostrophes to satisfy lint rules and added a few lightweight derived variables (counts/totals/next session) used by the new cards.

### Testing

- Ran `npm run lint` and it completed with no ESLint warnings or errors.  
- Ran `npm run typecheck` which failed due to a pre-existing repository TypeScript test issue (`lib/workouts/activity-matching.test.ts` referencing a missing `assert`) that is unrelated to these UI changes.  
- Started the dev server with `npm run dev` and compiled the app; runtime attempts to render server pages exposed missing Supabase env vars (expected in this environment) but compilation succeeded for the modified files.  
- Captured a dev-mode screenshot of the updated Dashboard route using an automated Playwright script (artifact saved during the run for visual review).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f591ca2a48332802bfd9808202d18)