### PR TITLE
Account menu: outside-click close and styling; remove week completion calc from layout/header

### DIFF
--- a/app/(protected)/account-menu.tsx
+++ b/app/(protected)/account-menu.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 
 type AccountMenuProps = {
   avatarUrl: string | null;
@@ -20,14 +20,29 @@ export function AccountMenu({ avatarUrl, initials, displayName, email, signOutAc
     }
   };
 
+  useEffect(() => {
+    const handlePointerDown = (event: PointerEvent) => {
+      const details = detailsRef.current;
+      if (!details?.open) return;
+      if (event.target instanceof Node && !details.contains(event.target)) {
+        details.open = false;
+      }
+    };
+
+    document.addEventListener("pointerdown", handlePointerDown);
+    return () => {
+      document.removeEventListener("pointerdown", handlePointerDown);
+    };
+  }, []);
+
   return (
     <details className="group relative" ref={detailsRef}>
-      <summary aria-label="Open account menu" className="list-none cursor-pointer rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] p-0.5 transition hover:border-cyan-400/50">
+      <summary aria-label="Open account menu" className="list-none cursor-pointer rounded-full border border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--bg-elevated))] p-0.5 shadow-[0_0_0_1px_hsl(var(--bg)),0_10px_25px_hsl(210_30%_5%_/_0.35)] transition hover:border-[hsl(var(--accent-performance)/0.7)] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)]">
         {avatarUrl ? (
           // eslint-disable-next-line @next/next/no-img-element
           <img src={avatarUrl} alt="User avatar" className="h-9 w-9 rounded-full object-cover" />
         ) : (
-          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-cyan-500/15 text-xs font-semibold text-cyan-200">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[hsl(var(--accent-performance)/0.2)] text-xs font-semibold text-accent">
             {initials}
           </span>
         )}

--- a/app/(protected)/global-header.tsx
+++ b/app/(protected)/global-header.tsx
@@ -30,12 +30,10 @@ function weekRangeLabel(weekStart: string) {
 export function GlobalHeader({
   raceName,
   daysToRace,
-  weekCompletion,
   account
 }: {
   raceName: string;
   daysToRace: number | null;
-  weekCompletion: number;
   account: {
     avatarUrl: string | null;
     initials: string;
@@ -73,7 +71,6 @@ export function GlobalHeader({
 
         <div className="flex flex-wrap items-center gap-2">
           {daysToRace !== null ? <span className="rounded-full border pill-accent px-3 py-1 text-xs font-medium">{raceName} • {daysToRace} days</span> : null}
-          <span className="signal-chip signal-recovery">Week {weekCompletion}%</span>
           <Link href="/coach" className="btn-primary px-3 py-1.5 text-xs">Ask tri.ai</Link>
           <AccountMenu
             avatarUrl={account.avatarUrl}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -14,11 +14,6 @@ type Profile = {
   race_name: string | null;
 };
 
-type Session = {
-  date: string;
-  duration_minutes: number | null;
-  status: "planned" | "completed" | "skipped";
-};
 
 type TrainingWeek = {
   week_index: number;
@@ -41,11 +36,6 @@ function getMonday(date = new Date()) {
   return monday;
 }
 
-function addDays(isoDate: string, days: number) {
-  const date = new Date(`${isoDate}T00:00:00.000Z`);
-  date.setUTCDate(date.getUTCDate() + days);
-  return date.toISOString().slice(0, 10);
-}
 
 export default async function ProtectedLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
@@ -63,29 +53,20 @@ export default async function ProtectedLayout({ children }: { children: React.Re
   const initials = getInitials(displayName);
 
   const currentWeekStart = getMonday().toISOString().slice(0, 10);
-  const currentWeekEnd = addDays(currentWeekStart, 7);
   const activePlanId = profile?.active_plan_id ?? null;
 
-  const [{ data: weekData }, { data: sessionsData }] = activePlanId
-    ? await Promise.all([
-        supabase
-          .from("training_weeks")
-          .select("week_index,focus,week_start_date,target_minutes")
-          .eq("plan_id", activePlanId)
-          .lte("week_start_date", currentWeekStart)
-          .order("week_start_date", { ascending: false })
-          .limit(1)
-          .maybeSingle(),
-        supabase.from("sessions").select("date,duration_minutes,status").eq("plan_id", activePlanId).gte("date", currentWeekStart).lt("date", currentWeekEnd)
-      ])
-    : [{ data: null }, { data: [] }];
+  const { data: weekData } = activePlanId
+    ? await supabase
+        .from("training_weeks")
+        .select("week_index,focus,week_start_date,target_minutes")
+        .eq("plan_id", activePlanId)
+        .lte("week_start_date", currentWeekStart)
+        .order("week_start_date", { ascending: false })
+        .limit(1)
+        .maybeSingle()
+    : { data: null };
 
   const weekContext = (weekData ?? null) as TrainingWeek | null;
-  const sessions = (sessionsData ?? []) as Session[];
-  const plannedMinutes = sessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const completedMinutes = sessions.filter((session) => session.status === "completed").reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-  const completionRate = plannedMinutes > 0 ? Math.round((completedMinutes / plannedMinutes) * 100) : 0;
-
   const raceName = profile?.race_name?.trim() || "Target race";
   const daysToRace = profile?.race_date
     ? Math.max(0, Math.ceil((new Date(`${profile.race_date}T00:00:00.000Z`).getTime() - Date.now()) / (1000 * 60 * 60 * 24)))
@@ -96,7 +77,6 @@ export default async function ProtectedLayout({ children }: { children: React.Re
       <GlobalHeader
         raceName={raceName}
         daysToRace={daysToRace}
-        weekCompletion={completionRate}
         account={{
           avatarUrl: profile?.avatar_url ?? null,
           initials,


### PR DESCRIPTION
### Motivation
- Improve account menu UX by closing the menu when clicking outside the popup and update its visual styling to match elevated UI tokens.
- Remove the week completion display and its related computation to simplify header UI and server-side data fetching.
- Reduce unnecessary database queries in the protected layout by only fetching the latest training week when an active plan exists.

### Description
- Add an effect in `AccountMenu` to listen for `pointerdown` and close the `<details>` when clicking outside, using a `ref` to the element (`useEffect` and `pointerdown` handler).
- Update `AccountMenu` summary and avatar/initials classes to use updated CSS variables and elevation/shadow styles for better focus and hover states.
- Remove the `weekCompletion` prop and the `Week {weekCompletion}%` UI element from `GlobalHeader`, and update its parameters accordingly.
- Simplify `ProtectedLayout` by deleting session-related types, removing the sessions query and completion rate computation, and only fetching the latest `training_weeks` row when `activePlanId` is present.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a362d15cb08332b1a595b7ea07bd16)