### PR TITLE
Distinct completed-today next-action copy and test coverage

### DIFF
--- a/app/(protected)/dashboard/next-action-copy.test.ts
+++ b/app/(protected)/dashboard/next-action-copy.test.ts
@@ -24,4 +24,10 @@ describe("getWhyTodayMattersCopy", () => {
       "Why today matters: use the space to recover and protect your next key session."
     );
   });
+
+  it("returns completed-today copy when today's session is already done", () => {
+    expect(getWhyTodayMattersCopy(NEXT_ACTION_STATE.SESSION_DONE_TODAY)).toBe(
+      "Why today matters: you showed up today—recover well to reinforce consistency."
+    );
+  });
 });

--- a/app/(protected)/dashboard/next-action-copy.ts
+++ b/app/(protected)/dashboard/next-action-copy.ts
@@ -38,7 +38,7 @@ export function getWhyTodayMattersCopy(state: NextActionState, session?: NextAct
   }
 
   if (state === NEXT_ACTION_STATE.SESSION_DONE_TODAY) {
-    return "Why today matters: today’s work is done—lean into recovery so tomorrow starts strong.";
+    return "Why today matters: you showed up today—recover well to reinforce consistency.";
   }
 
   if (session?.is_key) {


### PR DESCRIPTION
### Motivation
- Provide a distinct reinforcement/recovery message for the completed-today state so completed sessions are encouraged to recover and reinforce consistency rather than being treated as an empty day.

### Description
- Update `getWhyTodayMattersCopy(...)` to return `"Why today matters: you showed up today—recover well to reinforce consistency."` for `NEXT_ACTION_STATE.SESSION_DONE_TODAY` and add a unit test in `app/(protected)/dashboard/next-action-copy.test.ts` asserting this behavior while keeping the existing `NO_SESSION_TODAY` assertion unchanged.

### Testing
- Ran `npm test -- next-action-copy.test.ts` which passed with 1 test suite and 4 tests (all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a63b220c8332a35fecefa8d27698)