### PR TITLE
Remove week completion chip and improve avatar button contrast

### DIFF
--- a/app/(protected)/account-menu.tsx
+++ b/app/(protected)/account-menu.tsx
@@ -22,12 +22,12 @@ export function AccountMenu({ avatarUrl, initials, displayName, email, signOutAc
 
   return (
     <details className="group relative" ref={detailsRef}>
-      <summary aria-label="Open account menu" className="list-none cursor-pointer rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] p-0.5 transition hover:border-cyan-400/50">
+      <summary aria-label="Open account menu" className="list-none cursor-pointer rounded-full border border-[hsl(var(--ai-accent-core)/0.45)] bg-[hsl(var(--surface-2))] p-0.5 shadow-[0_0_0_1px_hsl(var(--bg-elevated))] transition hover:border-[hsl(var(--ai-accent-core)/0.65)] hover:bg-[hsl(var(--bg-card))]">
         {avatarUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img src={avatarUrl} alt="User avatar" className="h-9 w-9 rounded-full object-cover" />
         ) : (
-          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-cyan-500/15 text-xs font-semibold text-cyan-200">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[hsl(var(--ai-accent-core)/0.2)] text-xs font-semibold text-[hsl(var(--ai-accent-core))]">
             {initials}
           </span>
         )}

--- a/app/(protected)/global-header.tsx
+++ b/app/(protected)/global-header.tsx
@@ -30,12 +30,10 @@ function weekRangeLabel(weekStart: string) {
 export function GlobalHeader({
   raceName,
   daysToRace,
-  weekCompletion,
   account
 }: {
   raceName: string;
   daysToRace: number | null;
-  weekCompletion: number;
   account: {
     avatarUrl: string | null;
     initials: string;
@@ -73,7 +71,6 @@ export function GlobalHeader({
 
         <div className="flex flex-wrap items-center gap-2">
           {daysToRace !== null ? <span className="rounded-full border pill-accent px-3 py-1 text-xs font-medium">{raceName} • {daysToRace} days</span> : null}
-          <span className="signal-chip signal-recovery">Week {weekCompletion}%</span>
           <Link href="/coach" className="btn-primary px-3 py-1.5 text-xs">Ask tri.ai</Link>
           <AccountMenu
             avatarUrl={account.avatarUrl}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -82,9 +82,6 @@ export default async function ProtectedLayout({ children }: { children: React.Re
 
   const weekContext = (weekData ?? null) as TrainingWeek | null;
   const sessions = (sessionsData ?? []) as Session[];
-  const plannedMinutes = sessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const completedMinutes = sessions.filter((session) => session.status === "completed").reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const completionRate = plannedMinutes > 0 ? Math.round((completedMinutes / plannedMinutes) * 100) : 0;
 
   const raceName = profile?.race_name?.trim() || "Target race";
   const daysToRace = profile?.race_date
@@ -96,7 +93,6 @@ export default async function ProtectedLayout({ children }: { children: React.Re
       <GlobalHeader
         raceName={raceName}
         daysToRace={daysToRace}
-        weekCompletion={completionRate}
         account={{
           avatarUrl: profile?.avatar_url ?? null,
           initials,


### PR DESCRIPTION
### Motivation
- Simplify the global header by removing the low-contrast/low-value “Week {percent}%” chip that often reads as “Week 0%”.
- Remove now-unused week completion plumbing from the protected layout to keep data flow minimal.
- Improve avatar button contrast so the account affordance is easier to perceive while remaining consistent with existing accent tokens.

### Description
- Deleted the `Week {weekCompletion}%` signal from `GlobalHeader` and removed its prop/type usage. (`app/(protected)/global-header.tsx`)
- Removed completion rate calculation and the `weekCompletion` prop wiring from the protected layout. (`app/(protected)/layout.tsx`)
- Enhanced the avatar summary button in `AccountMenu` by strengthening the border/background, adding a subtle outline shadow, improving hover border behavior, and updating fallback initials to use the core accent token. (`app/(protected)/account-menu.tsx`)

### Testing
- Ran `npm run lint` which completed successfully with no ESLint warnings or errors. 
- Started the dev server with `npm run dev` which launched and served the app locally. 
- Captured a Playwright screenshot of the updated header which was saved as `browser:/tmp/codex_browser_invocations/4556f13cb70d6f3f/artifacts/artifacts/header-update.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a3600a9c0483328e6066015f34f873)