### PR TITLE
Fix open nav label and avatar menu overlay issues

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -113,7 +113,6 @@ export default async function ProtectedLayout({ children }: { children: React.Re
               <ShellNavRail compact />
             </div>
             <div className="hidden xl:block">
-              <p className="text-xs uppercase tracking-[0.16em] text-accent">Primary nav</p>
               <div className="mt-2">
                 <ShellNavRail />
               </div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -142,7 +142,7 @@
 
 
   .shell-header {
-    @apply relative overflow-hidden;
+    @apply relative z-30 overflow-visible;
   }
 
   .shell-header::before {


### PR DESCRIPTION
### Motivation
- Remove the placeholder "Primary nav" copy in the protected sidebar and ensure the account avatar dropdown renders above main content so menu items are clickable.

### Description
- Deleted the sidebar heading line that rendered `Primary nav` in `app/(protected)/layout.tsx` and adjusted header stacking by changing `.shell-header` to `@apply relative z-30 overflow-visible;` in `app/globals.css`.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors. 
- Started the dev server with `npm run dev` (app compiles; protected `/dashboard` route runtime rendering is blocked in this environment due to missing Supabase env vars). 
- Captured a Playwright screenshot for visual verification at `artifacts/issues-69-70-fix.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a35c8551048332bb0b01466142d26f)