### PR TITLE
Introduce `is_key` session flag, week-metrics utilities, UI updates, and DB migration

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -1,7 +1,7 @@
 import { createClient } from "@/lib/supabase/server";
 import { isValidIsoDate } from "@/lib/date/iso";
-import { PageHeader } from "../page-header";
 import { WeekCalendar } from "./week-calendar";
+import { computeWeekMinuteTotals, computeWeekSessionCounts } from "@/lib/training/week-metrics";
 
 type Session = {
   id: string;
@@ -12,6 +12,7 @@ type Session = {
   notes: string | null;
   created_at: string;
   status?: "planned" | "completed" | "skipped";
+  is_key?: boolean | null;
 };
 
 type LegacyPlannedSession = {
@@ -81,8 +82,7 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
 
   if (!user) return null;
 
-  const currentWeekStart = getMonday().toISOString().slice(0, 10);
-  const weekStart = isValidIsoDate(searchParams?.weekStart) ? searchParams.weekStart : currentWeekStart;
+  const weekStart = isValidIsoDate(searchParams?.weekStart) ? searchParams.weekStart : getMonday().toISOString().slice(0, 10);
   const weekEnd = addDays(weekStart, 7);
 
   const weekDays = Array.from({ length: 7 }).map((_, index) => {
@@ -95,13 +95,34 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     };
   });
 
-  const { data: sessionData, error: sessionError } = await supabase
-    .from("sessions")
-    .select("id,date,sport,type,duration_minutes,notes,created_at,status")
-    .gte("date", weekStart)
-    .lt("date", weekEnd)
-    .order("date", { ascending: true })
-    .order("created_at", { ascending: true });
+  let sessionData: unknown[] | null = null;
+  let sessionError: { code?: string; message?: string } | null = null;
+
+  {
+    const query = await supabase
+      .from("sessions")
+      .select("id,date,sport,type,duration_minutes,notes,created_at,status,is_key")
+      .gte("date", weekStart)
+      .lt("date", weekEnd)
+      .order("date", { ascending: true })
+      .order("created_at", { ascending: true });
+
+    sessionData = query.data as unknown[] | null;
+    sessionError = query.error;
+
+    if (sessionError && sessionError.code !== "PGRST205" && /(is_key|schema cache|42703)/i.test(sessionError.message ?? "")) {
+      const fallbackQuery = await supabase
+        .from("sessions")
+        .select("id,date,sport,type,duration_minutes,notes,created_at,status")
+        .gte("date", weekStart)
+        .lt("date", weekEnd)
+        .order("date", { ascending: true })
+        .order("created_at", { ascending: true });
+
+      sessionData = fallbackQuery.data as unknown[] | null;
+      sessionError = fallbackQuery.error;
+    }
+  }
 
   let normalizedSessions = (sessionData ?? []) as Session[];
 
@@ -126,7 +147,8 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       duration_minutes: session.duration ?? 0,
       notes: session.notes,
       created_at: session.created_at,
-      status: undefined
+      status: undefined,
+      is_key: false
     }));
   } else if (sessionError) {
     throw new Error(sessionError.message ?? "Failed to load calendar sessions.");
@@ -206,89 +228,51 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       status: linked.length > 0 ? ("completed" as const) : getSessionStatus(session, completionLedger),
       linkedActivityCount: linked.length,
       linkedStats,
-      unassignedSameDayCount: linked.length > 0 ? 0 : (unassignedByDate.get(session.date) ?? 0)
+      unassignedSameDayCount: linked.length > 0 ? 0 : (unassignedByDate.get(session.date) ?? 0),
+      is_key: Boolean((session as any).is_key)
     };
   });
 
 
-  const completedCount = sessions.filter((session) => session.status === "completed").length;
-  const pendingCount = sessions.filter((session) => session.status === "planned").length;
-  const skippedCount = sessions.filter((session) => session.status === "skipped").length;
+  const countMetrics = computeWeekSessionCounts(
+    sessions.map((session) => ({
+      id: session.id,
+      date: session.date,
+      sport: session.sport,
+      durationMinutes: session.duration,
+      status: session.status,
+      isKey: session.is_key
+    }))
+  );
+  const minuteMetrics = computeWeekMinuteTotals(
+    sessions.map((session) => ({
+      id: session.id,
+      date: session.date,
+      sport: session.sport,
+      durationMinutes: session.duration,
+      status: session.status,
+      isKey: session.is_key
+    }))
+  );
   const unmatchedUploads = [...unassignedByDate.values()].reduce((sum, count) => sum + count, 0);
   const todayIso = new Date().toISOString().slice(0, 10);
   const nextTodaySession = sessions.find((session) => session.date === todayIso && session.status === "planned") ?? null;
 
-  const raceDate = process.env.NEXT_PUBLIC_RACE_DATE;
-  const raceCountdown = raceDate
-    ? Math.max(0, Math.ceil((new Date(`${raceDate}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
-    : null;
 
   return (
-    <section className="space-y-4">
-      <PageHeader
-        title="Calendar"
-        objective="Execute each day with confidence by dragging, logging, and resolving conflicts before they become missed work."
-        actions={[
-          { href: "/plan", label: "Edit plan" },
-          { href: "/dashboard", label: "View dashboard", variant: "secondary" }
-        ]}
-      />
-
-      <div className="priority-layout">
-        <article className="priority-card-primary">
-          <p className="priority-kicker">Today&apos;s priority session</p>
-          <h2 className="priority-title">Execute your next key workout.</h2>
-          <p className="priority-subtitle">Keep focus on one clear session, then tidy the rest of the day.</p>
-          <p className="mt-3 text-sm text-muted">
-            {nextTodaySession
-              ? `Next up: ${nextTodaySession.type} (${nextTodaySession.duration} min).`
-              : "No planned session today. Pull one forward to keep confidence high."}
-          </p>
-        </article>
-
-        <article className="priority-card-secondary">
-          <p className="priority-kicker">On track this week</p>
-          <h2 className="priority-title">Monitor execution confidence daily.</h2>
-          <p className="priority-subtitle">Use completion and pending counts to prevent last-minute backlog.</p>
-          <div className="mt-3 grid gap-3 sm:grid-cols-3">
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Completed</p>
-              <p className="mt-1 text-lg font-semibold">{completedCount}</p>
-            </div>
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Planned</p>
-              <p className="mt-1 text-lg font-semibold">{pendingCount}</p>
-            </div>
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Skipped</p>
-              <p className="mt-1 text-lg font-semibold">{skippedCount}</p>
-            </div>
-          </div>
-        </article>
-
-        <article className="priority-card-secondary">
-          <p className="priority-kicker">Supporting analytics</p>
-          <h2 className="priority-title">Resolve upload and scheduling drift.</h2>
-          <p className="priority-subtitle">Catch unmatched activities early so your plan and execution stay aligned.</p>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Unmatched uploads</p>
-              <p className="mt-1 text-lg font-semibold">{unmatchedUploads}</p>
-            </div>
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Current week view</p>
-              <p className="mt-1 text-sm font-semibold">{weekStart === currentWeekStart ? "Current" : "Historical / Future"}</p>
-            </div>
-          </div>
-        </article>
-      </div>
-
+    <section className="space-y-3">
       <WeekCalendar
         weekDays={weekDays}
         sessions={sessions}
-        weekStart={weekStart}
-        isCurrentWeek={weekStart === currentWeekStart}
-        raceCountdown={raceCountdown}
+        executionLabel={nextTodaySession ? `Next key session: ${nextTodaySession.type}` : "No planned session today"}
+        executionSubtext={unmatchedUploads > 0 ? `${unmatchedUploads} uploads need matching.` : "Uploads and schedule aligned"}
+        completedCount={countMetrics.completedCount}
+        plannedTotalCount={countMetrics.plannedTotalCount}
+        skippedCount={countMetrics.skippedCount}
+        plannedRemainingCount={countMetrics.plannedRemainingCount}
+        plannedMinutes={minuteMetrics.plannedMinutes}
+        completedMinutes={minuteMetrics.completedMinutes}
+        remainingMinutes={minuteMetrics.remainingMinutes}
       />
     </section>
   );

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import Link from "next/link";
 import { ReactNode, useEffect, useMemo, useRef, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import {
@@ -44,6 +43,7 @@ type CalendarSession = {
   linkedActivityCount?: number;
   linkedStats?: { durationMin: number; distanceKm: number; avgHr: number | null; avgPower: number | null } | null;
   unassignedSameDayCount?: number;
+  is_key?: boolean;
 };
 
 type WeekDay = { iso: string; weekday: string; label: string };
@@ -97,15 +97,27 @@ function completedDuration(session: CalendarSession) {
 export function WeekCalendar({
   weekDays,
   sessions,
-  weekStart,
-  isCurrentWeek,
-  raceCountdown
+  executionLabel,
+  executionSubtext,
+  completedCount,
+  plannedTotalCount,
+  skippedCount,
+  plannedRemainingCount,
+  plannedMinutes,
+  completedMinutes,
+  remainingMinutes
 }: {
   weekDays: WeekDay[];
   sessions: CalendarSession[];
-  weekStart: string;
-  isCurrentWeek: boolean;
-  raceCountdown: number | null;
+  executionLabel: string;
+  executionSubtext?: string;
+  completedCount: number;
+  plannedTotalCount: number;
+  skippedCount: number;
+  plannedRemainingCount: number;
+  plannedMinutes: number;
+  completedMinutes: number;
+  remainingMinutes: number;
 }) {
   const router = useRouter();
   const [sportFilter, setSportFilter] = useState<SportFilter>("all");
@@ -164,11 +176,6 @@ export function WeekCalendar({
     }, {});
   }, [orderByDay, sessionsById, sportFilter, statusFilter, weekDays]);
 
-  const totals = useMemo(() => {
-    const planned = localSessions.reduce((sum, session) => sum + session.duration, 0);
-    const completed = localSessions.reduce((sum, session) => sum + completedDuration(session), 0);
-    return { planned, completed, remaining: Math.max(planned - completed, 0) };
-  }, [localSessions]);
 
   const progressBySport = useMemo(
     () =>
@@ -181,6 +188,7 @@ export function WeekCalendar({
       }),
     [localSessions]
   );
+
   const maxSportMinutes = Math.max(...progressBySport.map((item) => item.planned), 1);
 
   const sensors = useSensors(
@@ -190,14 +198,6 @@ export function WeekCalendar({
   );
 
   const todayIso = new Date().toISOString().slice(0, 10);
-  const prevWeek = new Date(`${weekStart}T00:00:00.000Z`);
-  prevWeek.setUTCDate(prevWeek.getUTCDate() - 7);
-  const nextWeek = new Date(`${weekStart}T00:00:00.000Z`);
-  nextWeek.setUTCDate(nextWeek.getUTCDate() + 7);
-
-  function weekLink(iso: string) {
-    return `/calendar?weekStart=${iso}`;
-  }
 
   function onDragStart(event: DragStartEvent) {
     setActiveId(String(event.active.id));
@@ -333,19 +333,29 @@ export function WeekCalendar({
   }
 
   return (
-    <section className="space-y-4">
-      <header className="surface sticky top-2 z-20 space-y-3 px-4 py-3 backdrop-blur">
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div>
-            <p className="text-xs uppercase tracking-[0.2em] text-accent">Week of {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}</p>
-            <p className="text-sm font-semibold">
-              {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}–{dayFormatter.format(new Date(`${weekDays[6].iso}T00:00:00.000Z`))}
-            </p>
-          </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <Link href={weekLink(prevWeek.toISOString().slice(0, 10))} className="btn-secondary px-3 py-1.5 text-xs">Prev week</Link>
-            <Link href="/calendar" className={`btn-secondary px-3 py-1.5 text-xs ${isCurrentWeek ? "border-[hsl(var(--accent-performance)/0.45)]" : ""}`}>Current week</Link>
-            <Link href={weekLink(nextWeek.toISOString().slice(0, 10))} className="btn-secondary px-3 py-1.5 text-xs">Next week</Link>
+    <section className="space-y-3">
+      <div className="surface-subtle flex flex-wrap items-center justify-between gap-2 px-3 py-2">
+        <div className="min-w-0">
+          <p className="truncate text-sm font-semibold">{executionLabel}</p>
+          {executionSubtext ? <p className="truncate text-xs text-muted">{executionSubtext}</p> : null}
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="signal-chip signal-ready">Completed {completedCount}</span>
+          <span className="signal-chip signal-load">Planned {plannedTotalCount}</span>
+          <span className="signal-chip signal-risk">Skipped {skippedCount}</span>
+        </div>
+      </div>
+
+      <header className="surface-subtle space-y-2 px-3 py-2">
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className="text-xs uppercase tracking-[0.14em] text-accent">Week of {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}–{dayFormatter.format(new Date(`${weekDays[6].iso}T00:00:00.000Z`))}</p>
+          <div className="flex items-center gap-2">
+            <select aria-label="Status filter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as FilterStatus)} className="input-base w-auto py-1 text-xs">
+              <option value="all">All statuses</option>
+              <option value="planned">Pending</option>
+              <option value="completed">Completed</option>
+              <option value="skipped">Missed</option>
+            </select>
             <button
               className="btn-primary px-3 py-1.5 text-xs"
               onClick={() =>
@@ -357,13 +367,10 @@ export function WeekCalendar({
             >
               Add session
             </button>
-            {raceCountdown !== null ? (
-              <span className="rounded-full border border-[hsl(var(--accent-performance)/0.35)] bg-[hsl(var(--accent-performance)/0.12)] px-3 py-1 text-xs font-medium text-accent">Race in {raceCountdown}d</span>
-            ) : null}
           </div>
         </div>
-        <div className="flex flex-wrap items-center justify-between gap-3">
-          <div className="flex flex-wrap gap-2">
+        <div className="overflow-x-auto">
+          <div className="flex min-w-max items-center gap-2">
             {(["all", "swim", "bike", "run", "strength"] as const).map((item) => (
               <button
                 key={item}
@@ -374,22 +381,18 @@ export function WeekCalendar({
               </button>
             ))}
           </div>
-          <select aria-label="Status filter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as FilterStatus)} className="input-base w-auto py-1 text-xs">
-            <option value="all">All statuses</option>
-            <option value="planned">Pending</option>
-            <option value="completed">Completed</option>
-            <option value="skipped">Missed</option>
-          </select>
         </div>
       </header>
 
-      <article className="surface px-4 py-3">
-        <div className="grid gap-2 md:grid-cols-6">
-          <div className="surface-subtle p-3 md:col-span-2">
+      <details className="surface-subtle px-3 py-2">
+        <summary className="cursor-pointer text-sm font-medium text-accent">Summary <span className="ml-2 text-xs text-muted">Completed {completedMinutes} / {plannedMinutes} min • {remainingMinutes} remaining</span></summary>
+        <div className="mt-3 grid gap-2 lg:grid-cols-6">
+          <div className="surface-subtle p-3 lg:col-span-2">
             <p className="text-xs uppercase tracking-wide text-muted">Week volume</p>
-            <p className="mt-1 text-lg font-semibold">Completed {totals.completed} / {totals.planned} min</p>
-            <p className="text-xs text-muted">{formatMinutes(totals.completed)} / {formatMinutes(totals.planned)} • {totals.remaining} min remaining</p>
+            <p className="mt-1 text-lg font-semibold">Completed {completedMinutes} / {plannedMinutes} min</p>
+            <p className="text-xs text-muted">{formatMinutes(completedMinutes)} / {formatMinutes(plannedMinutes)} • {remainingMinutes} min remaining</p>
           </div>
+          <div className="surface-subtle p-3"><p className="text-xs text-muted">Remaining sessions: {plannedRemainingCount}</p></div>
           {progressBySport.map((item) => {
             const discipline = getDisciplineMeta(item.sport);
             const targetRatio = Math.min(100, (item.planned / maxSportMinutes) * 100);
@@ -406,10 +409,11 @@ export function WeekCalendar({
             );
           })}
         </div>
-      </article>
+      </details>
 
       <DndContext sensors={sensors} collisionDetection={closestCenter} onDragStart={onDragStart} onDragEnd={onDragEnd}>
-        <article className="grid gap-3 md:grid-cols-2 xl:grid-cols-4 2xl:grid-cols-7">
+        <div className="overflow-x-auto">
+        <article className="grid min-w-[1260px] grid-cols-7 gap-3">
           {weekDays.map((day) => {
             const ids = filteredIdsByDay[day.iso] ?? [];
             const visibleIds = expandedDays[day.iso] ? ids : ids.slice(0, 2);
@@ -478,6 +482,7 @@ export function WeekCalendar({
             );
           })}
         </article>
+        </div>
       </DndContext>
 
       {activeId ? <p className="text-[11px] text-accent/80">Drag a session to another day to reschedule.</p> : null}
@@ -706,6 +711,7 @@ function SortableSessionCard({
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
             <span title={`${discipline.label} · ${discipline.shape}`} className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] ${discipline.className} ${discipline.textureClassName}`}><span aria-hidden="true">{discipline.icon}</span><span>{discipline.label}</span></span>
             <SessionStatusChip status={session.status} compact />
+            {session.is_key ? <span className="rounded-full border border-[hsl(var(--accent-performance)/0.5)] px-2 py-0.5 text-[10px] font-semibold text-accent">Key</span> : null}
           </div>
           <div className="flex items-center gap-1.5">
             <SessionOverflowMenu sessionTitle={title} sessionStatus={session.status} onOpen={onOpen} onMove={onMove} onSwap={onSwap} onSkip={onSkip} />
@@ -717,7 +723,14 @@ function SortableSessionCard({
           <p className="mt-1 text-2xl font-semibold leading-none tracking-tight">{session.duration}<span className="ml-1 text-sm font-medium text-muted">min</span></p>
           {session.linkedActivityCount ? (
             <p className="mt-1 text-xs text-[hsl(var(--signal-ready))]">
-              Completed ✓ {session.linkedStats?.durationMin ?? 0}m{session.linkedStats?.distanceKm ? ` · ${session.linkedStats.distanceKm.toFixed(1)} km` : ""}
+              Completed ✓ {(() => {
+                const duration = session.linkedStats?.durationMin ?? session.duration;
+                const distance = session.linkedStats?.distanceKm;
+                const power = session.linkedStats?.avgPower;
+                if (session.sport === "bike") return `${duration}m${power ? ` · ${Math.round(power)}w` : ""}`;
+                if (session.sport === "run" || session.sport === "swim") return `${duration}m${distance ? ` · ${distance.toFixed(1)} km` : ""}`;
+                return `${duration}m`;
+              })()}
             </p>
           ) : session.unassignedSameDayCount ? (
             <p className="mt-1 text-xs text-[hsl(var(--signal-load))]">{session.unassignedSameDayCount} unassigned activit{session.unassignedSameDayCount === 1 ? "y" : "ies"} on this day</p>

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -1,25 +1,13 @@
-import { PageHeader } from "../page-header";
 import { CoachChat } from "./coach-chat";
 
 export default function CoachPage() {
   return (
     <section className="space-y-4">
-      <PageHeader
-        title="Coach"
-        objective="Get concise, evidence-linked guidance from your plan and workout data so your next decision is clear and actionable."
-        actions={[
-          { href: "/dashboard", label: "Review dashboard" },
-          { href: "/calendar", label: "Open calendar", variant: "secondary" }
-        ]}
-      />
-
-      <div className="surface-subtle flex flex-wrap items-center gap-2 px-4 py-3 text-xs">
-        <span className="font-semibold uppercase tracking-[0.14em] text-muted">Context strip</span>
-        <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">Week goal: keep key sessions on plan</span>
-        <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">Fatigue: balanced</span>
-        <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">Confidence: building</span>
-      </div>
-
+      <article className="surface p-4">
+        <p className="text-xs uppercase tracking-[0.14em] text-accent">Coach</p>
+        <h1 className="mt-1 text-lg font-semibold">Adaptation workspace</h1>
+        <p className="mt-1 text-sm text-muted">Review one recommendation with evidence, then apply changes in chat.</p>
+      </article>
       <CoachChat />
     </section>
   );

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,11 +1,12 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import { isValidIsoDate } from "@/lib/date/iso";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { SessionStatusChip } from "@/lib/ui/status-chip";
-import { PageHeader } from "../page-header";
 import { markSkippedAction, moveSessionAction } from "./actions";
 import { WeekProgressCard } from "./week-progress-card";
+import { StatusStrip } from "../status-strip";
+import { DetailsAccordion } from "../details-accordion";
+import { computeWeekMinuteTotals, computeWeekSessionCounts, getKeySessionsRemaining } from "@/lib/training/week-metrics";
 
 type Session = {
   id: string;
@@ -17,6 +18,7 @@ type Session = {
   notes: string | null;
   created_at: string;
   status: "planned" | "completed" | "skipped";
+  is_key?: boolean | null;
 };
 
 type CompletedSession = {
@@ -66,13 +68,6 @@ function toHoursAndMinutes(minutes: number) {
   return `${hours}h ${mins}m`;
 }
 
-function formatWeekRange(startIso: string) {
-  const start = new Date(`${startIso}T00:00:00.000Z`);
-  const end = new Date(start);
-  end.setUTCDate(start.getUTCDate() + 6);
-  return `${shortDateFormatter.format(start)}–${shortDateFormatter.format(end)}`;
-}
-
 function getSessionStatus(session: Session, completionLedger: Record<string, number>) {
   if (session.status === "completed" || session.status === "skipped") {
     return session.status;
@@ -115,7 +110,6 @@ export default async function DashboardPage({
   const previousWeekStart = addDays(weekStart, -7);
   const previousWeekEnd = weekStart;
   const todayIso = new Date().toISOString().slice(0, 10);
-  const isCurrentWeek = weekStart === currentWeekStart;
 
   const [{ data: profileData }, { data: plansData }, { data: completedData }, { data: completedActivities }, { data: linksData }] = await Promise.all([
     supabase.from("profiles").select("active_plan_id,race_date,race_name").eq("id", user.id).maybeSingle(),
@@ -135,16 +129,35 @@ export default async function DashboardPage({
   const hasAnyPlan = plans.length > 0;
   const activePlanId = profile?.active_plan_id ?? plans[0]?.id ?? null;
 
-  const { data: sessionsData } = activePlanId
-    ? await supabase
+  let sessionsData: unknown[] | null = [];
+
+  if (activePlanId) {
+    const primary = await supabase
+      .from("sessions")
+      .select("id,plan_id,date,sport,type,duration_minutes,notes,created_at,status,is_key")
+      .eq("plan_id", activePlanId)
+      .gte("date", weekStart)
+      .lt("date", weekEnd)
+      .order("date", { ascending: true })
+      .order("created_at", { ascending: true });
+
+    if (primary.error && /(is_key|42703|schema cache)/i.test(primary.error.message ?? "")) {
+      const fallback = await supabase
         .from("sessions")
         .select("id,plan_id,date,sport,type,duration_minutes,notes,created_at,status")
         .eq("plan_id", activePlanId)
         .gte("date", weekStart)
         .lt("date", weekEnd)
         .order("date", { ascending: true })
-        .order("created_at", { ascending: true })
-    : { data: [] };
+        .order("created_at", { ascending: true });
+      if (fallback.error) throw new Error(fallback.error.message);
+      sessionsData = fallback.data as unknown[] | null;
+    } else if (primary.error) {
+      throw new Error(primary.error.message);
+    } else {
+      sessionsData = primary.data as unknown[] | null;
+    }
+  }
 
   const { data: previousWeekSessionsData } = activePlanId
     ? await supabase
@@ -187,7 +200,8 @@ export default async function DashboardPage({
   const sessions = ((sessionsData ?? []) as Session[]).map((session) => ({
     ...session,
     duration_minutes: session.duration_minutes ?? 0,
-    status: linkedSessionIds.has(session.id) ? ("completed" as const) : getSessionStatus(session, completionLedger)
+    status: linkedSessionIds.has(session.id) ? ("completed" as const) : getSessionStatus(session, completionLedger),
+    is_key: Boolean((session as any).is_key)
   }));
 
   const hasActivePlan = Boolean(activePlanId);
@@ -214,13 +228,26 @@ export default async function DashboardPage({
   const todaySessions = sessions.filter((session) => session.date === todayIso);
   const nextPendingTodaySession = todaySessions.find((session) => session.status === "planned") ?? null;
 
-  const totals = sessions.reduce(
-    (acc, session) => {
-      acc.planned += session.duration_minutes ?? 0;
-      acc.completed += getCompletedMinutes(session);
-      return acc;
-    },
-    { planned: 0, completed: 0 }
+  const minuteMetrics = computeWeekMinuteTotals(
+    sessions.map((session) => ({
+      id: session.id,
+      date: session.date,
+      sport: session.sport,
+      durationMinutes: session.duration_minutes ?? 0,
+      status: session.status,
+      isKey: session.is_key
+    }))
+  );
+  const totals = { planned: minuteMetrics.plannedMinutes, completed: minuteMetrics.completedMinutes };
+  const countMetrics = computeWeekSessionCounts(
+    sessions.map((session) => ({
+      id: session.id,
+      date: session.date,
+      sport: session.sport,
+      durationMinutes: session.duration_minutes ?? 0,
+      status: session.status,
+      isKey: session.is_key
+    }))
   );
   const unassignedMinutes = unassignedUploads.reduce((sum, activity) => sum + Math.round((activity.duration_sec ?? 0) / 60), 0);
 
@@ -246,10 +273,10 @@ export default async function DashboardPage({
     };
   }).sort((a, b) => (b.planned - b.completed) - (a.planned - a.completed));
 
+
   const keyTodaySession = [...todaySessions]
     .filter((session) => session.status === "planned")
     .sort((a, b) => (b.duration_minutes ?? 0) - (a.duration_minutes ?? 0))[0];
-
   const biggestGap = [...progressBySport].sort((a, b) => b.planned - b.completed - (a.planned - a.completed))[0];
 
   const focusText = keyTodaySession
@@ -258,6 +285,26 @@ export default async function DashboardPage({
       ? `Your biggest weekly gap is ${getDisciplineMeta(biggestGap.sport).label} (${biggestGap.completed}/${biggestGap.planned} min).`
       : "Start with one short session today to establish execution rhythm.";
 
+
+  const keyRemainingIds = new Set(
+    getKeySessionsRemaining(
+      sessions.map((session) => ({
+        id: session.id,
+        date: session.date,
+        sport: session.sport,
+        durationMinutes: session.duration_minutes ?? 0,
+        status: session.status,
+        isKey: session.is_key
+      })),
+      todayIso
+    )
+      .slice(0, 4)
+      .map((session) => session.id)
+  );
+
+  const keySessionsRemaining = sessions
+    .filter((session) => keyRemainingIds.has(session.id))
+    .sort((a, b) => a.date.localeCompare(b.date));
   const previousWeekSessions = (previousWeekSessionsData ?? []) as Array<{ duration_minutes: number | null; status: Session["status"] }>;
   const previousWeekTotals = previousWeekSessions.reduce(
     (acc, session) => {
@@ -283,38 +330,10 @@ export default async function DashboardPage({
   const fatigueTrend = completionPct >= 85 ? "↓" : completionPct >= 60 ? "→" : "↑";
   const confidenceTrend = completionDelta > 2 ? "↑" : completionDelta < -2 ? "↓" : "→";
 
-  const raceName = profile?.race_name?.trim() || "Target race";
-  const daysToRace = profile?.race_date
-    ? Math.max(0, Math.ceil((new Date(`${profile.race_date}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
-    : null;
 
   if (!hasActivePlan && !hasAnyPlan) {
     return (
       <section className="space-y-4">
-        <PageHeader
-          title="Dashboard"
-          objective="Orient the week at a glance, identify risk early, and execute the highest-impact next session."
-          actions={[
-            { href: "/plan", label: "Create a plan" },
-            { href: "/coach", label: "Ask tri.ai", variant: "secondary" }
-          ]}
-        />
-
-        <header className="surface sticky top-3 z-10 flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-          <div className="flex items-center gap-2 text-sm">
-            <span className="font-semibold">WEEK: {formatWeekRange(weekStart)}</span>
-          </div>
-          {daysToRace !== null ? (
-            <p className="rounded-full border pill-accent px-3 py-1 text-xs font-medium">
-              {raceName} • {daysToRace} days
-            </p>
-          ) : (
-            <Link href="/settings/race" className="btn-primary px-3 py-1.5 text-xs">
-              Set race date
-            </Link>
-          )}
-        </header>
-
         <article className="surface p-6">
           <p className="text-xs uppercase tracking-[0.16em] text-accent">Get started</p>
           <h1 className="mt-2 text-2xl font-semibold">Build your first week</h1>
@@ -333,42 +352,13 @@ export default async function DashboardPage({
 
   return (
     <section className="space-y-4">
-      <PageHeader
-        title="Dashboard"
-        objective="Stay oriented on this training week, maintain completion discipline, and surface where coaching attention is needed."
-        actions={[
-          { href: "/calendar", label: "Open calendar" },
-          { href: "/coach", label: "Ask tri.ai", variant: "secondary" }
-        ]}
-      />
-
-      <header className="surface sticky top-3 z-10 flex flex-wrap items-center justify-between gap-3 px-4 py-3">
-        <div className="flex flex-wrap items-center gap-2 text-sm">
-          <span className="font-semibold">WEEK: {formatWeekRange(weekStart)}</span>
-          <Link href={`/dashboard?weekStart=${addDays(weekStart, -7)}`} className="btn-secondary px-3 py-1.5 text-xs">Prev</Link>
-          <Link href="/dashboard" className={`btn-secondary px-3 py-1.5 text-xs ${isCurrentWeek ? "border-[hsl(var(--accent-performance)/0.55)] text-accent" : ""}`}>Current</Link>
-          <Link href={`/dashboard?weekStart=${addDays(weekStart, 7)}`} className="btn-secondary px-3 py-1.5 text-xs">Next</Link>
-        </div>
-
-        <div className="flex flex-wrap items-center gap-2">
-          {daysToRace !== null ? (
-            <p className="rounded-full border pill-accent px-3 py-1 text-xs font-medium">
-              {raceName} • {daysToRace} days
-            </p>
-          ) : (
-            <Link href="/settings/race" className="btn-secondary px-3 py-1.5 text-xs">Set race date</Link>
-          )}
-          <Link href="/coach" className="btn-primary px-3 py-1.5 text-xs">Ask tri.ai</Link>
-        </div>
-      </header>
-
       <div className="space-y-4">
         <article className="priority-card-primary">
           <p className="priority-kicker">Weekly coaching takeaway</p>
           <h1 className="priority-title">{hasWeekSessions ? focusText : "Set one key workout and execute it."}</h1>
           <p className="priority-subtitle">
             {hasWeekSessions
-              ? `You have ${remainingMinutes} minutes left this week. Keep execution tight and protect recovery.`
+              ? "Keep execution tight this week and protect recovery on non-key days."
               : "Add sessions for this week so your next best workout is always clear."}
           </p>
           <div className="mt-4 flex flex-wrap gap-2">
@@ -388,28 +378,14 @@ export default async function DashboardPage({
           </div>
         </article>
 
-        <div className="grid gap-3 md:grid-cols-4">
-          <article className="surface-subtle p-4">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Completion pace</p>
-            <p className="mt-1 text-2xl font-semibold">{completionPct}% <span className="text-base text-accent">{completionTrend}</span></p>
-            <p className="mt-1 text-xs text-muted">{completionDelta >= 0 ? `+${completionDelta}` : completionDelta} pts vs last week</p>
-          </article>
-          <article className="surface-subtle p-4">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Remaining load</p>
-            <p className="mt-1 text-2xl font-semibold">{toHoursAndMinutes(remainingMinutes)} <span className="text-base text-accent">{loadTrend}</span></p>
-            <p className="mt-1 text-xs text-muted">{remainingMinutesDelta >= 0 ? `+${remainingMinutesDelta}` : remainingMinutesDelta} min vs last week</p>
-          </article>
-          <article className="surface-subtle p-4">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Fatigue state</p>
-            <p className="mt-1 text-xl font-semibold">{fatigueState} <span className="text-sm text-accent">{fatigueTrend}</span></p>
-            <p className="mt-1 text-xs text-muted">threshold-adjusted vs last week</p>
-          </article>
-          <article className="surface-subtle p-4">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Confidence signal</p>
-            <p className="mt-1 text-xl font-semibold">{confidenceLabel} <span className="text-sm text-accent">{confidenceTrend}</span></p>
-            <p className="mt-1 text-xs text-muted">trajectory vs last week</p>
-          </article>
-        </div>
+        <StatusStrip
+          items={[
+            { label: "Completion", value: `${completionPct}%`, hint: `${completionTrend} ${completionDelta >= 0 ? `+${completionDelta}` : completionDelta} pts` },
+            { label: "Planned", value: `${countMetrics.plannedTotalCount} sessions`, hint: `${countMetrics.plannedRemainingCount} remaining` },
+            { label: "Fatigue", value: fatigueState, hint: fatigueTrend },
+            { label: "Confidence", value: confidenceLabel, hint: confidenceTrend }
+          ]}
+        />
 
         <div className="priority-layout">
           <article className="priority-card-emphasis">
@@ -417,7 +393,10 @@ export default async function DashboardPage({
             <h2 className="priority-title">Execute high-impact work first.</h2>
             <p className="priority-subtitle">{shortDateFormatter.format(new Date(`${todayIso}T00:00:00.000Z`))}</p>
             {todaySessions.length === 0 ? (
-              <p className="surface-subtle mt-4 p-3 text-sm text-muted">No sessions for today. Pull one workout forward to keep momentum.</p>
+              <div className="surface-subtle mt-4 p-3 text-sm text-muted">
+                <p>No sessions for today.</p>
+                <Link href="/calendar" className="mt-2 inline-flex text-xs text-accent underline">Open calendar</Link>
+              </div>
             ) : (
               <ul className="mt-4 space-y-2">
                 {todaySessions.map((session) => {
@@ -469,37 +448,8 @@ export default async function DashboardPage({
             </div>
           </article>
 
-          <article className="priority-card-supporting scroll-mt-24" id="coach-focus">
-            <p className="priority-kicker">Coach focus</p>
-            <h2 className="priority-title">Keep today&apos;s decision simple.</h2>
-            <p className="priority-subtitle">{focusText}</p>
-            <div className="mt-3 flex flex-wrap gap-2">
-              {keyTodaySession ? (
-                <>
-                  <form action={moveSessionAction} className="flex items-center gap-2">
-                    <input type="hidden" name="sessionId" value={keyTodaySession.id} />
-                    <select name="newDate" defaultValue={keyTodaySession.date} className="input-base py-1 text-xs" aria-label="Move session day">
-                      {weekDays.map((day) => (
-                        <option key={day.iso} value={day.iso}>{day.weekday}</option>
-                      ))}
-                    </select>
-                    <button className="btn-secondary px-3 py-1.5 text-xs">Move session</button>
-                  </form>
-                  <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">Swap days</Link>
-                  <form action={markSkippedAction}>
-                    <input type="hidden" name="sessionId" value={keyTodaySession.id} />
-                    <button className="btn-secondary px-3 py-1.5 text-xs">Mark skipped</button>
-                  </form>
-                </>
-              ) : null}
-            </div>
-          </article>
-
-          <article className="priority-card-supporting">
-            <p className="priority-kicker">Supporting analytics</p>
-            <h2 className="priority-title">Review sport load and upload gaps.</h2>
-            <p className="priority-subtitle">Use supporting signals to adjust volume and keep your data aligned.</p>
-            <div className="mt-4 grid gap-3 lg:grid-cols-2">
+          <DetailsAccordion title="Details">
+            <div className="grid gap-3 lg:grid-cols-2">
               <div className="priority-card-supporting">
                 <h3 className="text-sm font-semibold">Sport breakdown</h3>
                 <ul className="mt-2 space-y-2">
@@ -533,29 +483,28 @@ export default async function DashboardPage({
                 )}
               </div>
             </div>
-          </article>
+          </DetailsAccordion>
 
-          <article className="surface p-3">
-            <h2 className="mb-2 text-sm font-semibold text-muted">Week at a glance</h2>
-            <div className="grid grid-cols-7 gap-2">
-              {weekDays.map((day) => (
-                <Link
-                  key={day.iso}
-                  href={`/calendar?date=${day.iso}`}
-                  className={`surface-subtle block p-2 text-center transition hover:border-[hsl(var(--accent-performance)/0.55)] ${day.isToday ? "border-[hsl(var(--accent-performance)/0.6)] bg-[hsl(var(--accent-performance)/0.12)]" : ""}`}
-                >
-                  <p className="text-[10px] uppercase tracking-wide text-muted">{day.weekday}</p>
-                  <p className="text-xs font-medium">{day.day}</p>
-                  <p className="mt-1 text-[10px] text-muted">{day.completed}/{day.planned}m</p>
-                  <div className="mt-1 flex flex-wrap justify-center gap-1">
-                    {day.sports.slice(0, 3).map((sport) => {
-                      const d = getDisciplineMeta(sport);
-                      return <span key={`${day.iso}-${sport}`} className={`h-1.5 w-3 rounded-full ${d.className} ${d.textureClassName}`} aria-hidden="true" title={`${d.label} · ${d.shape}`} />;
-                    })}
-                  </div>
-                </Link>
-              ))}
-            </div>
+          <article className="surface-subtle p-3">
+            <h2 className="mb-2 text-sm font-semibold text-muted">Key sessions remaining</h2>
+            {keySessionsRemaining.length === 0 ? (
+              <p className="text-sm text-muted">No key sessions remaining. Keep consistency by protecting recovery and showing up for planned sessions.</p>
+            ) : (
+              <ul className="space-y-2">
+                {keySessionsRemaining.map((session) => (
+                  <li key={session.id} className="flex items-center justify-between gap-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-3 py-2">
+                    <div className="min-w-0">
+                      <p className="text-xs uppercase tracking-[0.12em] text-muted">{weekdayFormatter.format(new Date(`${session.date}T00:00:00.000Z`))}</p>
+                      <p className="truncate text-sm font-medium">{session.type}</p>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <p className="text-sm font-semibold">{session.duration_minutes}m</p>
+                      <Link href={`/calendar?focus=${session.id}`} className="text-xs text-accent underline">Open</Link>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )}
           </article>
         </div>
       </div>

--- a/app/(protected)/details-accordion.tsx
+++ b/app/(protected)/details-accordion.tsx
@@ -1,0 +1,10 @@
+import { ReactNode } from "react";
+
+export function DetailsAccordion({ title = "Details", children }: { title?: string; children: ReactNode }) {
+  return (
+    <details className="surface-subtle p-3">
+      <summary className="cursor-pointer text-sm font-medium text-accent">{title}</summary>
+      <div className="mt-3">{children}</div>
+    </details>
+  );
+}

--- a/app/(protected)/global-header.tsx
+++ b/app/(protected)/global-header.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname, useSearchParams } from "next/navigation";
+import { AccountMenu } from "./account-menu";
+
+const shortDateFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+
+function addDays(isoDate: string, days: number) {
+  const date = new Date(`${isoDate}T00:00:00.000Z`);
+  date.setUTCDate(date.getUTCDate() + days);
+  return date.toISOString().slice(0, 10);
+}
+
+function getMonday(date = new Date()) {
+  const day = date.getUTCDay();
+  const distanceFromMonday = day === 0 ? 6 : day - 1;
+  const monday = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate()));
+  monday.setUTCDate(monday.getUTCDate() - distanceFromMonday);
+  return monday;
+}
+
+function weekRangeLabel(weekStart: string) {
+  const start = new Date(`${weekStart}T00:00:00.000Z`);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  return `${shortDateFormatter.format(start)}–${shortDateFormatter.format(end)}`;
+}
+
+export function GlobalHeader({
+  raceName,
+  daysToRace,
+  weekCompletion,
+  account
+}: {
+  raceName: string;
+  daysToRace: number | null;
+  weekCompletion: number;
+  account: {
+    avatarUrl: string | null;
+    initials: string;
+    displayName: string;
+    email: string;
+    signOutAction: (formData: FormData) => void;
+  };
+}) {
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const currentWeekStart = getMonday().toISOString().slice(0, 10);
+  const weekStart = searchParams.get("weekStart") ?? currentWeekStart;
+
+  const withWeek = (targetWeekStart: string) => {
+    const params = new URLSearchParams(searchParams.toString());
+    if (targetWeekStart === currentWeekStart) {
+      params.delete("weekStart");
+    } else {
+      params.set("weekStart", targetWeekStart);
+    }
+    const query = params.toString();
+    return `${pathname}${query ? `?${query}` : ""}`;
+  };
+
+  return (
+    <div className="shell-header border-b border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.95] backdrop-blur">
+      <div className="mx-auto flex w-full max-w-[1280px] flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-6">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="text-sm uppercase tracking-[0.2em] text-accent">tri.ai</span>
+          <span className="hidden text-xs text-muted sm:inline">{weekRangeLabel(weekStart)}</span>
+          <Link href={withWeek(addDays(weekStart, -7))} className="btn-secondary px-2.5 py-1 text-xs">Prev</Link>
+          <Link href={withWeek(currentWeekStart)} className={`btn-secondary px-2.5 py-1 text-xs ${weekStart === currentWeekStart ? "border-[hsl(var(--accent-performance)/0.55)] text-accent" : ""}`}>Current</Link>
+          <Link href={withWeek(addDays(weekStart, 7))} className="btn-secondary px-2.5 py-1 text-xs">Next</Link>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2">
+          {daysToRace !== null ? <span className="rounded-full border pill-accent px-3 py-1 text-xs font-medium">{raceName} • {daysToRace} days</span> : null}
+          <span className="signal-chip signal-recovery">Week {weekCompletion}%</span>
+          <Link href="/coach" className="btn-primary px-3 py-1.5 text-xs">Ask tri.ai</Link>
+          <AccountMenu
+            avatarUrl={account.avatarUrl}
+            initials={account.initials}
+            displayName={account.displayName}
+            email={account.email}
+            signOutAction={account.signOutAction}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { signOutAction } from "./actions";
-import { AccountMenu } from "./account-menu";
+import { GlobalHeader } from "./global-header";
 import { MobileBottomTabs, ShellNavRail } from "./shell-nav";
 
 export const dynamic = "force-dynamic";
@@ -16,8 +16,6 @@ type Profile = {
 
 type Session = {
   date: string;
-  sport: string;
-  type: string | null;
   duration_minutes: number | null;
   status: "planned" | "completed" | "skipped";
 };
@@ -49,11 +47,7 @@ function addDays(isoDate: string, days: number) {
   return date.toISOString().slice(0, 10);
 }
 
-export default async function ProtectedLayout({
-  children
-}: Readonly<{
-  children: React.ReactNode;
-}>) {
+export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
   const {
     data: { user }
@@ -70,11 +64,9 @@ export default async function ProtectedLayout({
 
   const currentWeekStart = getMonday().toISOString().slice(0, 10);
   const currentWeekEnd = addDays(currentWeekStart, 7);
-  const previousWeekStart = addDays(currentWeekStart, -7);
-
   const activePlanId = profile?.active_plan_id ?? null;
 
-  const [{ data: weekData }, { data: sessionsData }, { data: previousWeekSessionsData }] = activePlanId
+  const [{ data: weekData }, { data: sessionsData }] = activePlanId
     ? await Promise.all([
         supabase
           .from("training_weeks")
@@ -84,128 +76,68 @@ export default async function ProtectedLayout({
           .order("week_start_date", { ascending: false })
           .limit(1)
           .maybeSingle(),
-        supabase
-          .from("sessions")
-          .select("date,sport,type,duration_minutes,status")
-          .eq("plan_id", activePlanId)
-          .gte("date", currentWeekStart)
-          .lt("date", currentWeekEnd),
-        supabase
-          .from("sessions")
-          .select("duration_minutes,status")
-          .eq("plan_id", activePlanId)
-          .gte("date", previousWeekStart)
-          .lt("date", currentWeekStart)
+        supabase.from("sessions").select("date,duration_minutes,status").eq("plan_id", activePlanId).gte("date", currentWeekStart).lt("date", currentWeekEnd)
       ])
-    : [{ data: null }, { data: [] }, { data: [] }];
+    : [{ data: null }, { data: [] }];
 
   const weekContext = (weekData ?? null) as TrainingWeek | null;
   const sessions = (sessionsData ?? []) as Session[];
-  const previousWeekSessions = (previousWeekSessionsData ?? []) as Array<Pick<Session, "duration_minutes" | "status">>;
-
   const plannedMinutes = sessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const completedMinutes = sessions
-    .filter((session) => session.status === "completed")
-    .reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const completedMinutes = sessions.filter((session) => session.status === "completed").reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
   const completionRate = plannedMinutes > 0 ? Math.round((completedMinutes / plannedMinutes) * 100) : 0;
-  const previousWeekPlannedMinutes = previousWeekSessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const previousWeekCompletedMinutes = previousWeekSessions
-    .filter((session) => session.status === "completed")
-    .reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const previousCompletionRate = previousWeekPlannedMinutes > 0 ? Math.round((previousWeekCompletedMinutes / previousWeekPlannedMinutes) * 100) : 0;
-  const completionDelta = completionRate - previousCompletionRate;
 
-  const trendDirection = completionDelta >= 8 ? "improving" : completionDelta <= -8 ? "declining" : "stable";
-  const trendLabel = trendDirection === "improving" ? "Improving" : trendDirection === "declining" ? "Declining" : "Stable";
-
-  const readiness = completionRate >= 70 ? "Ready" : completionRate >= 40 ? "Building" : "Needs focus";
-  const readinessClass = completionRate >= 70 ? "signal-ready" : completionRate >= 40 ? "signal-load" : "signal-risk";
-
+  const raceName = profile?.race_name?.trim() || "Target race";
   const daysToRace = profile?.race_date
     ? Math.max(0, Math.ceil((new Date(`${profile.race_date}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
     : null;
 
-  const todayIso = new Date().toISOString().slice(0, 10);
-  const nextKeySession = sessions
-    .filter((session) => session.status === "planned" && session.date >= todayIso)
-    .sort((a, b) => a.date.localeCompare(b.date))[0] ?? null;
-
-  const nextKeySessionLabel = nextKeySession
-    ? `${nextKeySession.sport}${nextKeySession.type ? ` · ${nextKeySession.type}` : ""} · ${nextKeySession.duration_minutes ?? 0} min`
-    : "No planned key session";
-
   return (
     <div className="app-shell">
-      <div className={`shell-header border-b border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))/0.95] backdrop-blur shell-header--${trendDirection}`}>
-        <div className="mx-auto flex w-full max-w-[1200px] flex-wrap items-center justify-between gap-3 px-4 py-3 md:px-6">
-          <p className="text-sm uppercase tracking-[0.2em] text-accent">tri.ai</p>
-          <div className="flex items-center gap-2">
-            <span className={`signal-chip ${readinessClass}`}>Readiness: {readiness}</span>
-            <span className="signal-chip signal-recovery">
-              Race: {daysToRace !== null ? `${daysToRace}d` : "set date"}
-            </span>
-            <span className="signal-chip signal-load">Week: {completionRate}% complete</span>
-          </div>
-          <AccountMenu avatarUrl={profile?.avatar_url ?? null} initials={initials} displayName={displayName} email={email} signOutAction={signOutAction} />
-        </div>
+      <GlobalHeader
+        raceName={raceName}
+        daysToRace={daysToRace}
+        weekCompletion={completionRate}
+        account={{
+          avatarUrl: profile?.avatar_url ?? null,
+          initials,
+          displayName,
+          email,
+          signOutAction
+        }}
+      />
 
-        <div className="mx-auto w-full max-w-[1200px] px-4 pb-3 md:px-6 lg:hidden">
-          <p className="inline-flex max-w-full items-center gap-2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))/0.9] px-3 py-1 text-xs text-muted">
-            <span className="font-semibold text-[hsl(var(--fg))]">{completionRate}% complete</span>
-            <span>·</span>
-            <span className="truncate">{nextKeySession ? `Next ${nextKeySession.sport}` : "No next key session"}</span>
-            {daysToRace !== null ? (
-              <>
-                <span>·</span>
-                <span>Race {daysToRace}d</span>
-              </>
-            ) : null}
-          </p>
-        </div>
-      </div>
-
-      <div className="mx-auto grid w-full max-w-[1200px] gap-4 px-4 pb-24 pt-5 md:px-6 lg:grid-cols-[260px_1fr] lg:pb-8">
+      <div className="mx-auto grid w-full max-w-[1280px] gap-4 px-4 pb-24 pt-4 md:px-6 lg:grid-cols-[84px_1fr] xl:grid-cols-[250px_1fr] lg:pb-8">
         <aside className="hidden lg:block">
-          <div className="surface sticky top-5 space-y-5 p-4">
-            <div>
+          <div className="surface sticky top-4 space-y-4 p-3 xl:p-4">
+            <div className="xl:hidden">
+              <ShellNavRail compact />
+            </div>
+            <div className="hidden xl:block">
               <p className="text-xs uppercase tracking-[0.16em] text-accent">Primary nav</p>
               <div className="mt-2">
                 <ShellNavRail />
               </div>
-
-              <div className="surface-subtle mt-3 p-3">
-                <div className="flex items-center justify-between gap-2">
-                  <p className="text-xs uppercase tracking-[0.14em] text-muted">Weekly progress</p>
-                  <span className={`signal-chip ${readinessClass}`}>{trendLabel}</span>
-                </div>
-                <div className="mt-2 h-1.5 overflow-hidden rounded-full bg-[hsl(var(--bg-elevated))]">
-                  <div className="h-full rounded-full bg-[hsl(var(--accent-performance))]" style={{ width: `${completionRate}%` }} />
-                </div>
-                <p className="mt-2 text-sm font-semibold">{completionRate}% completion</p>
-                <p className="mt-1 text-xs text-muted">Next key: {nextKeySessionLabel}</p>
-                {daysToRace !== null ? <p className="mt-1 text-xs text-muted">Race countdown: {daysToRace} days</p> : null}
-              </div>
             </div>
 
-            <div className="surface-subtle p-3">
+            <div className="hidden xl:block surface-subtle p-3">
               <p className="text-xs uppercase tracking-[0.14em] text-muted">Training week</p>
               {weekContext ? (
                 <>
                   <p className="mt-2 text-sm font-semibold">Week {weekContext.week_index} · {weekContext.focus}</p>
                   <p className="mt-1 text-xs text-muted">Starts {weekContext.week_start_date}</p>
-                  <p className="mt-1 text-xs text-muted">
-                    Target: {weekContext.target_minutes ? `${weekContext.target_minutes} min` : "not set"}
-                  </p>
+                  <p className="mt-1 text-xs text-muted">Target: {weekContext.target_minutes ? `${weekContext.target_minutes} min` : "not set"}</p>
                 </>
               ) : (
                 <p className="mt-2 text-sm text-muted">Create or activate a plan to see week context.</p>
               )}
-              <Link href="/plan" className="mt-3 inline-flex text-xs text-accent underline">Manage plan</Link>
+              <Link href="/plan/builder" className="mt-3 inline-flex text-xs text-accent underline">Manage plan</Link>
             </div>
           </div>
         </aside>
 
-        <main className="min-w-0 space-y-4">{children}</main>
+        <main className="min-w-0 space-y-4">
+          {children}
+        </main>
       </div>
 
       <MobileBottomTabs />

--- a/app/(protected)/plan/actions.ts
+++ b/app/(protected)/plan/actions.ts
@@ -35,7 +35,8 @@ const createSessionSchema = z.object({
   notes: z.string().trim().max(1000).optional(),
   distanceValue: z.union([z.literal(""), z.coerce.number().positive()]).optional(),
   distanceUnit: z.union([z.literal(""), z.enum(["m", "km", "mi", "yd"])]).optional(),
-  dayOrder: z.coerce.number().int().min(0).max(100).optional()
+  dayOrder: z.coerce.number().int().min(0).max(100).optional(),
+  isKey: z.coerce.boolean().optional()
 });
 
 const updateSessionSchema = createSessionSchema.extend({
@@ -144,6 +145,7 @@ async function insertSessionWithCompat(
   const withoutOptionalColumns: Record<string, unknown> = { ...payload };
   delete withoutOptionalColumns.day_order;
   delete withoutOptionalColumns.target;
+  delete withoutOptionalColumns.is_key;
 
   if (Object.keys(withoutOptionalColumns).length === Object.keys(payload).length) {
     throw new Error(initialError.message);
@@ -170,6 +172,7 @@ async function updateSessionWithCompat(
   const withoutOptionalColumns: Record<string, unknown> = { ...payload };
   delete withoutOptionalColumns.day_order;
   delete withoutOptionalColumns.target;
+  delete withoutOptionalColumns.is_key;
 
   if (Object.keys(withoutOptionalColumns).length === Object.keys(payload).length) {
     throw new Error(initialError.message);
@@ -196,6 +199,7 @@ async function insertSessionsBatchWithCompat(
     const next = { ...row };
     delete next.day_order;
     delete next.target;
+    delete next.is_key;
     return next;
   });
 
@@ -408,7 +412,7 @@ export async function duplicateWeekForwardAction(formData: FormData) {
 
   const sourceSessionsQuery = await supabase
     .from("sessions")
-    .select("sport,type,target,duration_minutes,notes,distance_value,distance_unit,status,date,day_order")
+    .select("sport,type,target,duration_minutes,notes,distance_value,distance_unit,status,is_key,date,day_order")
     .eq("week_id", sourceWeek.id)
     .order("date", { ascending: true });
 
@@ -418,7 +422,7 @@ export async function duplicateWeekForwardAction(formData: FormData) {
   if (sourceSessionsError && (isMissingColumnError(sourceSessionsError, "target") || isMissingColumnError(sourceSessionsError, "day_order"))) {
     const fallbackQuery = await supabase
       .from("sessions")
-      .select("sport,type,duration_minutes,notes,distance_value,distance_unit,status,date")
+      .select("sport,type,duration_minutes,notes,distance_value,distance_unit,status,is_key,date")
       .eq("week_id", sourceWeek.id)
       .order("date", { ascending: true });
 
@@ -602,7 +606,8 @@ export async function createSessionAction(formData: FormData) {
     notes: formData.get("notes"),
     distanceValue: formData.get("distanceValue"),
     distanceUnit: formData.get("distanceUnit"),
-    dayOrder: formData.get("dayOrder")
+    dayOrder: formData.get("dayOrder"),
+    isKey: formData.get("isKey")
   });
 
   const { supabase, user } = await getAuthedClient();
@@ -633,7 +638,8 @@ export async function createSessionAction(formData: FormData) {
     notes: parsed.notes ?? null,
     distance_value: parsed.distanceValue === "" ? null : parsed.distanceValue,
     distance_unit: parsed.distanceUnit === "" ? null : parsed.distanceUnit,
-    status: "planned"
+    status: "planned",
+    is_key: Boolean(parsed.isKey)
   };
 
   await insertSessionWithCompat(supabase, canonicalPayload);
@@ -654,7 +660,8 @@ export async function updateSessionAction(formData: FormData) {
     notes: formData.get("notes"),
     distanceValue: formData.get("distanceValue"),
     distanceUnit: formData.get("distanceUnit"),
-    status: formData.get("status")
+    status: formData.get("status"),
+    isKey: formData.get("isKey")
   });
 
   const { supabase, user } = await getAuthedClient();
@@ -674,7 +681,8 @@ export async function updateSessionAction(formData: FormData) {
     distance_unit: parsed.distanceUnit === "" ? null : parsed.distanceUnit,
     duration_minutes: parsed.durationMinutes,
     status: parsed.status,
-    user_id: user.id
+    user_id: user.id,
+    is_key: Boolean(parsed.isKey)
   };
 
   await updateSessionWithCompat(supabase, parsed.sessionId, canonicalPayload);

--- a/app/(protected)/plan/builder/page.tsx
+++ b/app/(protected)/plan/builder/page.tsx
@@ -1,0 +1,78 @@
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { createPlanAction, deletePlanAction } from "../actions";
+
+type Plan = { id: string; name: string; start_date: string; duration_weeks: number };
+
+export default async function PlanBuilderPage() {
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) return null;
+
+  const { data: plansData, error } = await supabase
+    .from("training_plans")
+    .select("id,name,start_date,duration_weeks")
+    .order("start_date", { ascending: false });
+
+  if (error) throw new Error(error.message);
+
+  const plans = (plansData ?? []) as Plan[];
+
+  return (
+    <section className="space-y-4">
+      <div className="flex items-center justify-between gap-2">
+        <div>
+          <h1 className="text-lg font-semibold">Plan settings</h1>
+          <p className="text-sm text-muted">Create plans and manage existing plan shells.</p>
+        </div>
+        <Link href="/plan" className="btn-secondary px-3 py-1.5 text-xs">Back to week schedule</Link>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-2">
+        <form action={createPlanAction} className="surface space-y-4 p-4">
+          <h2 className="text-sm font-semibold">Create plan</h2>
+          <div>
+            <label className="label-base" htmlFor="plan-name">Plan name</label>
+            <input id="plan-name" name="name" required className="input-base" />
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            <div>
+              <label className="label-base" htmlFor="plan-start">Start Monday</label>
+              <input id="plan-start" name="startDate" type="date" required className="input-base" />
+            </div>
+            <div>
+              <label className="label-base" htmlFor="plan-duration">Duration (weeks)</label>
+              <input id="plan-duration" name="durationWeeks" type="number" min={1} max={52} defaultValue={12} required className="input-base" />
+            </div>
+          </div>
+          <button className="btn-primary">Create plan with weeks</button>
+        </form>
+
+        <article className="surface p-4">
+          <h2 className="text-sm font-semibold">Existing plans ({plans.length})</h2>
+          <div className="mt-3 space-y-2">
+            {plans.length === 0 ? (
+              <p className="text-sm text-muted">No plans yet.</p>
+            ) : (
+              plans.map((plan) => (
+                <div key={plan.id} className="flex items-start gap-2 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] p-2">
+                  <Link href={`/plan?plan=${plan.id}`} className="min-w-0 flex-1 rounded-lg px-1 py-0.5">
+                    <p className="font-medium">{plan.name}</p>
+                    <p className="text-xs text-muted">{plan.start_date} • {plan.duration_weeks} weeks</p>
+                  </Link>
+                  <form action={deletePlanAction} onSubmit={(event) => { if (!window.confirm(`Delete plan "${plan.name}" and all weeks/sessions?`)) event.preventDefault(); }}>
+                    <input type="hidden" name="planId" value={plan.id} />
+                    <button className="btn-secondary px-2 py-1 text-xs">Delete</button>
+                  </form>
+                </div>
+              ))
+            )}
+          </div>
+        </article>
+      </div>
+    </section>
+  );
+}

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -1,5 +1,5 @@
+import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
-import { PageHeader } from "../page-header";
 import { PlanEditor } from "./plan-editor";
 
 type Plan = {
@@ -34,6 +34,7 @@ type Session = {
   distance_value: number | null;
   distance_unit: string | null;
   status: "planned" | "completed" | "skipped";
+  is_key?: boolean | null;
 };
 
 function buildPlanWeeks(startDateIso: string, durationWeeks: number, planId: string) {
@@ -50,56 +51,26 @@ function buildPlanWeeks(startDateIso: string, durationWeeks: number, planId: str
   });
 }
 
-
 function isMissingTableError(error: { code?: string; message?: string } | null, tableName: string) {
-  if (!error) {
-    return false;
-  }
-
-  if (error.code === "PGRST205") {
-    return true;
-  }
-
+  if (!error) return false;
+  if (error.code === "PGRST205") return true;
   return (error.message ?? "").toLowerCase().includes(`could not find the table '${tableName.toLowerCase()}' in the schema cache`);
 }
 
-function isMissingColumnError(error: { code?: string; message?: string } | null, columnName: string) {
-  if (!error) {
-    return false;
-  }
-
-  if (error.code === "42703") {
-    return true;
-  }
-
-  return (error.message ?? "").toLowerCase().includes(columnName.toLowerCase());
-}
-
-export default async function PlanPage({
-  searchParams
-}: {
-  searchParams?: {
-    plan?: string;
-  };
-}) {
+export default async function PlanPage({ searchParams }: { searchParams?: { plan?: string } }) {
   const supabase = await createClient();
-
   const {
     data: { user }
   } = await supabase.auth.getUser();
 
-  if (!user) {
-    return null;
-  }
+  if (!user) return null;
 
   const { data: plansData, error: plansError } = await supabase
     .from("training_plans")
     .select("id,name,start_date,duration_weeks")
     .order("start_date", { ascending: false });
 
-  if (plansError) {
-    throw new Error(plansError.message);
-  }
+  if (plansError) throw new Error(plansError.message);
 
   const plans = (plansData ?? []) as Plan[];
   const selectedPlan = plans.find((plan) => plan.id === searchParams?.plan) ?? plans[0];
@@ -129,9 +100,7 @@ export default async function PlanPage({
       ignoreDuplicates: true
     });
 
-    if (seedWeeksError) {
-      throw new Error(seedWeeksError.message);
-    }
+    if (seedWeeksError) throw new Error(seedWeeksError.message);
 
     const { data: seededWeeksData, error: seededWeeksFetchError } = await supabase
       .from("training_weeks")
@@ -139,10 +108,7 @@ export default async function PlanPage({
       .eq("plan_id", selectedPlan.id)
       .order("week_index", { ascending: true });
 
-    if (seededWeeksFetchError) {
-      throw new Error(seededWeeksFetchError.message);
-    }
-
+    if (seededWeeksFetchError) throw new Error(seededWeeksFetchError.message);
     weeksData = (seededWeeksData ?? []) as TrainingWeek[];
   }
 
@@ -151,7 +117,7 @@ export default async function PlanPage({
   if (selectedPlan) {
     const primaryQuery = await supabase
       .from("sessions")
-      .select("id,plan_id,week_id,date,sport,type,target,duration_minutes,day_order,notes,distance_value,distance_unit,status")
+      .select("id,plan_id,week_id,date,sport,type,target,duration_minutes,day_order,notes,distance_value,distance_unit,status,is_key")
       .eq("plan_id", selectedPlan.id)
       .order("date", { ascending: true })
       .order("day_order", { ascending: true, nullsFirst: false });
@@ -181,15 +147,7 @@ export default async function PlanPage({
         throw new Error(legacy.error.message);
       }
 
-      sessionsData = ((legacy.data ?? []) as Array<{
-        id: string;
-        plan_id: string;
-        date: string;
-        sport: string;
-        type: string;
-        duration: number;
-        notes: string | null;
-      }>).map((session) => ({
+      sessionsData = ((legacy.data ?? []) as Array<{ id: string; plan_id: string; date: string; sport: string; type: string; duration: number; notes: string | null }>).map((session) => ({
         id: session.id,
         plan_id: session.plan_id,
         week_id: "",
@@ -202,7 +160,8 @@ export default async function PlanPage({
         notes: session.notes,
         distance_value: null,
         distance_unit: null,
-        status: "planned"
+        status: "planned",
+        is_key: false
       }));
     } else if (primaryError) {
       throw new Error(primaryError.message);
@@ -211,66 +170,14 @@ export default async function PlanPage({
     }
   }
 
-  const totalPlannedMinutes = sessionsData.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const completeSessions = sessionsData.filter((session) => session.status === "completed").length;
-  const nextSession = sessionsData.find((session) => session.status === "planned") ?? null;
-
   return (
-    <section className="plan-editor-motion-lock space-y-4">
-      <PageHeader
-        title="Plan"
-        objective="Shape your training blocks, tune week intent, and publish sessions that keep race-day goals realistic."
-        actions={[
-          { href: "/calendar", label: "Review week" },
-          { href: "/dashboard", label: "Back to dashboard", variant: "secondary" }
-        ]}
-      />
-
-      <div className="priority-layout">
-        <article className="priority-card-primary">
-          <p className="priority-kicker">Today&apos;s priority session</p>
-          <h2 className="priority-title">Build the next session your athlete needs.</h2>
-          <p className="priority-subtitle">Keep today&apos;s key workout clear, specific, and realistic to execute.</p>
-          <p className="mt-3 text-sm text-muted">
-            {nextSession ? `Next up: ${nextSession.type} (${nextSession.duration_minutes} min).` : "No planned session yet. Add one now to set direction."}
-          </p>
-        </article>
-
-        <article className="priority-card-secondary">
-          <p className="priority-kicker">On track this week</p>
-          <h2 className="priority-title">Audit confidence before you publish.</h2>
-          <p className="priority-subtitle">Ensure volume and completion trend match your current race objective.</p>
-          <div className="mt-3 grid gap-3 sm:grid-cols-3">
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Weeks mapped</p>
-              <p className="mt-1 text-lg font-semibold">{weeksData.length}</p>
-            </div>
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Sessions planned</p>
-              <p className="mt-1 text-lg font-semibold">{sessionsData.length}</p>
-            </div>
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Completed sessions</p>
-              <p className="mt-1 text-lg font-semibold">{completeSessions}</p>
-            </div>
-          </div>
-        </article>
-
-        <article className="priority-card-secondary">
-          <p className="priority-kicker">Supporting analytics</p>
-          <h2 className="priority-title">Check volume and plan coverage.</h2>
-          <p className="priority-subtitle">Use supporting signals to keep structure balanced and actionable.</p>
-          <div className="mt-3 grid gap-3 sm:grid-cols-2">
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Total planned minutes</p>
-              <p className="mt-1 text-lg font-semibold">{totalPlannedMinutes}</p>
-            </div>
-            <div className="priority-card-supporting">
-              <p className="text-xs text-muted">Active plan</p>
-              <p className="mt-1 text-sm font-semibold">{selectedPlan?.name ?? "No active plan selected"}</p>
-            </div>
-          </div>
-        </article>
+    <section className="plan-editor-motion-lock space-y-3">
+      <div className="flex flex-wrap items-center justify-between gap-2 px-1">
+        <div>
+          <h1 className="text-lg font-semibold">Plan</h1>
+          <p className="text-xs uppercase tracking-[0.14em] text-muted">Week Schedule</p>
+        </div>
+        <Link href="/plan/builder" className="btn-secondary px-3 py-1.5 text-xs">Plan settings</Link>
       </div>
 
       <PlanEditor plans={plans} weeks={weeksData} sessions={sessionsData} selectedPlanId={selectedPlan?.id} />

--- a/app/(protected)/plan/plan-editor.tsx
+++ b/app/(protected)/plan/plan-editor.tsx
@@ -18,15 +18,11 @@ import {
   useSortable
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
-import Link from "next/link";
 import { ReactNode, useEffect, useMemo, useState, useTransition } from "react";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
-import { SessionStatusChip } from "@/lib/ui/status-chip";
 import {
   bulkReorderSessionsAction,
-  createPlanAction,
   createSessionAction,
-  deletePlanAction,
   deleteSessionAction,
   deleteWeekAction,
   duplicateWeekForwardAction,
@@ -60,6 +56,7 @@ type Session = {
   distance_value: number | null;
   distance_unit: string | null;
   status: "planned" | "completed" | "skipped";
+  is_key?: boolean | null;
 };
 
 type PlanEditorProps = { plans: Plan[]; weeks: TrainingWeek[]; sessions: Session[]; selectedPlanId?: string };
@@ -120,7 +117,7 @@ function DayDropZone({ iso, children }: { iso: string; children: ReactNode }) {
 }
 
 function SortableSessionCard({ session, onOpen }: { session: Session; onOpen: (id: string) => void }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: `session-${session.id}` });
+  const { setNodeRef, transform, transition, isDragging } = useSortable({ id: `session-${session.id}` });
   const style = { transform: CSS.Transform.toString(transform), transition };
   const meta = getDisciplineMeta(session.sport);
 
@@ -133,19 +130,10 @@ function SortableSessionCard({ session, onOpen }: { session: Session; onOpen: (i
       className={`group w-full rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] p-2 text-left ${isDragging ? "opacity-30" : ""}`}
     >
       <div className="flex items-center justify-between">
+        <div className="flex items-center gap-1">
         <span title={`${meta.label} · ${meta.shape}`} className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] ${meta.className} ${meta.textureClassName}`}><span aria-hidden="true">{meta.icon}</span><span>{meta.label}</span></span>
-        <span
-          {...attributes}
-          {...listeners}
-          onClick={(event) => event.stopPropagation()}
-          className="cursor-grab rounded-md px-1 text-xs text-muted opacity-0 group-hover:opacity-100"
-          aria-label="Drag session"
-        >
-          ⋮⋮
-        </span>
+        {session.is_key ? <span className="rounded-full border border-[hsl(var(--accent-performance)/0.5)] px-1.5 py-0.5 text-[10px] font-semibold text-accent">Key</span> : null}
       </div>
-      <div className="mt-1 flex items-center justify-between gap-2">
-        <SessionStatusChip status={session.status} />
       </div>
       <p className="mt-1 line-clamp-2 text-xs font-semibold">{session.type || "Session"}</p>
       <p className="mt-1 text-xs text-muted">{session.duration_minutes} min</p>
@@ -253,131 +241,117 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId }: PlanEdito
   const duplicateTargets = planWeeks.filter((week) => week.id !== selectedWeek?.id);
 
   return (
-    <section className="grid gap-4 lg:grid-cols-[320px_1fr]">
-      <aside className="surface p-4">
-        <h1 className="text-xl font-semibold">Plan Builder</h1>
-        <p className="mt-1 text-sm text-muted">Plan → Training Weeks → Sessions</p>
-        <form action={createPlanAction} className="mt-4 space-y-4">
-          <section className="surface-subtle p-3">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Plan</p>
-            <label className="label-base mt-2" htmlFor="plan-name">Plan name</label>
-            <input id="plan-name" name="name" required className="input-base" />
-          </section>
+    <section className="space-y-4">
+      {selectedPlan && selectedWeek ? (
+        <>
+          <div className="surface-subtle flex flex-wrap items-center justify-between gap-3 px-3 py-2">
+            <div>
+              <p className="text-sm font-semibold">Week {selectedWeek.week_index} • {selectedWeek.focus} • {weekRangeLabel(selectedWeek.week_start_date)}</p>
+              <p className="text-xs text-muted">Planned {totalMinutes} min • {selectedWeek.target_minutes ? `Target ${selectedWeek.target_minutes} min` : "Target unset"} • Focus {selectedWeek.focus}</p>
+            </div>
+            <div className="flex items-center gap-2">
+              <button form="week-details-form" className="btn-primary px-3 py-1.5 text-xs">Save</button>
+              <button type="button" onClick={() => setWeekActionOpen((v) => !v)} aria-expanded={weekActionOpen} className="btn-secondary px-3 py-1.5 text-xs">Week actions</button>
+            </div>
+          </div>
 
-          <section className="surface-subtle p-3">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Dates</p>
-            <div className="mt-2 grid gap-2 sm:grid-cols-2 lg:grid-cols-1">
-              <div>
-                <label className="label-base" htmlFor="plan-start">Start Monday</label>
-                <input id="plan-start" name="startDate" type="date" required className="input-base" />
-              </div>
-              <div>
-                <label className="label-base" htmlFor="plan-duration">Duration (weeks)</label>
-                <input id="plan-duration" name="durationWeeks" type="number" min={1} max={52} defaultValue={12} required className="input-base" />
+          {weekActionOpen ? (
+            <div className="surface-subtle p-3">
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4 text-sm">
+                <form action={duplicateWeekForwardAction} className="space-y-2"><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><label className="label-base">Duplicate to week</label><select name="destinationWeekId" className="input-base" required>{duplicateTargets.map((week) => <option key={week.id} value={week.id}>Week {week.week_index} ({weekRangeLabel(week.week_start_date)})</option>)}</select><label className="flex items-center gap-2 text-xs"><input type="checkbox" name="copyMetadata" defaultChecked /> Copy metadata</label><label className="flex items-center gap-2 text-xs"><input type="checkbox" name="copySessions" defaultChecked /> Copy sessions</label><button className="btn-secondary w-full text-xs">Duplicate</button></form>
+                <form action={shiftWeekAction} onSubmit={(event) => { if (!window.confirm("Shift this week and all sessions by +7 days?")) event.preventDefault(); }}><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><input type="hidden" name="direction" value="forward" /><button className="btn-secondary w-full text-xs">Shift +7d</button></form>
+                <form action={shiftWeekAction} onSubmit={(event) => { if (!window.confirm("Shift this week and all sessions by -7 days?")) event.preventDefault(); }}><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><input type="hidden" name="direction" value="backward" /><button className="btn-secondary w-full text-xs">Shift -7d</button></form>
+                <form action={deleteWeekAction} onSubmit={(event) => { if (!window.confirm("Delete this week and all sessions in it?")) event.preventDefault(); }}><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><button className="btn-secondary w-full text-xs text-rose-200">Delete week</button></form>
               </div>
             </div>
-          </section>
+          ) : null}
 
-          <section className="surface-subtle p-3">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-muted">Actions</p>
-            <p className="mt-1 text-xs text-muted">Set plan parameters first, then create training weeks.</p>
-            <button className="btn-primary mt-3 w-full">Create plan with weeks</button>
-          </section>
-        </form>
-
-        <details className="mt-4 surface-subtle p-3">
-          <summary className="cursor-pointer text-sm font-medium">Existing plans ({plans.length})</summary>
-          <div className="mt-3 space-y-2">
-            {plans.map((plan) => (
-              <div
-                key={plan.id}
-                className={`flex items-start gap-2 rounded-xl border p-2 ${
-                  selectedPlan?.id === plan.id
-                    ? "border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.1)]"
-                    : "border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))]"
-                }`}
-              >
-                <Link href={`/plan?plan=${plan.id}`} className="min-w-0 flex-1 rounded-lg px-1 py-0.5"><p className="font-medium">{plan.name}</p></Link>
-                <form action={deletePlanAction} onSubmit={(event) => { if (!window.confirm(`Delete plan "${plan.name}" and all weeks/sessions?`)) event.preventDefault(); }}>
-                  <input type="hidden" name="planId" value={plan.id} /><button className="btn-secondary px-2 py-1 text-xs">Delete</button>
-                </form>
-              </div>
-            ))}
-          </div>
-        </details>
-      </aside>
-
-      <main className="space-y-4">
-        {selectedPlan && selectedWeek ? (
-          <>
-            <header className="surface p-5"><h2 className="text-2xl font-semibold">Plan: {selectedPlan.name} → Week {selectedWeek.week_index} ({weekRangeLabel(selectedWeek.week_start_date)})</h2></header>
-            <article className="surface p-5">
-              <div className="grid gap-4 lg:grid-cols-[1.2fr_1fr]">
-                <form action={updateWeekAction} className="space-y-3">
-                  <input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} />
-                  <div className="grid gap-3 md:grid-cols-2">
-                    <div>
-                      <label className="label-base" htmlFor="focus">Week focus</label>
-                      <select id="focus" name="focus" defaultValue={selectedWeek.focus} className="input-base"><option>Build</option><option>Recovery</option><option>Taper</option><option>Race</option><option>Custom</option></select>
-                    </div>
-                    <div>
-                      <label className="label-base" htmlFor="targetMinutes">Target (goal) minutes</label>
-                      <input id="targetMinutes" name="targetMinutes" type="number" min={0} defaultValue={selectedWeek.target_minutes ?? ""} className="input-base" />
-                    </div>
+          <details className="surface-subtle p-3">
+            <summary className="cursor-pointer text-sm font-medium text-accent">Week details</summary>
+            <div className="mt-3 grid gap-4 lg:grid-cols-[1.2fr_1fr]">
+              <form id="week-details-form" action={updateWeekAction} className="space-y-3">
+                <input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} />
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="label-base" htmlFor="focus">Week focus</label>
+                    <select id="focus" name="focus" defaultValue={selectedWeek.focus} className="input-base"><option>Build</option><option>Recovery</option><option>Taper</option><option>Race</option><option>Custom</option></select>
                   </div>
                   <div>
-                    <label className="label-base" htmlFor="notes">Coach notes</label>
-                    <textarea id="notes" name="notes" defaultValue={selectedWeek.notes ?? ""} className="input-base min-h-20" />
-                  </div>
-                  <button className="btn-primary">Save</button>
-                </form>
-                <div className="space-y-3">
-                  <div className="surface-subtle p-3"><p className="text-xs uppercase tracking-wide text-muted">Planned (from sessions)</p><p className="mt-1 text-2xl font-semibold">{totalMinutes}</p><p className="text-xs text-muted">Δ vs target: {minuteDelta > 0 ? "+" : ""}{minuteDelta} min</p></div>
-                  <div className="surface-subtle p-3"><p className="text-xs uppercase tracking-wide text-muted">Discipline breakdown</p><div className="mt-2 space-y-2">{disciplineTotals.map((item) => { const meta = getDisciplineMeta(item.sport); const pct = Math.round((item.minutes / maxDisciplineMinutes) * 100); return <div key={item.sport}><div className="flex items-center justify-between"><p className="text-xs">{meta.label}</p><p className="text-xs text-muted">{item.minutes} min</p></div><div className="mt-1 h-1.5 rounded-full bg-[hsl(var(--surface-2))]"><div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: item.sport === "swim" ? "#56B6D9" : item.sport === "bike" ? "#6BAA75" : item.sport === "run" ? "#C48772" : item.sport === "strength" ? "#9A86C8" : "hsl(var(--signal-neutral))" }} /></div></div>; })}</div></div>
-                  <div className="surface-subtle p-3">
-                    <div className="flex items-center justify-between"><p className="text-xs uppercase tracking-wide text-muted">Week actions</p><button type="button" onClick={() => setWeekActionOpen((v) => !v)} aria-expanded={weekActionOpen} className="btn-secondary px-3 py-1 text-xs">⋯</button></div>
-                    {weekActionOpen ? (
-                      <div className="mt-3 space-y-3 text-sm">
-                        <form action={duplicateWeekForwardAction} className="space-y-2"><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><label className="label-base">Duplicate to week</label><select name="destinationWeekId" className="input-base" required>{duplicateTargets.map((week) => <option key={week.id} value={week.id}>Week {week.week_index} ({weekRangeLabel(week.week_start_date)})</option>)}</select><label className="flex items-center gap-2 text-xs"><input type="checkbox" name="copyMetadata" defaultChecked /> Copy metadata</label><label className="flex items-center gap-2 text-xs"><input type="checkbox" name="copySessions" defaultChecked /> Copy sessions</label><button className="btn-secondary w-full text-xs">Duplicate</button></form>
-                        <form action={shiftWeekAction} onSubmit={(event) => { if (!window.confirm("Shift this week and all sessions by +7 days?")) event.preventDefault(); }}><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><input type="hidden" name="direction" value="forward" /><button className="btn-secondary w-full text-xs">Shift +7d</button></form>
-                        <form action={shiftWeekAction} onSubmit={(event) => { if (!window.confirm("Shift this week and all sessions by -7 days?")) event.preventDefault(); }}><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><input type="hidden" name="direction" value="backward" /><button className="btn-secondary w-full text-xs">Shift -7d</button></form>
-                        <form action={deleteWeekAction} onSubmit={(event) => { if (!window.confirm("Delete this week and all sessions in it?")) event.preventDefault(); }}><input type="hidden" name="planId" value={selectedPlan.id} /><input type="hidden" name="weekId" value={selectedWeek.id} /><button className="btn-secondary w-full text-xs text-rose-200">Delete week</button></form>
-                      </div>
-                    ) : null}
+                    <label className="label-base" htmlFor="targetMinutes">Target (goal) minutes</label>
+                    <input id="targetMinutes" name="targetMinutes" type="number" min={0} defaultValue={selectedWeek.target_minutes ?? ""} className="input-base" />
                   </div>
                 </div>
+                <div>
+                  <label className="label-base" htmlFor="notes">Coach notes</label>
+                  <textarea id="notes" name="notes" defaultValue={selectedWeek.notes ?? ""} className="input-base min-h-20" />
+                </div>
+              </form>
+              <div className="space-y-3">
+                <div className="surface p-3"><p className="text-xs uppercase tracking-wide text-muted">Planned (from sessions)</p><p className="mt-1 text-2xl font-semibold">{totalMinutes}</p><p className="text-xs text-muted">Δ vs target: {minuteDelta > 0 ? "+" : ""}{minuteDelta} min</p></div>
+                <div className="surface p-3"><p className="text-xs uppercase tracking-wide text-muted">Discipline breakdown</p><div className="mt-2 space-y-2">{disciplineTotals.map((item) => { const meta = getDisciplineMeta(item.sport); const pct = Math.round((item.minutes / maxDisciplineMinutes) * 100); return <div key={item.sport}><div className="flex items-center justify-between"><p className="text-xs">{meta.label}</p><p className="text-xs text-muted">{item.minutes} min</p></div><div className="mt-1 h-1.5 rounded-full bg-[hsl(var(--surface-2))]"><div className="h-full rounded-full" style={{ width: `${pct}%`, backgroundColor: item.sport === "swim" ? "#56B6D9" : item.sport === "bike" ? "#6BAA75" : item.sport === "run" ? "#C48772" : item.sport === "strength" ? "#9A86C8" : "hsl(var(--signal-neutral))" }} /></div></div>; })}</div></div>
               </div>
-            </article>
+            </div>
+          </details>
 
-            <article className="surface p-5">
-              <h3 className="text-lg font-semibold">Week schedule (Mon–Sun)</h3>
-              <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
-                <div className="mt-3 grid gap-3 md:grid-cols-2 xl:grid-cols-7">
+          <article className="surface p-4">
+            <h3 className="text-base font-semibold">Week schedule (Mon–Sun)</h3>
+            <DndContext sensors={sensors} collisionDetection={closestCenter} onDragEnd={onDragEnd}>
+              <div className="mt-3 space-y-3 lg:hidden">
+                {weekDays.map((day) => {
+                  const isExpanded = expandedDays[day.iso] ?? false;
+                  const visible = isExpanded ? day.sessions : day.sessions.slice(0, 3);
+                  const hiddenCount = Math.max(day.sessions.length - visible.length, 0);
+                  return (
+                    <section key={day.iso} className="surface-subtle p-3" id={`day-${day.iso}`}>
+                      <div className="flex items-center justify-between border-b border-[hsl(var(--border))] pb-2">
+                        <p className="text-sm font-semibold">{day.label} • {day.date}</p><p className="text-xs text-muted">{day.totalMinutes} min</p>
+                      </div>
+                      <SortableContext items={day.sessions.map((session) => `session-${session.id}`)} strategy={rectSortingStrategy}>
+                        <DayDropZone iso={day.iso}><div className="mt-3 space-y-2" data-day={day.iso}>
+                          {visible.map((session) => <SortableSessionCard key={session.id} session={session} onOpen={setActiveSessionId} />)}
+                          {hiddenCount > 0 ? <button type="button" className="w-full text-xs text-accent" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: true }))}>+{hiddenCount} more</button> : null}
+                          {day.sessions.length > 3 && isExpanded ? <button type="button" className="w-full text-xs text-muted" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: false }))}>Collapse</button> : null}
+                          <button type="button" onClick={() => setQuickAddDay(day.iso)} className="w-full rounded-lg border border-dashed border-[hsl(var(--accent-performance)/0.45)] px-2 py-2 text-xs text-accent">+ Add session</button>
+                        </div></DayDropZone>
+                      </SortableContext>
+                    </section>
+                  );
+                })}
+              </div>
+
+              <div className="mt-3 hidden overflow-x-auto lg:block">
+                <div className="grid min-w-[1260px] grid-cols-7 gap-3">
                   {weekDays.map((day) => {
                     const isExpanded = expandedDays[day.iso] ?? false;
-                    const visible = isExpanded ? day.sessions : day.sessions.slice(0, 2);
+                    const visible = isExpanded ? day.sessions : day.sessions.slice(0, 3);
                     const hiddenCount = Math.max(day.sessions.length - visible.length, 0);
                     return (
-                      <section key={day.iso} className="surface-subtle min-h-[220px] p-3" id={`day-${day.iso}`}>
-                        <p className="text-xs uppercase tracking-wide text-muted">{day.label}</p><p className="text-sm font-medium">{day.date}</p><p className="mt-1 text-xs text-muted">{day.totalMinutes} min</p>
+                      <section key={day.iso} className="surface-subtle min-h-[320px] min-w-0 p-3" id={`day-${day.iso}`}>
+                        <div className="border-b border-[hsl(var(--border))] pb-2">
+                          <p className="text-xs uppercase tracking-wide text-muted">{day.label}</p><p className="text-sm font-medium">{day.date}</p><p className="mt-1 text-xs text-muted">{day.totalMinutes} min</p>
+                        </div>
                         <SortableContext items={day.sessions.map((session) => `session-${session.id}`)} strategy={rectSortingStrategy}>
                           <DayDropZone iso={day.iso}><div className="mt-3 space-y-2" data-day={day.iso}>
                             {visible.map((session) => <SortableSessionCard key={session.id} session={session} onOpen={setActiveSessionId} />)}
                             {hiddenCount > 0 ? <button type="button" className="w-full text-xs text-accent" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: true }))}>+{hiddenCount} more</button> : null}
-                            {day.sessions.length > 2 && isExpanded ? <button type="button" className="w-full text-xs text-muted" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: false }))}>Collapse</button> : null}
-                            <button type="button" onClick={() => setQuickAddDay(day.iso)} className="w-full rounded-lg border border-dashed border-[hsl(var(--accent-performance)/0.45)] px-2 py-1 text-xs text-accent">+ Add</button>
+                            {day.sessions.length > 3 && isExpanded ? <button type="button" className="w-full text-xs text-muted" onClick={() => setExpandedDays((prev) => ({ ...prev, [day.iso]: false }))}>Collapse</button> : null}
+                            <button type="button" onClick={() => setQuickAddDay(day.iso)} className="mt-2 w-full rounded-lg border border-dashed border-[hsl(var(--accent-performance)/0.45)] px-2 py-1 text-xs text-accent">+ Add session</button>
                           </div></DayDropZone>
                         </SortableContext>
                       </section>
                     );
                   })}
                 </div>
-                <DragOverlay>{isPending ? <div className="rounded-xl border border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--bg-card))] px-3 py-2 text-xs">Updating…</div> : null}</DragOverlay>
-              </DndContext>
-            </article>
-          </>
-        ) : null}
-      </main>
+              </div>
+              <DragOverlay>{isPending ? <div className="rounded-xl border border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--bg-card))] px-3 py-2 text-xs">Updating…</div> : null}</DragOverlay>
+            </DndContext>
+          </article>
+        </>
+      ) : (
+        <article className="surface p-5">
+          <p className="text-sm text-muted">Create a plan from Plan settings to start building week schedules.</p>
+        </article>
+      )}
 
       {selectedWeek && quickAddDay ? (
         <div className="fixed inset-0 z-20 flex items-center justify-center bg-black/55 p-2 sm:p-4">
@@ -399,6 +373,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId }: PlanEdito
                 <label className="label-base">Title / Type</label><input name="sessionType" className="input-base" placeholder="Easy, Long, Intervals" />
                 <label className="label-base">Target</label><input name="target" className="input-base" placeholder="Z2, 3x10 @ FTP" />
                 <details className="surface-subtle p-3"><summary className="cursor-pointer text-sm text-accent">Add distance (optional)</summary><div className="mt-2 grid grid-cols-2 gap-2"><div><label className="label-base">Distance value</label><input name="distanceValue" type="number" min={0.01} step="0.01" className="input-base" /></div><div><label className="label-base">Distance unit</label><select name="distanceUnit" className="input-base" defaultValue=""><option value="">Select unit</option><option value="m">m</option><option value="km">km</option><option value="mi">mi</option><option value="yd">yd</option></select></div></div></details>
+                <label className="flex items-center gap-2 text-xs"><input type="checkbox" name="isKey" /> Key session</label>
                 <label className="label-base">Notes</label><textarea name="notes" className="input-base min-h-20" />
               </div>
 
@@ -421,6 +396,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId }: PlanEdito
             <label className="label-base">Target</label><input name="target" defaultValue={activeSession.target ?? ""} className="input-base" />
             <div className="grid grid-cols-2 gap-3"><div><label className="label-base">Distance value</label><input name="distanceValue" type="number" min={0.01} step="0.01" defaultValue={activeSession.distance_value ?? ""} className="input-base" /></div><div><label className="label-base">Distance unit</label><select name="distanceUnit" defaultValue={activeSession.distance_unit ?? ""} className="input-base"><option value="">Select unit</option><option value="m">m</option><option value="km">km</option><option value="mi">mi</option><option value="yd">yd</option></select></div></div>
             <label className="label-base">Status</label><select name="status" defaultValue={activeSession.status} className="input-base"><option value="planned">Planned</option><option value="completed">Completed</option><option value="skipped">Skipped</option></select>
+            <label className="flex items-center gap-2 text-xs"><input type="checkbox" name="isKey" defaultChecked={Boolean(activeSession.is_key)} /> Key session</label>
             <label className="label-base">Notes</label><textarea name="notes" defaultValue={activeSession.notes ?? ""} className="input-base min-h-20" />
             <div className="flex gap-2"><button className="btn-primary flex-1">Save changes</button><button formAction={deleteSessionAction} formMethod="post" onClick={(event) => { if (!window.confirm("Delete this session?")) event.preventDefault(); }} className="btn-secondary px-3">Delete</button></div>
           </form>

--- a/app/(protected)/shell-nav.tsx
+++ b/app/(protected)/shell-nav.tsx
@@ -4,17 +4,17 @@ import Link from "next/link";
 import { usePathname } from "next/navigation";
 
 const navItems = [
-  { href: "/dashboard", label: "Dashboard", semanticLabel: "Overview" },
-  { href: "/plan", label: "Plan", semanticLabel: "Design" },
-  { href: "/calendar", label: "Calendar", semanticLabel: "Execution" },
-  { href: "/coach", label: "Coach", semanticLabel: "Adaptation" }
+  { href: "/dashboard", label: "Dashboard", semanticLabel: "Overview", icon: "◧" },
+  { href: "/plan", label: "Plan", semanticLabel: "Design", icon: "▦" },
+  { href: "/calendar", label: "Calendar", semanticLabel: "Execution", icon: "◫" },
+  { href: "/coach", label: "Coach", semanticLabel: "Adaptation", icon: "◎" }
 ];
 
-export function ShellNavRail() {
+export function ShellNavRail({ compact = false }: { compact?: boolean }) {
   const pathname = usePathname();
 
   return (
-    <nav className="space-y-1">
+    <nav className={compact ? "flex flex-col gap-2" : "space-y-1"}>
       {navItems.map((item) => {
         const active = pathname === item.href || pathname.startsWith(`${item.href}/`);
         return (
@@ -22,14 +22,20 @@ export function ShellNavRail() {
             key={item.href}
             href={item.href}
             title={`${item.label} · ${item.semanticLabel}`}
-            className={`block rounded-xl px-3 py-2 text-sm transition ${
+            className={`rounded-xl px-3 py-2 text-sm transition ${
               active
                 ? "bg-[hsl(var(--accent-performance)/0.14)] text-[hsl(var(--accent-performance))] ring-1 ring-[hsl(var(--accent-performance)/0.45)]"
                 : "text-[hsl(var(--fg-muted))] hover:bg-[hsl(var(--bg-card))] hover:text-[hsl(var(--fg))]"
-            }`}
+            } ${compact ? "flex items-center justify-center" : "block"}`}
           >
-            <span className="block font-medium">{item.label}</span>
-            <span className="block text-[11px] uppercase tracking-[0.12em] text-muted">{item.semanticLabel}</span>
+            {compact ? (
+              <span aria-hidden="true" className="text-base">{item.icon}</span>
+            ) : (
+              <>
+                <span className="block font-medium">{item.label}</span>
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted">{item.semanticLabel}</span>
+              </>
+            )}
           </Link>
         );
       })}

--- a/app/(protected)/status-strip.tsx
+++ b/app/(protected)/status-strip.tsx
@@ -1,0 +1,22 @@
+export type StatusStripItem = {
+  label: string;
+  value: string;
+  hint?: string;
+};
+
+export function StatusStrip({ items }: { items: StatusStripItem[] }) {
+  return (
+    <div className="surface-subtle overflow-x-auto px-2 py-1.5">
+      <div className="flex min-w-max items-center gap-2">
+        {items.map((item, index) => (
+          <div key={item.label} className="flex items-center gap-2 rounded-lg px-2 py-1">
+            <p className="text-[10px] uppercase tracking-[0.12em] text-muted">{item.label}</p>
+            <p className="text-sm font-semibold">{item.value}</p>
+            {item.hint ? <p className="text-[11px] text-muted">{item.hint}</p> : null}
+            {index < items.length - 1 ? <span className="ml-1 text-muted">•</span> : null}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/lib/training/week-metrics.test.ts
+++ b/lib/training/week-metrics.test.ts
@@ -1,0 +1,31 @@
+import { computeWeekMinuteTotals, computeWeekSessionCounts, getKeySessionsRemaining } from "./week-metrics";
+
+describe("week metrics", () => {
+  const sessions = [
+    { id: "1", date: "2026-02-23", sport: "run", durationMinutes: 45, status: "completed" as const, isKey: true },
+    { id: "2", date: "2026-02-24", sport: "bike", durationMinutes: 60, status: "planned" as const, isKey: true },
+    { id: "3", date: "2026-02-25", sport: "swim", durationMinutes: 30, status: "skipped" as const, isKey: false },
+    { id: "4", date: "2026-02-26", sport: "bike", durationMinutes: 90, status: "planned" as const, isKey: true }
+  ];
+
+  it("computes planned total vs planned remaining counts", () => {
+    expect(computeWeekSessionCounts(sessions)).toEqual({
+      completedCount: 1,
+      skippedCount: 1,
+      plannedRemainingCount: 2,
+      plannedTotalCount: 4
+    });
+  });
+
+  it("computes minute totals consistently", () => {
+    expect(computeWeekMinuteTotals(sessions)).toEqual({
+      plannedMinutes: 225,
+      completedMinutes: 45,
+      remainingMinutes: 180
+    });
+  });
+
+  it("returns key sessions remaining in chronological order", () => {
+    expect(getKeySessionsRemaining(sessions, "2026-02-24").map((s) => s.id)).toEqual(["2", "4"]);
+  });
+});

--- a/lib/training/week-metrics.ts
+++ b/lib/training/week-metrics.ts
@@ -1,0 +1,47 @@
+export type SessionStatus = "planned" | "completed" | "skipped";
+
+export type WeekMetricSession = {
+  id: string;
+  date: string;
+  sport: string;
+  durationMinutes: number;
+  status: SessionStatus;
+  isKey?: boolean;
+};
+
+export function computeWeekSessionCounts(sessions: WeekMetricSession[]) {
+  const completedCount = sessions.filter((s) => s.status === "completed").length;
+  const skippedCount = sessions.filter((s) => s.status === "skipped").length;
+  const plannedRemainingCount = sessions.filter((s) => s.status === "planned").length;
+  const plannedTotalCount = completedCount + skippedCount + plannedRemainingCount;
+
+  return {
+    completedCount,
+    skippedCount,
+    plannedRemainingCount,
+    plannedTotalCount
+  };
+}
+
+export function computeWeekMinuteTotals(sessions: WeekMetricSession[]) {
+  const plannedMinutes = sessions.reduce((sum, session) => sum + Math.max(session.durationMinutes, 0), 0);
+  const completedMinutes = sessions
+    .filter((session) => session.status === "completed")
+    .reduce((sum, session) => sum + Math.max(session.durationMinutes, 0), 0);
+
+  const remainingMinutes = Math.max(plannedMinutes - completedMinutes, 0);
+
+  return {
+    plannedMinutes,
+    completedMinutes,
+    remainingMinutes
+  };
+}
+
+export function getKeySessionsRemaining(sessions: WeekMetricSession[], todayIso?: string) {
+  const floorDate = todayIso ?? new Date().toISOString().slice(0, 10);
+
+  return sessions
+    .filter((session) => session.isKey && session.status === "planned" && session.date >= floorDate)
+    .sort((a, b) => a.date.localeCompare(b.date));
+}

--- a/supabase/migrations/202603010001_add_is_key_to_sessions.sql
+++ b/supabase/migrations/202603010001_add_is_key_to_sessions.sql
@@ -1,0 +1,4 @@
+alter table if exists public.sessions
+  add column if not exists is_key boolean not null default false;
+
+comment on column public.sessions.is_key is 'Manual key-session flag used across plan, calendar, and dashboard.';


### PR DESCRIPTION
### Motivation

- Add a first-class "key session" flag to sessions so the planner, calendar, and dashboard can surface and prioritize key workouts.  
- Centralize week-level computation (counts and minute totals) to keep UI components consistent and reusable.  
- Improve UX for week navigation and summary information while keeping DB compatibility for deployments that may not yet have the new column.  

### Description

- Add a new boolean column migration `supabase/migrations/202603010001_add_is_key_to_sessions.sql` to add `is_key` to `public.sessions` with a default of `false`.  
- Introduce `lib/training/week-metrics.ts` with `computeWeekSessionCounts`, `computeWeekMinuteTotals`, and `getKeySessionsRemaining`, and add unit tests in `lib/training/week-metrics.test.ts`.  
- Wire `is_key` through the stack: include `is_key` in queries and results in `plan`, `dashboard`, and `calendar` pages, surface a Key badge in session cards, and expose a `Key session` checkbox in the plan editor quick-add and edit forms.  
- Replace several UI header/summary patterns with reusable components: add `GlobalHeader`, `StatusStrip`, and `DetailsAccordion`, update layout to use `GlobalHeader`, and refresh calendar/dashboard/plan UIs to consume the new metrics functions for counts and minute totals.  
- Add query/insert/update compatibility fallbacks to `plan/actions.ts` and calendar queries so the app tolerates missing `is_key`, `day_order`, or `target` columns on older DB schemas by retrying without optional columns or using legacy tables.  
- Minor improvements to week/calendar UI, filtering, and labels (compact nav rail icons, expanded calendar summary, improved completed/linked stat display).  

### Testing

- Added unit tests for week metrics in `lib/training/week-metrics.test.ts` and ran the test file; `computeWeekSessionCounts`, `computeWeekMinuteTotals`, and `getKeySessionsRemaining` tests passed.  
- No other automated test changes were added; existing app behaviour includes compatibility fallbacks exercised manually during development to ensure safe rollout to databases without the new `is_key` column.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f73469a648332a7a87552c804b31a)