### PR TITLE
Refine protected shell progress rail, nav semantics, and header motif

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -15,6 +15,9 @@ type Profile = {
 };
 
 type Session = {
+  date: string;
+  sport: string;
+  type: string | null;
   duration_minutes: number | null;
   status: "planned" | "completed" | "skipped";
 };
@@ -67,10 +70,11 @@ export default async function ProtectedLayout({
 
   const currentWeekStart = getMonday().toISOString().slice(0, 10);
   const currentWeekEnd = addDays(currentWeekStart, 7);
+  const previousWeekStart = addDays(currentWeekStart, -7);
 
   const activePlanId = profile?.active_plan_id ?? null;
 
-  const [{ data: weekData }, { data: sessionsData }] = activePlanId
+  const [{ data: weekData }, { data: sessionsData }, { data: previousWeekSessionsData }] = activePlanId
     ? await Promise.all([
         supabase
           .from("training_weeks")
@@ -82,21 +86,37 @@ export default async function ProtectedLayout({
           .maybeSingle(),
         supabase
           .from("sessions")
-          .select("duration_minutes,status")
+          .select("date,sport,type,duration_minutes,status")
           .eq("plan_id", activePlanId)
           .gte("date", currentWeekStart)
-          .lt("date", currentWeekEnd)
+          .lt("date", currentWeekEnd),
+        supabase
+          .from("sessions")
+          .select("duration_minutes,status")
+          .eq("plan_id", activePlanId)
+          .gte("date", previousWeekStart)
+          .lt("date", currentWeekStart)
       ])
-    : [{ data: null }, { data: [] }];
+    : [{ data: null }, { data: [] }, { data: [] }];
 
   const weekContext = (weekData ?? null) as TrainingWeek | null;
   const sessions = (sessionsData ?? []) as Session[];
+  const previousWeekSessions = (previousWeekSessionsData ?? []) as Array<Pick<Session, "duration_minutes" | "status">>;
 
   const plannedMinutes = sessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
   const completedMinutes = sessions
     .filter((session) => session.status === "completed")
     .reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
   const completionRate = plannedMinutes > 0 ? Math.round((completedMinutes / plannedMinutes) * 100) : 0;
+  const previousWeekPlannedMinutes = previousWeekSessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const previousWeekCompletedMinutes = previousWeekSessions
+    .filter((session) => session.status === "completed")
+    .reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const previousCompletionRate = previousWeekPlannedMinutes > 0 ? Math.round((previousWeekCompletedMinutes / previousWeekPlannedMinutes) * 100) : 0;
+  const completionDelta = completionRate - previousCompletionRate;
+
+  const trendDirection = completionDelta >= 8 ? "improving" : completionDelta <= -8 ? "declining" : "stable";
+  const trendLabel = trendDirection === "improving" ? "Improving" : trendDirection === "declining" ? "Declining" : "Stable";
 
   const readiness = completionRate >= 70 ? "Ready" : completionRate >= 40 ? "Building" : "Needs focus";
   const readinessClass = completionRate >= 70 ? "signal-ready" : completionRate >= 40 ? "signal-load" : "signal-risk";
@@ -105,9 +125,18 @@ export default async function ProtectedLayout({
     ? Math.max(0, Math.ceil((new Date(`${profile.race_date}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
     : null;
 
+  const todayIso = new Date().toISOString().slice(0, 10);
+  const nextKeySession = sessions
+    .filter((session) => session.status === "planned" && session.date >= todayIso)
+    .sort((a, b) => a.date.localeCompare(b.date))[0] ?? null;
+
+  const nextKeySessionLabel = nextKeySession
+    ? `${nextKeySession.sport}${nextKeySession.type ? ` · ${nextKeySession.type}` : ""} · ${nextKeySession.duration_minutes ?? 0} min`
+    : "No planned key session";
+
   return (
     <div className="app-shell">
-      <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.95] backdrop-blur">
+      <div className={`shell-header border-b border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.95] backdrop-blur shell-header--${trendDirection}`}>
         <div className="mx-auto flex w-full max-w-[1200px] flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-6">
           <p className="text-sm uppercase tracking-[0.2em] text-accent">tri.ai</p>
           <div className="flex items-center gap-2">
@@ -119,6 +148,20 @@ export default async function ProtectedLayout({
           </div>
           <AccountMenu avatarUrl={profile?.avatar_url ?? null} initials={initials} displayName={displayName} email={email} signOutAction={signOutAction} />
         </div>
+
+        <div className="mx-auto w-full max-w-[1200px] px-4 pb-3 md:px-6 lg:hidden">
+          <p className="inline-flex max-w-full items-center gap-2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))/0.9] px-3 py-1 text-xs text-muted">
+            <span className="font-semibold text-[hsl(var(--fg))]">{completionRate}% complete</span>
+            <span>·</span>
+            <span className="truncate">{nextKeySession ? `Next ${nextKeySession.sport}` : "No next key session"}</span>
+            {daysToRace !== null ? (
+              <>
+                <span>·</span>
+                <span>Race {daysToRace}d</span>
+              </>
+            ) : null}
+          </p>
+        </div>
       </div>
 
       <div className="mx-auto grid w-full max-w-[1200px] gap-4 px-4 pb-24 pt-5 md:px-6 lg:grid-cols-[260px_1fr] lg:pb-8">
@@ -128,6 +171,19 @@ export default async function ProtectedLayout({
               <p className="text-xs uppercase tracking-[0.16em] text-accent">Primary nav</p>
               <div className="mt-2">
                 <ShellNavRail />
+              </div>
+
+              <div className="surface-subtle mt-3 p-3">
+                <div className="flex items-center justify-between gap-2">
+                  <p className="text-xs uppercase tracking-[0.14em] text-muted">Weekly progress</p>
+                  <span className={`signal-chip ${readinessClass}`}>{trendLabel}</span>
+                </div>
+                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[hsl(var(--bg-elevated))]">
+                  <div className="h-full rounded-full bg-[hsl(var(--accent-performance))]" style={{ width: `${completionRate}%` }} />
+                </div>
+                <p className="mt-2 text-sm font-semibold">{completionRate}% completion</p>
+                <p className="mt-1 text-xs text-muted">Next key: {nextKeySessionLabel}</p>
+                {daysToRace !== null ? <p className="mt-1 text-xs text-muted">Race countdown: {daysToRace} days</p> : null}
               </div>
             </div>
 

--- a/app/(protected)/shell-nav.tsx
+++ b/app/(protected)/shell-nav.tsx
@@ -4,10 +4,10 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const navItems = [
-  { href: "/dashboard", label: "Dashboard" },
-  { href: "/plan", label: "Plan" },
-  { href: "/calendar", label: "Calendar" },
-  { href: "/coach", label: "Coach" }
+  { href: "/dashboard", label: "Dashboard", semanticLabel: "Overview" },
+  { href: "/plan", label: "Plan", semanticLabel: "Design" },
+  { href: "/calendar", label: "Calendar", semanticLabel: "Execution" },
+  { href: "/coach", label: "Coach", semanticLabel: "Adaptation" }
 ];
 
 export function ShellNavRail() {
@@ -21,13 +21,15 @@ export function ShellNavRail() {
           <Link
             key={item.href}
             href={item.href}
+            title={`${item.label} · ${item.semanticLabel}`}
             className={`block rounded-xl px-3 py-2 text-sm transition ${
               active
                 ? "bg-[hsl(var(--accent-performance)/0.14)] text-[hsl(var(--accent-performance))] ring-1 ring-[hsl(var(--accent-performance)/0.45)]"
                 : "text-[hsl(var(--fg-muted))] hover:bg-[hsl(var(--bg-card))] hover:text-[hsl(var(--fg))]"
             }`}
           >
-            {item.label}
+            <span className="block font-medium">{item.label}</span>
+            <span className="block text-[11px] uppercase tracking-[0.12em] text-muted">{item.semanticLabel}</span>
           </Link>
         );
       })}
@@ -47,9 +49,11 @@ export function MobileBottomTabs() {
             <Link
               key={item.href}
               href={item.href}
+              title={`${item.label} · ${item.semanticLabel}`}
               className={`rounded-lg px-2 py-2 text-center text-xs font-medium ${active ? "bg-[hsl(var(--accent-performance)/0.14)] text-[hsl(var(--accent-performance))]" : "text-muted"}`}
             >
-              {item.label}
+              <span className="block">{item.label}</span>
+              <span className="block text-[10px] uppercase tracking-[0.12em]">{item.semanticLabel}</span>
             </Link>
           );
         })}

--- a/app/globals.css
+++ b/app/globals.css
@@ -134,6 +134,34 @@
     animation: none;
   }
 
+
+  .shell-header {
+    @apply relative overflow-hidden;
+  }
+
+  .shell-header::before {
+    content: "";
+    position: absolute;
+    inset: -40% -15% auto;
+    height: 210%;
+    pointer-events: none;
+    background: radial-gradient(circle at top right, hsl(var(--accent-performance) / 0.14), transparent 56%);
+    opacity: 0.3;
+    transform-origin: top right;
+  }
+
+  .shell-header--improving::before {
+    animation: progress-motif-up 16s ease-in-out infinite alternate;
+  }
+
+  .shell-header--stable::before {
+    animation: progress-motif-stable 22s ease-in-out infinite;
+  }
+
+  .shell-header--declining::before {
+    animation: progress-motif-down 18s ease-in-out infinite alternate;
+  }
+
   .surface {
     background: hsl(var(--bg-elevated));
     border: 1px solid hsl(var(--border));
@@ -454,6 +482,41 @@
   .discipline-strength,
   .discipline-other {
     background-blend-mode: soft-light;
+  }
+}
+
+
+@keyframes progress-motif-up {
+  0% {
+    opacity: 0.2;
+    transform: translate3d(-1%, 1.5%, 0) scale(0.98) rotate(-1deg);
+  }
+  100% {
+    opacity: 0.36;
+    transform: translate3d(2%, -2%, 0) scale(1.04) rotate(1deg);
+  }
+}
+
+@keyframes progress-motif-stable {
+  0%,
+  100% {
+    opacity: 0.22;
+    transform: translate3d(0, 0, 0) scale(1);
+  }
+  50% {
+    opacity: 0.3;
+    transform: translate3d(0.8%, -0.4%, 0) scale(1.01);
+  }
+}
+
+@keyframes progress-motif-down {
+  0% {
+    opacity: 0.32;
+    transform: translate3d(2%, -1%, 0) scale(1.02) rotate(0.8deg);
+  }
+  100% {
+    opacity: 0.18;
+    transform: translate3d(-1%, 2%, 0) scale(0.97) rotate(-1.2deg);
   }
 }
 


### PR DESCRIPTION
### Motivation
- Surface compact weekly progress and next-session context near global navigation without adding backend dependencies. 
- Make navigation states more semantic so users can quickly understand the mental model behind each top-level area. 
- Provide a subtle, non-distracting header motif that communicates completion trend direction (improving/stable/declining). 

### Description
- Add a weekly progress rail to the protected shell sidebar that shows completion %, a next key planned session label, and race countdown derived from existing `sessions` and `profiles` data (no backend changes), implemented in `app/(protected)/layout.tsx`. 
- Compute previous-week completion and derive a `trendDirection` of `improving` / `stable` / `declining` to annotate the rail and header; surface a `trendLabel` and `readiness` signal in the UI. 
- Collapse the rail into a single restrained status pill on mobile placed in the shell header to keep chrome lightweight on small screens. 
- Make nav items semantic by adding `semanticLabel` subtitles (`Overview`, `Design`, `Execution`, `Adaptation`) and matching `title` tooltips in `app/(protected)/shell-nav.tsx`. 
- Introduce a restrained header motif layer and three small animations (`progress-motif-up`, `progress-motif-stable`, `progress-motif-down`) in `app/globals.css` and toggle them via header classes tied to `trendDirection`. 

### Testing
- Ran `npm run lint` and it completed with no ESLint warnings or errors. 
- Ran `npm run typecheck` and it failed due to an existing unrelated repo TypeScript test issue (`lib/workouts/activity-matching.test.ts` referencing `assert`), not introduced by this change. 
- Started the dev server (`npm run dev`) and attempted a Playwright visual check which produced a screenshot artifact, but full runtime page rendering in this environment showed Supabase env-var errors (missing public keys) so server-side data calls failed in CI-like environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f64d7743883329fe556479236aca3)