### PR TITLE
Add dedicated "Done for today" next-action state on dashboard

### DIFF
--- a/app/(protected)/dashboard/next-action-copy.ts
+++ b/app/(protected)/dashboard/next-action-copy.ts
@@ -1,5 +1,6 @@
 export const NEXT_ACTION_STATE = {
   SESSION_TODAY: "SESSION_TODAY",
+  SESSION_DONE_TODAY: "SESSION_DONE_TODAY",
   NO_SESSION_TODAY: "NO_SESSION_TODAY",
   MISSED_KEY: "MISSED_KEY"
 } as const;
@@ -34,6 +35,10 @@ export function getWhyTodayMattersCopy(state: NextActionState, session?: NextAct
 
   if (state === NEXT_ACTION_STATE.NO_SESSION_TODAY) {
     return "Why today matters: use the space to recover and protect your next key session.";
+  }
+
+  if (state === NEXT_ACTION_STATE.SESSION_DONE_TODAY) {
+    return "Why today matters: today’s work is done—lean into recovery so tomorrow starts strong.";
   }
 
   if (session?.is_key) {

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -190,6 +190,7 @@ export default async function DashboardPage({
   const hasActivePlan = Boolean(activePlanId);
   const todaySessions = sessions.filter((session) => session.date === todayIso);
   const nextPendingTodaySession = todaySessions.find((session) => session.status === "planned") ?? null;
+  const completedTodaySessions = todaySessions.filter((session) => session.status === "completed");
 
   const weekMetricSessions = sessions.map((session) => ({
     id: session.id,
@@ -250,7 +251,14 @@ export default async function DashboardPage({
     ? NEXT_ACTION_STATE.SESSION_TODAY
     : overdueKeySession
       ? NEXT_ACTION_STATE.MISSED_KEY
+      : completedTodaySessions.length > 0
+        ? NEXT_ACTION_STATE.SESSION_DONE_TODAY
       : NEXT_ACTION_STATE.NO_SESSION_TODAY;
+
+  const completedTodaySummary = completedTodaySessions
+    .slice(0, 2)
+    .map((session) => `${session.type} · ${session.duration_minutes} min · ${getDisciplineMeta(session.sport).label}`)
+    .join(" • ");
 
 
   if (!hasActivePlan && !hasAnyPlan) {
@@ -300,6 +308,15 @@ export default async function DashboardPage({
               <p className="priority-subtitle">Reschedule now to protect this week&apos;s intent.</p>
               <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState, overdueKeySession)}</p>
             </>
+          ) : completedTodaySessions.length > 0 ? (
+            <>
+              <h1 className="priority-title">Done for today</h1>
+              <p className="priority-subtitle">
+                {completedTodaySummary}
+                {completedTodaySessions.length > 2 ? ` • +${completedTodaySessions.length - 2} more completed` : ""}
+              </p>
+              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState)}</p>
+            </>
           ) : (
             <>
               <h1 className="priority-title">No session planned today</h1>
@@ -324,12 +341,17 @@ export default async function DashboardPage({
                   <Link href={`/calendar?focus=${overdueKeySession.id}`} className="btn-primary px-3 py-1.5 text-xs">Reschedule in calendar</Link>
                   <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">Skip and adjust week</Link>
                 </>
+              ) : completedTodaySessions.length > 0 ? (
+                <>
+                  <Link href="/calendar" className="btn-primary px-3 py-1.5 text-xs">Open calendar</Link>
+                  <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">Review recovery options</Link>
+                </>
               ) : null}
-              {!nextPendingTodaySession && !overdueKeySession ? (
+              {!nextPendingTodaySession && !overdueKeySession && completedTodaySessions.length === 0 ? (
                 <Link href="/calendar" className="btn-primary px-3 py-1.5 text-xs">Open calendar</Link>
               ) : null}
             </div>
-            {!nextPendingTodaySession && !overdueKeySession ? (
+            {!nextPendingTodaySession && !overdueKeySession && completedTodaySessions.length === 0 ? (
               <Link href="/calendar" className="text-xs text-muted underline underline-offset-2">Why no session?</Link>
             ) : null}
           </div>


### PR DESCRIPTION
### Motivation
- Surface a distinct "done for today" UX when there are completed sessions and no pending session to avoid showing the generic "no session" message.
- Provide a focused CTA path oriented to recovery/calendar actions rather than suggesting pulling work forward when the user has already completed sessions.

### Description
- Added `SESSION_DONE_TODAY` to `NEXT_ACTION_STATE` and a matching copy branch in `getWhyTodayMattersCopy` in `app/(protected)/dashboard/next-action-copy.ts`.
- Derived `completedTodaySessions` from `todaySessions` and updated `nextActionState` ordering in `app/(protected)/dashboard/page.tsx` so completed-today sessions are surfaced before the `NO_SESSION_TODAY` fallback.
- Computed a `completedTodaySummary` (first two sessions summarized as `type · duration min · discipline`) and updated the Next action card to render a "Done for today" variant with summary text and calendar/recovery-oriented CTAs.
- Tweaked conditional rendering so the "Why no session?" link and pull-forward CTA only appear when there are truly no completed or pending sessions.

### Testing
- Ran `npm run lint` and it completed successfully.
- Ran `npm run typecheck` which failed due to a pre-existing unrelated error in `lib/workouts/activity-matching.test.ts` (`Cannot find name 'assert'`).
- Attempted to run `npm run dev` and capture a Playwright screenshot, but the app returned a server error in this environment due to missing Supabase environment variables, so UI validation was limited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a4498564833282cddf58c4a677b3)