### PR TITLE
Dashboard polish: remove duplicate progress chip, prioritize CTAs, and add contextual rationale

### DIFF
--- a/app/(protected)/dashboard/next-action-copy.test.ts
+++ b/app/(protected)/dashboard/next-action-copy.test.ts
@@ -1,0 +1,27 @@
+import { getWhyTodayMattersCopy, NEXT_ACTION_STATE } from "./next-action-copy";
+
+describe("getWhyTodayMattersCopy", () => {
+  it("returns key-session copy for key sessions today", () => {
+    expect(
+      getWhyTodayMattersCopy(NEXT_ACTION_STATE.SESSION_TODAY, {
+        is_key: true,
+        type: "Threshold"
+      })
+    ).toBe("Why today matters: protect quality—hit this as planned.");
+  });
+
+  it("returns easy-session copy for easy sessions today", () => {
+    expect(
+      getWhyTodayMattersCopy(NEXT_ACTION_STATE.SESSION_TODAY, {
+        is_key: false,
+        type: "Easy aerobic"
+      })
+    ).toBe("Why today matters: bank easy volume to support upcoming quality.");
+  });
+
+  it("returns no-session copy when no session is planned", () => {
+    expect(getWhyTodayMattersCopy(NEXT_ACTION_STATE.NO_SESSION_TODAY)).toBe(
+      "Why today matters: use the space to recover and protect your next key session."
+    );
+  });
+});

--- a/app/(protected)/dashboard/next-action-copy.ts
+++ b/app/(protected)/dashboard/next-action-copy.ts
@@ -1,0 +1,48 @@
+export const NEXT_ACTION_STATE = {
+  SESSION_TODAY: "SESSION_TODAY",
+  NO_SESSION_TODAY: "NO_SESSION_TODAY",
+  MISSED_KEY: "MISSED_KEY"
+} as const;
+
+export type NextActionState = (typeof NEXT_ACTION_STATE)[keyof typeof NEXT_ACTION_STATE];
+
+type NextActionSession = {
+  is_key?: boolean | null;
+  type?: string | null;
+  title?: string | null;
+  intent?: string | null;
+  intensity?: string | null;
+};
+
+function isEasySession(session: NextActionSession | null | undefined) {
+  if (!session) return false;
+
+  const normalizedIntent = (session.intent ?? "").toLowerCase();
+  const normalizedIntensity = (session.intensity ?? "").toLowerCase();
+  if ([normalizedIntent, normalizedIntensity].some((value) => ["easy", "recovery", "endurance"].includes(value))) {
+    return true;
+  }
+
+  const descriptor = `${session.title ?? ""} ${session.type ?? ""}`.toLowerCase();
+  return /(easy|recovery|endurance)/i.test(descriptor);
+}
+
+export function getWhyTodayMattersCopy(state: NextActionState, session?: NextActionSession | null) {
+  if (state === NEXT_ACTION_STATE.MISSED_KEY) {
+    return "Why today matters: reschedule to protect the week’s intent.";
+  }
+
+  if (state === NEXT_ACTION_STATE.NO_SESSION_TODAY) {
+    return "Why today matters: use the space to recover and protect your next key session.";
+  }
+
+  if (session?.is_key) {
+    return "Why today matters: protect quality—hit this as planned.";
+  }
+
+  if (isEasySession(session)) {
+    return "Why today matters: bank easy volume to support upcoming quality.";
+  }
+
+  return "Why today matters: stay consistent—this keeps your week on track.";
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { WeekProgressCard } from "./week-progress-card";
 import { ProgressGlanceCard } from "./progress-glance-card";
 import { computeWeekMinuteTotals } from "@/lib/training/week-metrics";
+import { getWhyTodayMattersCopy, NEXT_ACTION_STATE } from "./next-action-copy";
 
 type Session = {
   id: string;
@@ -245,6 +246,12 @@ export default async function DashboardPage({
     ? `Close your ${biggestGap.label} gap (+${biggestGap.planned - biggestGap.completed}m) by adding 2 × 30–45m easy ${biggestGap.label.toLowerCase()} sessions.`
     : "Protect consistency this week with short, low-friction sessions on open days.";
 
+  const nextActionState = nextPendingTodaySession
+    ? NEXT_ACTION_STATE.SESSION_TODAY
+    : overdueKeySession
+      ? NEXT_ACTION_STATE.MISSED_KEY
+      : NEXT_ACTION_STATE.NO_SESSION_TODAY;
+
 
   if (!hasActivePlan && !hasAnyPlan) {
     return (
@@ -285,12 +292,13 @@ export default async function DashboardPage({
                 {nextPendingTodaySession.duration_minutes} min • {getDisciplineMeta(nextPendingTodaySession.sport).label}
                 {nextPendingTodaySession.is_key ? <span className="ml-2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">Key session</span> : null}
               </p>
-              <p className="mt-1 text-sm text-muted">Why today matters: lock in today to keep your key-session quality intact.</p>
+              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState, nextPendingTodaySession)}</p>
             </>
           ) : overdueKeySession ? (
             <>
               <h1 className="priority-title">Key session missed: {overdueKeySession.type}</h1>
               <p className="priority-subtitle">Reschedule now to protect this week&apos;s intent.</p>
+              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState, overdueKeySession)}</p>
             </>
           ) : (
             <>
@@ -299,6 +307,7 @@ export default async function DashboardPage({
                 Keep momentum by pulling one session forward
                 {hasGapSuggestion ? ` — 30–45m easy ${biggestGap!.label.toLowerCase()} is the best fit.` : "."}
               </p>
+              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState)}</p>
             </>
           )}
           <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
@@ -332,7 +341,7 @@ export default async function DashboardPage({
             <h2 className="priority-title">{weeklyFocusText}</h2>
             <p className="priority-subtitle">Make one scheduling decision now, then return to execution.</p>
             <div className="mt-4">
-              <Link href="/calendar" className="btn-primary px-3 py-1.5 text-xs">Add suggested sessions</Link>
+              <Link href="/calendar" className={`${nextActionState === NEXT_ACTION_STATE.SESSION_TODAY ? "btn-secondary" : "btn-primary"} px-3 py-1.5 text-xs`}>Add suggested sessions</Link>
             </div>
           </article>
 
@@ -350,6 +359,7 @@ export default async function DashboardPage({
                   completedMinutes: item.completed,
                   color: item.color
                 }))}
+                showStatusChip={false}
               />
             </div>
           </article>

--- a/app/(protected)/dashboard/week-progress-card.tsx
+++ b/app/(protected)/dashboard/week-progress-card.tsx
@@ -14,6 +14,7 @@ type WeekProgressCardProps = {
   plannedTotalMinutes: number;
   completedTotalMinutes: number;
   disciplines: Discipline[];
+  showStatusChip?: boolean;
 };
 
 function formatMinutes(minutes: number) {
@@ -25,7 +26,8 @@ const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(ma
 export function WeekProgressCard({
   plannedTotalMinutes,
   completedTotalMinutes,
-  disciplines
+  disciplines,
+  showStatusChip = true
 }: WeekProgressCardProps) {
   const [hideEmpty, setHideEmpty] = useState(true);
 
@@ -60,10 +62,12 @@ export function WeekProgressCard({
     <article className="surface p-6">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Week Progress</h2>
-        <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${overMinutes > 0 ? "signal-chip signal-load" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"}`}>
-          {overMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--signal-load))]" /> : null}
-          <span>{chipLabel}</span>
-        </span>
+        {showStatusChip ? (
+          <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${overMinutes > 0 ? "signal-chip signal-load" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"}`}>
+            {overMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--signal-load))]" /> : null}
+            <span>{chipLabel}</span>
+          </span>
+        ) : null}
       </div>
 
       <div className="mt-4">


### PR DESCRIPTION
### Motivation
- Avoid duplicate status chips on the Dashboard by showing the week-status only once in the Progress Glance.
- Reduce CTA competition so that the strongest action above the fold is the session-specific `Open session` when a session is planned for today.
- Make the Next Action rationale copy context-aware so it matches session intent (key / easy / no-session / missed key).

### Description
- Added a `showStatusChip?: boolean` prop to `WeekProgressCard` (default `true`) and render the chip only when this prop is true, and passed `showStatusChip={false}` from the Dashboard so the chip appears just in `ProgressGlanceCard` on Dashboard. (file: `week-progress-card.tsx`, `page.tsx`).
- Implemented a small helper `next-action-copy.ts` exposing `NEXT_ACTION_STATE` and `getWhyTodayMattersCopy(...)` with a deterministic `isEasySession` heuristic to return one-line contextual rationale for `SESSION_TODAY`, `NO_SESSION_TODAY`, and `MISSED_KEY`. (file: `next-action-copy.ts`).
- Wired Dashboard to compute `nextActionState` and use `getWhyTodayMattersCopy(...)` for all Next Action states, keeping the visual layout unchanged. (file: `page.tsx`).
- Demoted the “Add suggested sessions” CTA to a secondary style (`btn-secondary`) when `nextActionState === SESSION_TODAY`, and left it primary otherwise. (file: `page.tsx`).
- Added lightweight unit tests for the helper covering a key-session, an easy-session, and the no-session case. (file: `next-action-copy.test.ts`).

### Testing
- Ran the new unit tests with `npm test -- --runInBand next-action-copy.test.ts` and they passed (3 tests). 
- Ran the full test suite with `npm test -- --runInBand` and observed unrelated pre-existing failure in `lib/workouts/activity-matching.test.ts` due to `assert is not defined`, causing the overall run to fail. 
- Launched the app locally via `npm run dev` and captured a screenshot of the Dashboard route; the render hit a 500 due to missing Supabase env vars in the environment but the screenshot artifact was produced for verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a369ae57d08332a2db86941009823f)