### PR TITLE
Add schedule_status and decouple activities from planned-session linkage

### DIFF
--- a/app/(protected)/settings/integrations/activity-uploads-panel.tsx
+++ b/app/(protected)/settings/integrations/activity-uploads-panel.tsx
@@ -10,8 +10,8 @@ type UploadRow = {
   created_at: string;
   status: "uploaded" | "parsed" | "matched" | "error";
   error_message: string | null;
-  completed_activities: { id: string; sport_type: string; duration_sec: number; distance_m: number | null }[];
-  session_activity_links: { planned_session_id: string }[];
+  completed_activities: { id: string; sport_type: string; duration_sec: number; distance_m: number | null; schedule_status: "scheduled" | "unscheduled" }[];
+  session_activity_links: { planned_session_id: string | null }[];
 };
 
 type PlannedSession = { id: string; date: string; sport: string; type: string; duration: number };
@@ -125,14 +125,14 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions }: { init
           <tbody>
             {uploads.map((upload) => {
               const activity = upload.completed_activities[0];
-              const linked = upload.status === "matched" || upload.session_activity_links.length > 0;
+              const linked = activity?.schedule_status === "scheduled" || upload.status === "matched" || upload.session_activity_links.some((link) => Boolean(link.planned_session_id));
               return (
                 <tr key={upload.id} className="border-t border-white/10">
                   <td className="py-2">{formatUploadDate(upload.created_at)}</td>
                   <td>{activity?.sport_type ?? "—"}</td>
                   <td>{fmtDuration(activity?.duration_sec)}</td>
                   <td>{activity?.distance_m ? `${(Number(activity.distance_m) / 1000).toFixed(2)} km` : "—"}</td>
-                  <td>{upload.status === "error" ? "Error" : linked ? "Linked" : "Unassigned"}</td>
+                  <td>{upload.status === "error" ? "Error" : linked ? "Scheduled" : "Unscheduled"}</td>
                   <td className="space-x-2 text-xs">
                     {activity?.id ? <Link className="text-cyan-300 underline" href={`/activities/${activity.id}`}>View activity</Link> : <button className="text-cyan-300 underline" onClick={() => setDetailId(upload.id)}>View details</button>}
                     {!linked && upload.status !== "error" ? (

--- a/app/(protected)/settings/integrations/page.tsx
+++ b/app/(protected)/settings/integrations/page.tsx
@@ -8,8 +8,8 @@ type UploadRow = {
   created_at: string;
   status: "uploaded" | "parsed" | "matched" | "error";
   error_message: string | null;
-  completed_activities: { id: string; sport_type: string; duration_sec: number; distance_m: number | null }[];
-  session_activity_links: { planned_session_id: string }[];
+  completed_activities: { id: string; sport_type: string; duration_sec: number; distance_m: number | null; schedule_status: "scheduled" | "unscheduled" }[];
+  session_activity_links: { planned_session_id: string | null }[];
 };
 
 type PlannedCandidate = {
@@ -52,7 +52,7 @@ export default async function IntegrationsPage() {
     uploadIds.length
       ? supabase
           .from("completed_activities")
-          .select("id,upload_id,sport_type,duration_sec,distance_m")
+          .select("id,upload_id,sport_type,duration_sec,distance_m,schedule_status")
           .eq("user_id", user.id)
           .in("upload_id", uploadIds)
       : Promise.resolve({ data: [] as any[] }),

--- a/app/api/uploads/activities/[uploadId]/attach/route.ts
+++ b/app/api/uploads/activities/[uploadId]/attach/route.ts
@@ -43,6 +43,12 @@ export async function POST(request: Request, { params }: { params: { uploadId: s
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });
 
+  await supabase
+    .from("completed_activities")
+    .update({ schedule_status: "scheduled" })
+    .eq("id", activity.id)
+    .eq("user_id", user.id);
+
   await supabase.from("activity_uploads").update({ status: "matched", error_message: null }).eq("id", params.uploadId).eq("user_id", user.id);
 
   return NextResponse.json({ ok: true });

--- a/app/api/uploads/activities/route.ts
+++ b/app/api/uploads/activities/route.ts
@@ -18,7 +18,7 @@ export async function GET() {
 
   const { data, error } = await supabase
     .from("activity_uploads")
-    .select("id,filename,file_type,file_size,status,error_message,created_at,completed_activities(id,sport_type,duration_sec,distance_m),session_activity_links(planned_session_id)")
+    .select("id,filename,file_type,file_size,status,error_message,created_at,completed_activities(id,sport_type,duration_sec,distance_m,schedule_status),session_activity_links(planned_session_id)")
     .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(15);
@@ -86,9 +86,10 @@ export async function POST(request: Request) {
         avg_power: parsed.avgPower,
         calories: parsed.calories,
         parse_summary: parsed.parseSummary,
-        source: "upload"
+        source: "upload",
+        schedule_status: "unscheduled"
       })
-      .select("id,start_time_utc,sport_type,duration_sec,distance_m")
+      .select("id,start_time_utc,sport_type,duration_sec,distance_m,schedule_status")
       .single();
 
     if (activityError || !createdActivity) throw new Error(activityError?.message ?? "Could not save parsed activity");
@@ -125,8 +126,9 @@ export async function POST(request: Request) {
     );
 
     const best = pickAutoMatch(scored);
+    let matched = false;
     if (best) {
-      await supabase.from("session_activity_links").insert({
+      const { error: linkError } = await supabase.from("session_activity_links").insert({
         user_id: user.id,
         planned_session_id: best.candidateId,
         completed_activity_id: createdActivity.id,
@@ -134,10 +136,20 @@ export async function POST(request: Request) {
         confidence: Number(best.confidence.toFixed(2)),
         match_reason: best.reason
       });
-      await supabase.from("activity_uploads").update({ status: "matched" }).eq("id", upload.id).eq("user_id", user.id);
+
+      if (!linkError) {
+        matched = true;
+        await supabase
+          .from("completed_activities")
+          .update({ schedule_status: "scheduled" })
+          .eq("id", createdActivity.id)
+          .eq("user_id", user.id);
+
+        await supabase.from("activity_uploads").update({ status: "matched" }).eq("id", upload.id).eq("user_id", user.id);
+      }
     }
 
-    return NextResponse.json({ uploadId: upload.id, completedActivityId: createdActivity.id, matched: Boolean(best) });
+    return NextResponse.json({ uploadId: upload.id, completedActivityId: createdActivity.id, matched });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to parse file";
     await supabase.from("activity_uploads").update({ status: "error", error_message: message }).eq("id", upload.id).eq("user_id", user.id);

--- a/supabase/migrations/202602220006_activity_schedule_status.sql
+++ b/supabase/migrations/202602220006_activity_schedule_status.sql
@@ -1,0 +1,24 @@
+alter table public.completed_activities
+  add column if not exists schedule_status text
+  check (schedule_status in ('scheduled', 'unscheduled'))
+  default 'unscheduled';
+
+update public.completed_activities ca
+set schedule_status = case
+  when exists (
+    select 1
+    from public.session_activity_links sal
+    where sal.completed_activity_id = ca.id
+      and sal.planned_session_id is not null
+  ) then 'scheduled'
+  else 'unscheduled'
+end
+where schedule_status is null
+   or schedule_status not in ('scheduled', 'unscheduled');
+
+alter table public.completed_activities
+  alter column schedule_status set not null;
+
+alter table public.session_activity_links
+  alter column planned_session_id drop not null;
+


### PR DESCRIPTION
### Motivation
- Make activity scheduling explicit so a `completed_activities` row can exist independently of a plan link. 
- Avoid treating `session_activity_links` presence as the sole source of truth for whether an activity is scheduled.
- Surface scheduling state to API clients so UIs can show `Scheduled`/`Unscheduled` without relying only on link rows.

### Description
- Add DB migration `supabase/migrations/202602220006_activity_schedule_status.sql` that adds `completed_activities.schedule_status` (`scheduled` | `unscheduled`), backfills existing rows from `session_activity_links`, sets the column `NOT NULL`, and makes `session_activity_links.planned_session_id` nullable.
- Update the upload ingestion flow in `app/api/uploads/activities/route.ts` to always persist activities (insert with `schedule_status: "unscheduled"`), include `schedule_status` in list/select responses, and mark the activity `scheduled` only after a successful link insert.
- Update manual attach flow in `app/api/uploads/activities/[uploadId]/attach/route.ts` to set `completed_activities.schedule_status = "scheduled"` after linking.
- Update client DTOs and UI in `app/(protected)/settings/integrations/page.tsx` and `app/(protected)/settings/integrations/activity-uploads-panel.tsx` to return `schedule_status` and allow `planned_session_id` to be nullable, and render upload status as `Scheduled`/`Unscheduled` while still returning linkage info.

### Testing
- Ran lint: `npm run lint` — passed.
- Built the app: `npm run build -- --no-lint` — build succeeded.
- Ran unit tests for activity matching: `npm run test -- lib/workouts/activity-matching.test.ts` — run failed due to a pre-existing test error (`ReferenceError: assert is not defined`) in the test file, not related to the schema/flow changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a32ec5988332a629ad46f876f224)