### PR TITLE
Theme overhaul: introduce neutral signal and replace hardcoded cyan accents across calendar, coach, and dashboard

### DIFF
--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -336,14 +336,14 @@ export function WeekCalendar({
       <header className="surface sticky top-2 z-20 space-y-3 px-4 py-3 backdrop-blur">
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-cyan-300">Week of {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}</p>
+            <p className="text-xs uppercase tracking-[0.2em] text-accent">Week of {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}</p>
             <p className="text-sm font-semibold">
               {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}–{dayFormatter.format(new Date(`${weekDays[6].iso}T00:00:00.000Z`))}
             </p>
           </div>
           <div className="flex flex-wrap items-center gap-2">
             <Link href={weekLink(prevWeek.toISOString().slice(0, 10))} className="btn-secondary px-3 py-1.5 text-xs">Prev week</Link>
-            <Link href="/calendar" className={`btn-secondary px-3 py-1.5 text-xs ${isCurrentWeek ? "border-cyan-400/60" : ""}`}>Current week</Link>
+            <Link href="/calendar" className={`btn-secondary px-3 py-1.5 text-xs ${isCurrentWeek ? "border-[hsl(var(--accent-performance)/0.45)]" : ""}`}>Current week</Link>
             <Link href={weekLink(nextWeek.toISOString().slice(0, 10))} className="btn-secondary px-3 py-1.5 text-xs">Next week</Link>
             <button
               className="btn-primary px-3 py-1.5 text-xs"
@@ -357,7 +357,7 @@ export function WeekCalendar({
               Add session
             </button>
             {raceCountdown !== null ? (
-              <span className="rounded-full border border-cyan-400/40 bg-cyan-500/10 px-3 py-1 text-xs font-medium text-cyan-100">Race in {raceCountdown}d</span>
+              <span className="rounded-full border border-[hsl(var(--accent-performance)/0.35)] bg-[hsl(var(--accent-performance)/0.12)] px-3 py-1 text-xs font-medium text-accent">Race in {raceCountdown}d</span>
             ) : null}
           </div>
         </div>
@@ -366,7 +366,7 @@ export function WeekCalendar({
             {(["all", "swim", "bike", "run", "strength"] as const).map((item) => (
               <button
                 key={item}
-                className={`rounded-full border px-3 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70 ${sportFilter === item ? "border-cyan-300 bg-cyan-500/15 text-cyan-100" : "border-[hsl(var(--border))] text-muted"}`}
+                className={`rounded-full border px-3 py-1 text-xs focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)] ${sportFilter === item ? "border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.12)] text-accent" : "border-[hsl(var(--border))] text-muted"}`}
                 onClick={() => setSportFilter(item)}
               >
                 {item === "all" ? "All" : getDisciplineMeta(item).label}
@@ -396,8 +396,8 @@ export function WeekCalendar({
               <div key={item.sport} className="surface-subtle p-3">
                 <p title={`${discipline.label} · ${discipline.shape}`} className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] ${discipline.className} ${discipline.textureClassName}`}><span aria-hidden="true">{discipline.icon}</span><span>{discipline.label}</span></p>
                 <p className="mt-1 text-xs">{item.completed}/{item.planned} min</p>
-                <div className="mt-2 h-1.5 rounded-full bg-black/35">
-                  <div className="h-full rounded-full bg-gradient-to-r from-cyan-400/80 to-blue-400/90 transition-[width]" style={{ width: `${ratio}%` }} />
+                <div className="mt-2 h-1.5 rounded-full bg-[hsl(var(--surface-2))]">
+                  <div className="h-full rounded-full bg-[hsl(var(--accent-performance))] transition-[width]" style={{ width: `${ratio}%` }} />
                 </div>
               </div>
             );
@@ -421,10 +421,10 @@ export function WeekCalendar({
             return (
               <DayDropZone key={day.iso} id={`day:${day.iso}`} isActive={activeId !== null}>
                 <section className="surface min-h-[280px] p-3">
-                  <div className={`border-b pb-2 ${isToday ? "border-cyan-300/80 bg-cyan-500/8 px-2" : "border-[hsl(var(--border))]"}`}>
+                  <div className={`border-b pb-2 ${isToday ? "border-[hsl(var(--accent-performance)/0.5)] bg-[hsl(var(--accent-performance)/0.08)] px-2" : "border-[hsl(var(--border))]"}`}>
                     <div className="flex items-center gap-2">
                       <p className="text-xs uppercase tracking-wide text-muted">{day.weekday}</p>
-                      {isToday ? <span className="rounded-full border border-cyan-300/70 bg-cyan-500/15 px-1.5 py-0.5 text-[10px] font-medium text-cyan-100">Today</span> : null}
+                      {isToday ? <span className="rounded-full border border-[hsl(var(--accent-performance)/0.5)] bg-[hsl(var(--accent-performance)/0.12)] px-1.5 py-0.5 text-[10px] font-medium text-accent">Today</span> : null}
                     </div>
                     <p className="text-sm font-semibold">{day.label}</p>
                     <p className="text-xs text-muted">{planned === 0 ? "rest" : `${completed}/${planned} min`}</p>
@@ -433,7 +433,7 @@ export function WeekCalendar({
                   <SortableContext items={ids} strategy={verticalListSortingStrategy}>
                     <div className="mt-2 space-y-2">
                       {visibleIds.length === 0 ? (
-                        <button onClick={() => setQuickAddState({ initialDate: day.iso, allowDaySelection: false })} className="w-full rounded-xl border border-dashed border-[hsl(var(--border))] px-2 py-6 text-xs text-muted hover:border-cyan-400/50 hover:text-cyan-100">
+                        <button onClick={() => setQuickAddState({ initialDate: day.iso, allowDaySelection: false })} className="w-full rounded-xl border border-dashed border-[hsl(var(--border))] px-2 py-6 text-xs text-muted hover:border-[hsl(var(--accent-performance)/0.45)] hover:text-accent">
                           + Add
                         </button>
                       ) : (
@@ -462,11 +462,11 @@ export function WeekCalendar({
                   </SortableContext>
 
                   {hiddenCount > 0 ? (
-                    <button className="mt-2 text-xs text-cyan-200 hover:underline" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: true }))}>
+                    <button className="mt-2 text-xs text-accent hover:underline" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: true }))}>
                       +{hiddenCount} more
                     </button>
                   ) : ids.length > 2 && expandedDays[day.iso] ? (
-                    <button className="mt-2 text-xs text-muted hover:text-cyan-200" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: false }))}>
+                    <button className="mt-2 text-xs text-muted hover:text-accent" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: false }))}>
                       Show less
                     </button>
                   ) : null}
@@ -477,7 +477,7 @@ export function WeekCalendar({
         </article>
       </DndContext>
 
-      {activeId ? <p className="text-[11px] text-cyan-200/85">Drag a session to another day to reschedule.</p> : null}
+      {activeId ? <p className="text-[11px] text-accent/80">Drag a session to another day to reschedule.</p> : null}
 
       {quickAddState ? (
         <QuickAddModal
@@ -640,11 +640,11 @@ export function WeekCalendar({
       ) : null}
 
       {toast ? (
-        <div className="fixed bottom-5 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-xl border border-cyan-400/45 bg-slate-950/95 px-3 py-2 text-xs text-cyan-100 shadow-lg shadow-black/50 sm:left-auto sm:right-6 sm:translate-x-0">
+        <div className="fixed bottom-5 left-1/2 z-50 flex -translate-x-1/2 items-center gap-3 rounded-xl border border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--bg-elevated))] px-3 py-2 text-xs text-[hsl(var(--text-primary))] shadow-lg sm:left-auto sm:right-6 sm:translate-x-0">
           <span>{toast.message}</span>
           {toast.onUndo ? (
             <button
-              className="rounded-md border border-cyan-300/45 px-2 py-1 font-medium text-cyan-100 hover:bg-cyan-500/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70"
+              className="rounded-md border border-[hsl(var(--accent-performance)/0.45)] px-2 py-1 font-medium text-accent hover:bg-[hsl(var(--accent-performance)/0.1)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)]"
               onClick={() => {
                 const undo = toast.onUndo;
                 setToast(null);
@@ -664,7 +664,7 @@ export function WeekCalendar({
 function DayDropZone({ children, id, isActive }: { children: ReactNode; id: string; isActive: boolean }) {
   const { isOver, setNodeRef } = useDroppable({ id });
   const highlight = isActive && isOver;
-  return <div ref={setNodeRef} className={highlight ? "rounded-2xl ring-1 ring-cyan-300/70" : ""}>{children}</div>;
+  return <div ref={setNodeRef} className={highlight ? "rounded-2xl ring-1 ring-[hsl(var(--accent-performance)/0.5)]" : ""}>{children}</div>;
 }
 
 function SortableSessionCard({
@@ -696,7 +696,7 @@ function SortableSessionCard({
     <article
       ref={setNodeRef}
       style={style}
-      className={`group relative surface-subtle status-card-transition ${statusMotion} p-2.5 pr-8 focus-within:ring-1 focus-within:ring-cyan-300/70 ${isDragging ? "opacity-60" : ""} ${skipped ? "bg-slate-900/70" : ""}`}
+      className={`group relative surface-subtle status-card-transition ${statusMotion} p-2.5 pr-8 focus-within:ring-1 focus-within:ring-[hsl(var(--accent-performance)/0.5)] ${isDragging ? "opacity-60" : ""} `}
     >
       <div className="space-y-2">
         <div className="flex items-start justify-between gap-2">
@@ -723,7 +723,7 @@ function SortableSessionCard({
       </div>
       <button
         type="button"
-        className="absolute right-2 bottom-2 rounded p-1 text-cyan-200/65 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70"
+        className="absolute right-2 bottom-2 rounded p-1 text-accent/70 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)]"
         aria-label={`Drag ${title}`}
         {...attributes}
         {...listeners}
@@ -780,7 +780,7 @@ function SessionOverflowMenu({
     <div className="relative" ref={menuRef}>
       <button
         type="button"
-        className="rounded-md border border-[hsl(var(--border))] px-1.5 py-0.5 text-sm text-muted hover:text-cyan-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70"
+        className="rounded-md border border-[hsl(var(--border))] px-1.5 py-0.5 text-sm text-muted hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)]"
         aria-haspopup="menu"
         aria-expanded={isOpen}
         aria-label={`Open actions for ${sessionTitle}`}
@@ -795,7 +795,7 @@ function SessionOverflowMenu({
 
       {isOpen ? (
         <div
-          className="absolute right-0 top-8 z-30 min-w-[160px] rounded-lg border border-white/15 bg-slate-950/95 p-1 shadow-xl"
+          className="absolute right-0 top-8 z-30 min-w-[160px] rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] p-1 shadow-xl"
           role="menu"
           onPointerDown={(event) => event.stopPropagation()}
         >
@@ -807,7 +807,7 @@ function SessionOverflowMenu({
           ].map((item) => (
             <button
               key={item.label}
-              className="block w-full rounded-md px-2 py-1.5 text-left text-xs text-slate-100 hover:bg-white/10 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-300/70"
+              className="block w-full rounded-md px-2 py-1.5 text-left text-xs text-[hsl(var(--text-primary))] hover:bg-[hsl(var(--bg-card))] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)]"
               role="menuitem"
               onClick={() => {
                 item.action();

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -12,7 +12,7 @@ type DecisionCard = {
   title: string;
   recommendation: string;
   detail: string;
-  tone: "signal-ready" | "signal-recovery" | "signal-load" | "signal-risk";
+  tone: "signal-ready" | "signal-recovery" | "signal-load" | "signal-risk" | "signal-neutral";
   actionLabel: string;
   actionHref: string;
 };
@@ -165,7 +165,7 @@ export function CoachChat() {
 
   const confidenceSignal = useMemo(() => {
     if (!summary) {
-      return { label: "No data", tone: "signal-recovery" };
+      return { label: "No data", tone: "signal-neutral" };
     }
 
     if (summary.completionPct >= 90) {
@@ -181,7 +181,7 @@ export function CoachChat() {
 
   const urgencySignal = useMemo(() => {
     if (!summary) {
-      return { label: "Awaiting recommendation", tone: "signal-recovery" };
+      return { label: "Awaiting recommendation", tone: "signal-neutral" };
     }
 
     if (summary.completionPct >= 85) {
@@ -435,16 +435,16 @@ export function CoachChat() {
 
                       return (
                         <div className="space-y-2 text-xs">
-                          <div>
-                            <p className="font-semibold uppercase tracking-[0.14em] text-tertiary">Summary</p>
+                          <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--surface-1))] px-2.5 py-2">
+                            <p className="font-semibold uppercase tracking-[0.14em] text-tertiary">◉ Summary</p>
                             <p className="mt-1 text-sm text-[hsl(var(--text-primary))]">{structured.summaryBlock}</p>
                           </div>
-                          <div>
-                            <p className="font-semibold uppercase tracking-[0.14em] text-tertiary">Reasoning</p>
+                          <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--surface-1))] px-2.5 py-2">
+                            <p className="font-semibold uppercase tracking-[0.14em] text-tertiary">▦ Reasoning</p>
                             <p className="mt-1 text-sm text-muted">{structured.reasoning}</p>
                           </div>
-                          <div>
-                            <p className="font-semibold uppercase tracking-[0.14em] text-tertiary">Action options</p>
+                          <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--surface-1))] px-2.5 py-2">
+                            <p className="font-semibold uppercase tracking-[0.14em] text-tertiary">▲ Action options</p>
                             <ul className="mt-1 list-disc space-y-1 pl-4 text-sm text-muted">
                               {structured.actionOptions.map((option) => (
                                 <li key={option}>{option}</li>
@@ -515,11 +515,11 @@ export function CoachChat() {
         </div>
       </section>
 
-      <aside className="space-y-3 opacity-80">
-        <div className={`rounded-2xl bg-gradient-to-r ${completionTone} p-5 text-white shadow-xl`}>
-          <p className="text-xs uppercase tracking-wide text-white/90">Recent completion</p>
+      <aside className="space-y-3">
+        <div className={`rounded-2xl border border-[hsl(var(--border))] bg-gradient-to-r ${completionTone} p-5 text-[hsl(var(--text-primary))] shadow-sm`}>
+          <p className="text-xs uppercase tracking-wide text-tertiary">Recent completion</p>
           <p className="mt-2 text-3xl font-bold">{summary?.completionPct ?? 0}%</p>
-          <p className="mt-1 text-sm text-white/90">
+          <p className="mt-1 text-sm text-muted">
             {summary?.completedMinutes ?? 0} min done / {summary?.plannedMinutes ?? 0} min planned
           </p>
         </div>
@@ -531,6 +531,12 @@ export function CoachChat() {
           <div className="mt-3 flex flex-wrap gap-2">
             <span className={`signal-chip ${confidenceSignal.tone}`}>Coach confidence: {confidenceSignal.label}</span>
             <span className={`signal-chip ${urgencySignal.tone}`}>Recommendation urgency: {urgencySignal.label}</span>
+          </div>
+          <div className="mt-3">
+            <p className="text-xs text-tertiary">Confidence meter</p>
+            <div className="mt-1 h-1.5 overflow-hidden rounded-full bg-[hsl(var(--surface-2))]">
+              <div className="h-full rounded-full bg-[hsl(var(--ai-accent-core))]" style={{ width: `${Math.max(8, summary?.completionPct ?? 0)}%` }} />
+            </div>
           </div>
         </div>
 

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -226,12 +226,12 @@ export default async function DashboardPage({
       label: getDisciplineMeta(sport).label,
       color:
         sport === "swim"
-          ? "hsl(190 85% 78%)"
+          ? "#56B6D9"
           : sport === "bike"
-            ? "hsl(118 45% 78%)"
+            ? "#6BAA75"
             : sport === "run"
-              ? "hsl(19 75% 78%)"
-              : "hsl(258 78% 85%)"
+              ? "#C48772"
+              : "#9A86C8"
     };
   }).sort((a, b) => (b.planned - b.completed) - (a.planned - a.completed));
 
@@ -251,6 +251,10 @@ export default async function DashboardPage({
   const remainingMinutes = Math.max(totals.planned - totals.completed, 0);
   const fatigueState = completionPct >= 85 ? "Controlled" : completionPct >= 60 ? "Balanced" : "Accumulating";
   const confidenceLabel = completionPct >= 85 ? "High" : completionPct >= 60 ? "Building" : "Low";
+  const completionTrend = completionPct >= 80 ? "↑" : completionPct >= 50 ? "→" : "↓";
+  const loadTrend = remainingMinutes <= 120 ? "↓" : remainingMinutes <= 300 ? "→" : "↑";
+  const fatigueTrend = completionPct >= 85 ? "↓" : completionPct >= 60 ? "→" : "↑";
+  const confidenceTrend = completionPct >= 85 ? "↑" : completionPct >= 60 ? "→" : "↓";
 
   const raceName = profile?.race_name?.trim() || "Target race";
   const daysToRace = profile?.race_date
@@ -360,22 +364,22 @@ export default async function DashboardPage({
         <div className="grid gap-3 md:grid-cols-4">
           <article className="surface-subtle p-4">
             <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Completion pace</p>
-            <p className="mt-1 text-2xl font-semibold">{completionPct}%</p>
-            <p className="mt-1 text-xs text-muted">{totals.completed}/{totals.planned} min</p>
+            <p className="mt-1 text-2xl font-semibold">{completionPct}% <span className="text-base text-accent">{completionTrend}</span></p>
+            <p className="mt-1 text-xs text-muted">{totals.completed}/{totals.planned} min · vs target</p>
           </article>
           <article className="surface-subtle p-4">
             <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Remaining load</p>
-            <p className="mt-1 text-2xl font-semibold">{toHoursAndMinutes(remainingMinutes)}</p>
+            <p className="mt-1 text-2xl font-semibold">{toHoursAndMinutes(remainingMinutes)} <span className="text-base text-accent">{loadTrend}</span></p>
             <p className="mt-1 text-xs text-muted">left in this week</p>
           </article>
           <article className="surface-subtle p-4">
             <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Fatigue state</p>
-            <p className="mt-1 text-xl font-semibold">{fatigueState}</p>
+            <p className="mt-1 text-xl font-semibold">{fatigueState} <span className="text-sm text-accent">{fatigueTrend}</span></p>
             <p className="mt-1 text-xs text-muted">based on completion pressure</p>
           </article>
           <article className="surface-subtle p-4">
             <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Confidence signal</p>
-            <p className="mt-1 text-xl font-semibold">{confidenceLabel}</p>
+            <p className="mt-1 text-xl font-semibold">{confidenceLabel} <span className="text-sm text-accent">{confidenceTrend}</span></p>
             <p className="mt-1 text-xs text-muted">coach readiness estimate</p>
           </article>
         </div>
@@ -438,7 +442,7 @@ export default async function DashboardPage({
             </div>
           </article>
 
-          <article className="priority-card-secondary scroll-mt-24" id="coach-focus">
+          <article className="priority-card-supporting scroll-mt-24" id="coach-focus">
             <p className="priority-kicker">Coach focus</p>
             <h2 className="priority-title">Keep today&apos;s decision simple.</h2>
             <p className="priority-subtitle">{focusText}</p>
@@ -464,7 +468,7 @@ export default async function DashboardPage({
             </div>
           </article>
 
-          <article className="priority-card-secondary">
+          <article className="priority-card-supporting">
             <p className="priority-kicker">Supporting analytics</p>
             <h2 className="priority-title">Review sport load and upload gaps.</h2>
             <p className="priority-subtitle">Use supporting signals to adjust volume and keep your data aligned.</p>

--- a/app/globals.css
+++ b/app/globals.css
@@ -5,23 +5,26 @@
 :root {
   color-scheme: light;
   /* Core semantic surfaces: warm neutral base with gentle elevation for cards and shells. */
-  --surface: 38 24% 97%;
-  --surface-elevated: 34 18% 93%;
-  --surface-soft: 34 17% 90%;
+  --surface: 196 22% 96%;
+  --surface-elevated: 0 0% 100%;
+  --surface-soft: 196 26% 97%;
+  --surface-1: var(--surface-elevated);
+  --surface-2: 196 20% 94%;
 
   /* Typography semantics: high-contrast reading text and supportive secondary copy. */
   --text-primary: 225 24% 16%;
-  --text-secondary: 220 12% 38%;
-  --text-tertiary: 215 10% 56%;
+  --text-secondary: 216 14% 35%;
+  --text-tertiary: 215 12% 48%;
 
   /* Domain accents: performance and recovery cues tuned for readable contrast on light surfaces. */
   --accent-performance: 196 92% 28%;
   --accent-recovery: 156 60% 30%;
 
-  --signal-ready: 151 62% 51%;
-  --signal-load: 38 92% 56%;
-  --signal-risk: 8 86% 62%;
-  --signal-recovery: var(--accent-recovery);
+  --signal-ready: 147 47% 36%;
+  --signal-load: 35 74% 47%;
+  --signal-risk: 3 67% 58%;
+  --signal-recovery: 193 39% 46%;
+  --signal-neutral: 215 17% 56%;
 
   --ai-accent-core: var(--accent-performance);
   --ai-accent-glow: 192 52% 78%;
@@ -31,7 +34,7 @@
   --bg-card: var(--surface-soft);
   --fg: var(--text-primary);
   --fg-muted: var(--text-secondary);
-  --border: 220 14% 78%;
+  --border: 213 21% 82%;
   --ring: var(--ai-accent-core);
   --accent: var(--ai-accent-core);
   --accent-soft: var(--ai-accent-glow);
@@ -48,6 +51,8 @@
     --surface: 224 24% 8%;
     --surface-elevated: 222 21% 12%;
     --surface-soft: 223 18% 15%;
+    --surface-1: var(--surface-elevated);
+    --surface-2: 223 16% 18%;
     --text-primary: 210 20% 96%;
     --text-secondary: 215 14% 72%;
     --text-tertiary: 215 10% 56%;
@@ -55,6 +60,7 @@
     --accent-recovery: 166 70% 60%;
     --ai-accent-glow: 204 70% 19%;
     --border: 218 18% 25%;
+    --signal-neutral: 216 12% 70%;
   }
 }
 
@@ -369,14 +375,21 @@
     color: hsl(var(--signal-recovery));
   }
 
+
+  .signal-neutral {
+    border-color: hsl(var(--signal-neutral) / 0.45);
+    background: hsl(var(--signal-neutral) / 0.12);
+    color: hsl(var(--signal-neutral));
+  }
+
   .status-chip {
     @apply inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-[11px] font-medium;
   }
 
   .status-chip-planned {
-    border-color: hsl(var(--signal-load) / 0.35);
-    background: hsl(var(--signal-load) / 0.14);
-    color: hsl(var(--signal-load));
+    border-color: hsl(var(--signal-neutral) / 0.4);
+    background: hsl(var(--signal-neutral) / 0.12);
+    color: hsl(var(--signal-neutral));
   }
 
   .status-chip-completed {
@@ -443,37 +456,37 @@
 
   .discipline-swim {
     @apply border;
-    background: hsl(192 60% 18% / 0.5);
-    border-color: hsl(192 58% 42% / 0.7);
-    color: hsl(190 85% 78%);
+    background: hsl(193 67% 61% / 0.2);
+    border-color: hsl(193 60% 56% / 0.55);
+    color: hsl(197 58% 37%);
   }
 
   .discipline-bike {
     @apply border;
-    background: hsl(114 33% 16% / 0.5);
-    border-color: hsl(122 32% 38% / 0.7);
-    color: hsl(118 45% 78%);
+    background: hsl(133 36% 56% / 0.2);
+    border-color: hsl(133 30% 48% / 0.55);
+    color: hsl(136 30% 33%);
   }
 
   .discipline-run {
     @apply border;
-    background: hsl(13 42% 16% / 0.5);
-    border-color: hsl(14 50% 40% / 0.7);
-    color: hsl(19 75% 78%);
+    background: hsl(18 44% 62% / 0.2);
+    border-color: hsl(18 37% 57% / 0.55);
+    color: hsl(18 31% 37%);
   }
 
   .discipline-strength {
     @apply border;
-    background: hsl(262 34% 18% / 0.5);
-    border-color: hsl(258 32% 47% / 0.7);
-    color: hsl(258 78% 85%);
+    background: hsl(258 50% 72% / 0.22);
+    border-color: hsl(258 40% 64% / 0.55);
+    color: hsl(256 28% 42%);
   }
 
   .discipline-other {
     @apply border;
-    background: hsl(214 17% 21% / 0.6);
-    border-color: hsl(214 14% 45% / 0.7);
-    color: hsl(210 20% 85%);
+    background: hsl(213 20% 60% / 0.18);
+    border-color: hsl(213 17% 56% / 0.5);
+    color: hsl(215 20% 35%);
   }
 
   .discipline-swim,


### PR DESCRIPTION
### Motivation
- Replace numerous hardcoded cyan/legacy color tokens with semantic theme variables to improve consistency and accessibility across the app.
- Introduce a neutral signal and more granular surface variables to better support coach signals and UI states.
- Surface small UX improvements (trend indicators, confidence meter, stronger card contrast) to make coaching signals clearer.

### Description
- Add and adjust root CSS variables in `globals.css` including `--surface-1`, `--surface-2`, `--signal-neutral`, and retune several signal colors and border tokens.
- Replace many inline cyan classes in `app/(protected)/calendar/week-calendar.tsx` with semantic uses of `var(--accent-performance)` and `text-accent`/`[hsl(var(--...))]` patterns, and update progress bar and focus/highlight styles accordingly.
- Update `app/(protected)/coach/coach-chat.tsx` to add the `signal-neutral` tone, change default tones for empty states, reflow assistant response blocks with labeled sections and add a confidence meter UI element.
- Update `app/(protected)/dashboard/page.tsx` to set discipline color hex values, add trend indicators (`completionTrend`, `loadTrend`, `fatigueTrend`, `confidenceTrend`), and swap several card variants to the new supporting styles.

### Testing
- Performed a TypeScript type-check with `tsc` which completed without errors.
- Ran the test suite via `pnpm test` and unit tests passed.
- Ran the linter via `pnpm lint` and fixed reported issues so linting succeeds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699efa92bca883328cb4b975b24483af)