### PR TITLE
Merge planned sessions with linked/unlinked completed activities in calendar view

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -2,6 +2,7 @@ import { createClient } from "@/lib/supabase/server";
 import { isValidIsoDate } from "@/lib/date/iso";
 import { WeekCalendar } from "./week-calendar";
 import { computeWeekMinuteTotals, computeWeekSessionCounts } from "@/lib/training/week-metrics";
+import { buildCalendarDisplayItems } from "@/lib/calendar/day-items";
 
 type Session = {
   id: string;
@@ -25,17 +26,6 @@ type LegacyPlannedSession = {
   created_at: string;
 };
 
-type CompletedItem = {
-  id: string;
-  date: string;
-  sport: string;
-  duration_min: number;
-  distance_km: number | null;
-  avg_hr: number | null;
-  avg_power: number | null;
-  linked_session_id?: string;
-};
-
 const weekdayFormatter = new Intl.DateTimeFormat("en-US", { weekday: "short", timeZone: "UTC" });
 const dayFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
 
@@ -51,27 +41,6 @@ function addDays(isoDate: string, days: number) {
   const date = new Date(`${isoDate}T00:00:00.000Z`);
   date.setUTCDate(date.getUTCDate() + days);
   return date.toISOString().slice(0, 10);
-}
-
-function getSessionStatus(session: Pick<Session, "date" | "sport" | "notes" | "status">, completionLedger: Record<string, number>) {
-  if (session.status) {
-    return session.status;
-  }
-
-  const isSkipped = /\[skipped\s\d{4}-\d{2}-\d{2}\]/i.test(session.notes ?? "");
-  if (isSkipped) {
-    return "skipped" as const;
-  }
-
-  const key = `${session.date}:${session.sport}`;
-  const completedCount = completionLedger[key] ?? 0;
-
-  if (completedCount > 0) {
-    completionLedger[key] = completedCount - 1;
-    return "completed" as const;
-  }
-
-  return "planned" as const;
 }
 
 export default async function CalendarPage({ searchParams }: { searchParams?: { weekStart?: string } }) {
@@ -160,79 +129,28 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       .from("completed_activities")
       .select("id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power")
       .eq("user_id", user.id)
-      .gte("start_time_utc", `${weekStart}T00:00:00.000Z`)
-      .lt("start_time_utc", `${weekEnd}T00:00:00.000Z`),
+      .gte("start_time_utc", `${addDays(weekStart, -1)}T00:00:00.000Z`)
+      .lt("start_time_utc", `${addDays(weekEnd, 1)}T00:00:00.000Z`),
     supabase
       .from("session_activity_links")
       .select("planned_session_id,completed_activity_id")
       .eq("user_id", user.id)
   ]);
 
-  const activityById = new Map<string, CompletedItem>();
-  (activities ?? []).forEach((activity: any) => {
-    activityById.set(activity.id, {
-      id: activity.id,
-      date: String(activity.start_time_utc).slice(0, 10),
-      sport: activity.sport_type,
-      duration_min: Math.round(Number(activity.duration_sec ?? 0) / 60),
-      distance_km: activity.distance_m ? Number(activity.distance_m) / 1000 : null,
-      avg_hr: activity.avg_hr,
-      avg_power: activity.avg_power
-    });
+  const timeZone =
+    (user.user_metadata && typeof user.user_metadata.timezone === "string" && user.user_metadata.timezone) ||
+    Intl.DateTimeFormat().resolvedOptions().timeZone ||
+    "UTC";
+
+  const sessions = buildCalendarDisplayItems({
+    sessions: normalizedSessions,
+    activities: (activities ?? []) as any[],
+    links: (links ?? []) as any[],
+    legacyCompleted: (legacyCompleted ?? []) as Array<{ date: string; sport: string }>,
+    timeZone,
+    weekStart,
+    weekEndExclusive: weekEnd
   });
-
-  const linkedBySession = new Map<string, CompletedItem[]>();
-  const linkedActivityIds = new Set<string>();
-  (links ?? []).forEach((link: any) => {
-    const activity = activityById.get(link.completed_activity_id);
-    if (!activity) return;
-    linkedActivityIds.add(activity.id);
-    const list = linkedBySession.get(link.planned_session_id) ?? [];
-    list.push({ ...activity, linked_session_id: link.planned_session_id });
-    linkedBySession.set(link.planned_session_id, list);
-  });
-
-  const unassignedByDate = new Map<string, number>();
-  [...activityById.values()]
-    .filter((item) => !linkedActivityIds.has(item.id))
-    .forEach((item) => {
-      unassignedByDate.set(item.date, (unassignedByDate.get(item.date) ?? 0) + 1);
-    });
-
-  const completionLedger = ((legacyCompleted ?? []) as Array<{ date: string; sport: string }>).reduce<Record<string, number>>((acc, item) => {
-    const key = `${item.date}:${item.sport}`;
-    acc[key] = (acc[key] ?? 0) + 1;
-    return acc;
-  }, {});
-
-
-  const sessions = normalizedSessions.map((session) => {
-    const linked = linkedBySession.get(session.id) ?? [];
-    const linkedStats = linked[0]
-      ? {
-          durationMin: linked.reduce((sum, item) => sum + item.duration_min, 0),
-          distanceKm: linked.reduce((sum, item) => sum + (item.distance_km ?? 0), 0),
-          avgHr: linked[0].avg_hr,
-          avgPower: linked[0].avg_power
-        }
-      : null;
-
-    return {
-      id: session.id,
-      date: session.date,
-      sport: session.sport,
-      type: session.type,
-      duration: session.duration_minutes ?? 0,
-      notes: session.notes,
-      created_at: session.created_at,
-      status: linked.length > 0 ? ("completed" as const) : getSessionStatus(session, completionLedger),
-      linkedActivityCount: linked.length,
-      linkedStats,
-      unassignedSameDayCount: linked.length > 0 ? 0 : (unassignedByDate.get(session.date) ?? 0),
-      is_key: Boolean((session as any).is_key)
-    };
-  });
-
 
   const countMetrics = computeWeekSessionCounts(
     sessions.map((session) => ({
@@ -254,7 +172,7 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       isKey: session.is_key
     }))
   );
-  const unmatchedUploads = [...unassignedByDate.values()].reduce((sum, count) => sum + count, 0);
+  const unmatchedUploads = sessions.filter((item) => item.displayType === "completed_activity").length;
   const todayIso = new Date().toISOString().slice(0, 10);
   const nextTodaySession = sessions.find((session) => session.date === todayIso && session.status === "planned") ?? null;
 

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -44,6 +44,7 @@ type CalendarSession = {
   linkedStats?: { durationMin: number; distanceKm: number; avgHr: number | null; avgPower: number | null } | null;
   unassignedSameDayCount?: number;
   is_key?: boolean;
+  displayType?: "planned_session" | "completed_activity";
 };
 
 type WeekDay = { iso: string; weekday: string; label: string };
@@ -65,6 +66,10 @@ function parseTarget(notes: string | null) {
 }
 
 function buildSessionTitle(session: CalendarSession) {
+  if (session.displayType === "completed_activity") {
+    return "Completed activity";
+  }
+
   const type = session.type?.trim();
   if (type && type.toLowerCase() !== "session") {
     return type;
@@ -200,6 +205,8 @@ export function WeekCalendar({
   const todayIso = new Date().toISOString().slice(0, 10);
 
   function onDragStart(event: DragStartEvent) {
+    const activeSession = sessionsById[String(event.active.id)];
+    if (activeSession?.displayType === "completed_activity") return;
     setActiveId(String(event.active.id));
   }
 
@@ -210,7 +217,7 @@ export function WeekCalendar({
     if (!overId) return;
 
     const activeSession = sessionsById[activeIdValue];
-    if (!activeSession) return;
+    if (!activeSession || activeSession.displayType === "completed_activity") return;
 
     const fromDay = activeSession.date;
     const targetDay = overId.startsWith("day:") ? overId.replace("day:", "") : sessionsById[overId]?.date;
@@ -688,7 +695,8 @@ function SortableSessionCard({
   onMove: () => void;
   onSwap: () => void;
 }) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: session.id });
+  const isReadOnly = session.displayType === "completed_activity";
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({ id: session.id, disabled: isReadOnly });
   const style = {
     transform: CSS.Transform.toString(transform),
     transition
@@ -714,11 +722,11 @@ function SortableSessionCard({
             {session.is_key ? <span className="rounded-full border border-[hsl(var(--accent-performance)/0.5)] px-2 py-0.5 text-[10px] font-semibold text-accent">Key</span> : null}
           </div>
           <div className="flex items-center gap-1.5">
-            <SessionOverflowMenu sessionTitle={title} sessionStatus={session.status} onOpen={onOpen} onMove={onMove} onSwap={onSwap} onSkip={onSkip} />
+            {isReadOnly ? null : <SessionOverflowMenu sessionTitle={title} sessionStatus={session.status} onOpen={onOpen} onMove={onMove} onSwap={onSwap} onSkip={onSkip} />}
           </div>
         </div>
 
-        <button type="button" onClick={onOpen} className="w-full text-left" aria-label={`Open details for ${title}`}>
+        <div className="w-full text-left" aria-label={`Summary for ${title}`}>
           <p className={`truncate text-sm font-medium leading-tight ${skipped ? "line-through opacity-80" : ""}`}>{title}</p>
           <p className="mt-1 text-2xl font-semibold leading-none tracking-tight">{session.duration}<span className="ml-1 text-sm font-medium text-muted">min</span></p>
           {session.linkedActivityCount ? (
@@ -735,9 +743,9 @@ function SortableSessionCard({
           ) : session.unassignedSameDayCount ? (
             <p className="mt-1 text-xs text-[hsl(var(--signal-load))]">{session.unassignedSameDayCount} unassigned activit{session.unassignedSameDayCount === 1 ? "y" : "ies"} on this day</p>
           ) : null}
-        </button>
+        </div>
       </div>
-      <button
+      {isReadOnly ? null : <button
         type="button"
         className="absolute right-2 bottom-2 rounded p-1 text-accent/70 opacity-0 transition-opacity group-hover:opacity-100 focus-visible:opacity-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[hsl(var(--accent-performance)/0.45)]"
         aria-label={`Drag ${title}`}
@@ -745,7 +753,7 @@ function SortableSessionCard({
         {...listeners}
       >
         ⋮⋮
-      </button>
+      </button>}
     </article>
   );
 }

--- a/lib/calendar/day-items.test.ts
+++ b/lib/calendar/day-items.test.ts
@@ -1,0 +1,110 @@
+import { buildCalendarDisplayItems } from "./day-items";
+
+describe("buildCalendarDisplayItems", () => {
+  it("marks a planned session completed when a linked activity exists", () => {
+    const items = buildCalendarDisplayItems({
+      sessions: [
+        {
+          id: "s1",
+          date: "2026-03-02",
+          sport: "run",
+          type: "Tempo",
+          duration_minutes: 45,
+          notes: null,
+          created_at: "2026-02-28T00:00:00.000Z"
+        }
+      ],
+      activities: [
+        {
+          id: "a1",
+          sport_type: "run",
+          start_time_utc: "2026-03-02T12:00:00.000Z",
+          duration_sec: 2700,
+          distance_m: 10000,
+          avg_hr: 150,
+          avg_power: null
+        }
+      ],
+      links: [{ planned_session_id: "s1", completed_activity_id: "a1" }],
+      legacyCompleted: [],
+      timeZone: "UTC",
+      weekStart: "2026-03-02",
+      weekEndExclusive: "2026-03-09"
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: "s1",
+      status: "completed",
+      displayType: "planned_session",
+      linkedActivityCount: 1
+    });
+  });
+
+  it("includes unlinked completed activity with completed_activity discriminator", () => {
+    const items = buildCalendarDisplayItems({
+      sessions: [],
+      activities: [
+        {
+          id: "a2",
+          sport_type: "bike",
+          start_time_utc: "2026-03-03T08:00:00.000Z",
+          duration_sec: 3600,
+          distance_m: 30000,
+          avg_hr: 140,
+          avg_power: 220
+        }
+      ],
+      links: [{ planned_session_id: null, completed_activity_id: "a2" }],
+      legacyCompleted: [],
+      timeZone: "UTC",
+      weekStart: "2026-03-02",
+      weekEndExclusive: "2026-03-09"
+    });
+
+    expect(items).toHaveLength(1);
+    expect(items[0]).toMatchObject({
+      id: "activity:a2",
+      date: "2026-03-03",
+      status: "completed",
+      displayType: "completed_activity"
+    });
+  });
+
+  it("returns mixed day view with timezone-aware unlinked activity grouping", () => {
+    const items = buildCalendarDisplayItems({
+      sessions: [
+        {
+          id: "s3",
+          date: "2026-03-02",
+          sport: "swim",
+          type: "Endurance",
+          duration_minutes: 50,
+          notes: null,
+          created_at: "2026-03-01T10:00:00.000Z"
+        }
+      ],
+      activities: [
+        {
+          id: "a3",
+          sport_type: "run",
+          start_time_utc: "2026-03-03T04:30:00.000Z",
+          duration_sec: 1800,
+          distance_m: 5000,
+          avg_hr: null,
+          avg_power: null
+        }
+      ],
+      links: [],
+      legacyCompleted: [],
+      timeZone: "America/Los_Angeles",
+      weekStart: "2026-03-02",
+      weekEndExclusive: "2026-03-09"
+    });
+
+    expect(items.map((item) => ({ id: item.id, date: item.date, displayType: item.displayType }))).toEqual([
+      { id: "s3", date: "2026-03-02", displayType: "planned_session" },
+      { id: "activity:a3", date: "2026-03-02", displayType: "completed_activity" }
+    ]);
+  });
+});

--- a/lib/calendar/day-items.ts
+++ b/lib/calendar/day-items.ts
@@ -1,0 +1,209 @@
+export type CalendarSessionRecord = {
+  id: string;
+  date: string;
+  sport: string;
+  type: string;
+  duration_minutes: number | null;
+  notes: string | null;
+  created_at: string;
+  status?: "planned" | "completed" | "skipped";
+  is_key?: boolean | null;
+};
+
+export type CalendarActivityRecord = {
+  id: string;
+  sport_type: string;
+  start_time_utc: string;
+  duration_sec: number | null;
+  distance_m: number | null;
+  avg_hr: number | null;
+  avg_power: number | null;
+};
+
+export type CalendarLinkRecord = {
+  planned_session_id: string | null;
+  completed_activity_id: string;
+};
+
+export type LegacyCompletedRecord = {
+  date: string;
+  sport: string;
+};
+
+export type CalendarDisplayItem = {
+  id: string;
+  date: string;
+  sport: string;
+  type: string;
+  duration: number;
+  notes: string | null;
+  created_at: string;
+  status: "planned" | "completed" | "skipped";
+  linkedActivityCount: number;
+  linkedStats: { durationMin: number; distanceKm: number; avgHr: number | null; avgPower: number | null } | null;
+  unassignedSameDayCount: number;
+  is_key: boolean;
+  displayType: "planned_session" | "completed_activity";
+};
+
+type ActivityItem = {
+  id: string;
+  date: string;
+  sport: string;
+  duration_min: number;
+  distance_km: number | null;
+  avg_hr: number | null;
+  avg_power: number | null;
+  created_at: string;
+};
+
+function isSkipped(notes: string | null) {
+  return /\[skipped\s\d{4}-\d{2}-\d{2}\]/i.test(notes ?? "");
+}
+
+function localIsoDate(utcIso: string, timeZone: string) {
+  const date = new Date(utcIso);
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  });
+  return formatter.format(date);
+}
+
+
+function dateInRange(date: string, start?: string, endExclusive?: string) {
+  if (start && date < start) return false;
+  if (endExclusive && date >= endExclusive) return false;
+  return true;
+}
+function fallbackStatus(
+  session: Pick<CalendarSessionRecord, "date" | "sport" | "notes" | "status">,
+  completionLedger: Record<string, number>
+) {
+  if (session.status) return session.status;
+  if (isSkipped(session.notes)) return "skipped";
+
+  const key = `${session.date}:${session.sport}`;
+  const completedCount = completionLedger[key] ?? 0;
+  if (completedCount > 0) {
+    completionLedger[key] = completedCount - 1;
+    return "completed";
+  }
+
+  return "planned";
+}
+
+export function buildCalendarDisplayItems(input: {
+  sessions: CalendarSessionRecord[];
+  activities: CalendarActivityRecord[];
+  links: CalendarLinkRecord[];
+  legacyCompleted: LegacyCompletedRecord[];
+  timeZone: string;
+  weekStart?: string;
+  weekEndExclusive?: string;
+}) {
+  const { sessions, activities, links, legacyCompleted, timeZone, weekStart, weekEndExclusive } = input;
+
+  const activityById = new Map<string, ActivityItem>(
+    activities
+      .map((activity) => ({ ...activity, localDate: localIsoDate(activity.start_time_utc, timeZone) }))
+      .filter((activity) => dateInRange(activity.localDate, weekStart, weekEndExclusive))
+      .map((activity) => [
+      activity.id,
+      {
+        id: activity.id,
+        date: activity.localDate,
+        sport: activity.sport_type,
+        duration_min: Math.round(Number(activity.duration_sec ?? 0) / 60),
+        distance_km: activity.distance_m ? Number(activity.distance_m) / 1000 : null,
+        avg_hr: activity.avg_hr,
+        avg_power: activity.avg_power,
+        created_at: activity.start_time_utc
+      }
+    ])
+  );
+
+  const linkedBySession = new Map<string, ActivityItem[]>();
+  const linkedActivityIds = new Set<string>();
+
+  links.forEach((link) => {
+    const activity = activityById.get(link.completed_activity_id);
+    if (!activity || !link.planned_session_id) return;
+    linkedActivityIds.add(activity.id);
+    const list = linkedBySession.get(link.planned_session_id) ?? [];
+    list.push(activity);
+    linkedBySession.set(link.planned_session_id, list);
+  });
+
+  const unassignedByDate = new Map<string, number>();
+  [...activityById.values()]
+    .filter((item) => !linkedActivityIds.has(item.id))
+    .forEach((item) => {
+      unassignedByDate.set(item.date, (unassignedByDate.get(item.date) ?? 0) + 1);
+    });
+
+  const completionLedger = legacyCompleted.reduce<Record<string, number>>((acc, item) => {
+    const key = `${item.date}:${item.sport}`;
+    acc[key] = (acc[key] ?? 0) + 1;
+    return acc;
+  }, {});
+
+  const plannedItems: CalendarDisplayItem[] = sessions.map((session) => {
+    const linked = linkedBySession.get(session.id) ?? [];
+    const linkedStats = linked[0]
+      ? {
+          durationMin: linked.reduce((sum, item) => sum + item.duration_min, 0),
+          distanceKm: linked.reduce((sum, item) => sum + (item.distance_km ?? 0), 0),
+          avgHr: linked[0].avg_hr,
+          avgPower: linked[0].avg_power
+        }
+      : null;
+
+    return {
+      id: session.id,
+      date: session.date,
+      sport: session.sport,
+      type: session.type,
+      duration: session.duration_minutes ?? 0,
+      notes: session.notes,
+      created_at: session.created_at,
+      status: linked.length > 0 ? "completed" : fallbackStatus(session, completionLedger),
+      linkedActivityCount: linked.length,
+      linkedStats,
+      unassignedSameDayCount: linked.length > 0 ? 0 : (unassignedByDate.get(session.date) ?? 0),
+      is_key: Boolean(session.is_key),
+      displayType: "planned_session"
+    };
+  });
+
+  const unlinkedActivityItems: CalendarDisplayItem[] = [...activityById.values()]
+    .filter((item) => !linkedActivityIds.has(item.id))
+    .map((item) => ({
+      id: `activity:${item.id}`,
+      date: item.date,
+      sport: item.sport,
+      type: "Completed activity",
+      duration: item.duration_min,
+      notes: null,
+      created_at: item.created_at,
+      status: "completed",
+      linkedActivityCount: 1,
+      linkedStats: {
+        durationMin: item.duration_min,
+        distanceKm: item.distance_km ?? 0,
+        avgHr: item.avg_hr,
+        avgPower: item.avg_power
+      },
+      unassignedSameDayCount: 0,
+      is_key: false,
+      displayType: "completed_activity"
+    }));
+
+  return [...plannedItems, ...unlinkedActivityItems].sort((a, b) => {
+    if (a.date !== b.date) return a.date.localeCompare(b.date);
+    if (a.displayType !== b.displayType) return a.displayType === "planned_session" ? -1 : 1;
+    return a.created_at.localeCompare(b.created_at);
+  });
+}


### PR DESCRIPTION
### Motivation
- Remove the previous requirement that completed activities must have a non-null `planned_session_id` to appear in plan/calendar views so unlinked completions are visible. 
- Ensure completed activities are grouped under the correct local day (respecting user timezone) and can mark planned sessions completed when linked. 
- Centralize the session/activity merging and display model to simplify view logic and make it easier to test (`buildCalendarDisplayItems`).

### Description
- Added a new builder `lib/calendar/day-items.ts` that merges planned sessions and completed activities into a single display list with a `displayType` discriminator (`planned_session` | `completed_activity`) and timezone-aware local-date grouping.  
- Updated the calendar page loader (`app/(protected)/calendar/page.tsx`) to call `buildCalendarDisplayItems`, widen the activity fetch window to handle timezone edge cases, and pass `weekStart`/`weekEndExclusive` + `timeZone` to the builder.  
- Adjusted the UI model/behavior in `app/(protected)/calendar/week-calendar.tsx` so `completed_activity` rows render read-only (non-draggable/non-editable) while planned sessions remain interactive.  
- Added regression tests in `lib/calendar/day-items.test.ts` covering linked completion, unlinked completion, and a mixed-day view that verifies timezone-aware grouping.

### Testing
- Ran unit tests with `npm test -- lib/calendar/day-items.test.ts` and the suite passed (3 tests).  
- Ran linting with `npm run -s lint` and there were no ESLint errors.  
- Attempted an automated Playwright screenshot of the running dev server, but the headless Chromium process crashed in this environment (SIGSEGV), so full end-to-end UI capture did not complete.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a49e71888332b238680f25447fdc)