### PR TITLE
Non-blocking activity matching with auditable confirmation flow

### DIFF
--- a/app/(protected)/activities/[activityId]/actions.ts
+++ b/app/(protected)/activities/[activityId]/actions.ts
@@ -19,10 +19,16 @@ export async function linkActivityAction(activityId: string, plannedSessionId: s
     completed_activity_id: activityId,
     link_type: "manual",
     confidence: 1,
-    match_reason: { source: "activity_details" }
+    match_reason: { source: "activity_details" },
+    confirmation_status: "confirmed",
+    matched_by: user.id,
+    matched_at: new Date().toISOString(),
+    match_method: "manual_override"
   });
 
   if (error) return { error: error.message };
+
+  await supabase.from("completed_activities").update({ schedule_status: "scheduled", is_unplanned: false }).eq("id", activityId).eq("user_id", user.id);
 
   revalidatePath(`/activities/${activityId}`);
   revalidatePath("/dashboard");
@@ -37,6 +43,8 @@ export async function unlinkActivityAction(activityId: string) {
   const { error } = await supabase.from("session_activity_links").delete().eq("user_id", user.id).eq("completed_activity_id", activityId);
   if (error) return { error: error.message };
 
+  await supabase.from("completed_activities").update({ schedule_status: "unscheduled" }).eq("id", activityId).eq("user_id", user.id);
+
   revalidatePath(`/activities/${activityId}`);
   revalidatePath("/dashboard");
   return { ok: true };
@@ -48,7 +56,7 @@ export async function markUnplannedAction(activityId: string) {
   if (!user) return { error: "Unauthorized" };
 
   await supabase.from("session_activity_links").delete().eq("user_id", user.id).eq("completed_activity_id", activityId);
-  const { error } = await supabase.from("completed_activities").update({ is_unplanned: true }).eq("id", activityId).eq("user_id", user.id);
+  const { error } = await supabase.from("completed_activities").update({ is_unplanned: true, schedule_status: "unscheduled" }).eq("id", activityId).eq("user_id", user.id);
   if (error) return { error: error.message };
 
   revalidatePath(`/activities/${activityId}`);

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -29,6 +29,8 @@ type CompletedActivity = {
   sport_type: string;
   start_time_utc: string;
   duration_sec: number;
+  schedule_status: "scheduled" | "unscheduled";
+  is_unplanned: boolean | null;
 };
 
 type Profile = {
@@ -110,11 +112,11 @@ export default async function DashboardPage({
     supabase.from("completed_sessions").select("date,sport").gte("date", weekStart).lt("date", weekEnd),
     supabase
       .from("completed_activities")
-      .select("id,sport_type,start_time_utc,duration_sec")
+      .select("id,sport_type,start_time_utc,duration_sec,schedule_status,is_unplanned")
       .eq("user_id", user.id)
       .gte("start_time_utc", `${weekStart}T00:00:00.000Z`)
       .lt("start_time_utc", `${weekEnd}T00:00:00.000Z`),
-    supabase.from("session_activity_links").select("completed_activity_id,planned_session_id").eq("user_id", user.id)
+    supabase.from("session_activity_links").select("completed_activity_id,planned_session_id,confirmation_status").eq("user_id", user.id)
   ]);
 
   const profile = (profileData ?? null) as Profile | null;
@@ -159,12 +161,13 @@ export default async function DashboardPage({
   }, {});
 
   const uploadedActivities = (completedActivities ?? []) as CompletedActivity[];
-  const links = (linksData ?? []) as Array<{ completed_activity_id: string; planned_session_id?: string | null }>;
-  const linkedActivityIds = new Set(links.map((item) => item.completed_activity_id));
-  const linkedSessionIds = new Set(links.map((item) => item.planned_session_id).filter((value): value is string => Boolean(value)));
+  const links = (linksData ?? []) as Array<{ completed_activity_id: string; planned_session_id?: string | null; confirmation_status?: "suggested" | "confirmed" | "rejected" | null }>;
+  const confirmedLinks = links.filter((item) => item.confirmation_status === "confirmed" || !item.confirmation_status);
+  const linkedActivityIds = new Set(confirmedLinks.map((item) => item.completed_activity_id));
+  const linkedSessionIds = new Set(confirmedLinks.map((item) => item.planned_session_id).filter((value): value is string => Boolean(value)));
 
   const durationByActivityId = new Map(uploadedActivities.map((activity) => [activity.id, Math.round((activity.duration_sec ?? 0) / 60)]));
-  const linkedMinutesBySession = links.reduce<Map<string, number>>((acc, link) => {
+  const linkedMinutesBySession = confirmedLinks.reduce<Map<string, number>>((acc, link) => {
     if (!link.planned_session_id) return acc;
     const minutes = durationByActivityId.get(link.completed_activity_id) ?? 0;
     acc.set(link.planned_session_id, (acc.get(link.planned_session_id) ?? 0) + minutes);
@@ -202,6 +205,8 @@ export default async function DashboardPage({
   }));
 
   const minuteMetrics = computeWeekMinuteTotals(weekMetricSessions);
+  const missedPlannedSessions = sessions.filter((session) => session.status === "planned").length;
+  const unmatchedExtraSessions = uploadedActivities.filter((activity) => (activity.schedule_status === "unscheduled" || !linkedActivityIds.has(activity.id)) && !activity.is_unplanned).length;
   const totals = { planned: minuteMetrics.plannedMinutes, completed: minuteMetrics.completedMinutes };
 
   const progressBySport = sports.map((sport) => {
@@ -289,6 +294,8 @@ export default async function DashboardPage({
           plannedTimeLabel={toHoursAndMinutes(totals.planned)}
           remainingTimeLabel={toHoursAndMinutes(remainingMinutes)}
           statusLabel={progressStatus}
+          missedPlannedCount={missedPlannedSessions}
+          unmatchedExtraCount={unmatchedExtraSessions}
         />
 
         <article className="priority-card-primary">

--- a/app/(protected)/dashboard/progress-glance-card.tsx
+++ b/app/(protected)/dashboard/progress-glance-card.tsx
@@ -6,6 +6,8 @@ type ProgressGlanceCardProps = {
   plannedTimeLabel: string;
   remainingTimeLabel: string;
   statusLabel: "Ahead" | "On track" | "Behind plan";
+  unmatchedExtraCount: number;
+  missedPlannedCount: number;
 };
 
 export function ProgressGlanceCard({
@@ -13,7 +15,9 @@ export function ProgressGlanceCard({
   completedTimeLabel,
   plannedTimeLabel,
   remainingTimeLabel,
-  statusLabel
+  statusLabel,
+  unmatchedExtraCount,
+  missedPlannedCount
 }: ProgressGlanceCardProps) {
   const ringPct = Math.max(0, Math.min(completionPct, 100));
   const statusClassName = statusLabel === "Ahead"
@@ -40,7 +44,7 @@ export function ProgressGlanceCard({
 
           <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold text-[hsl(var(--fg))]">{completedTimeLabel} / {plannedTimeLabel}</p>
-            <p className="text-xs text-muted">{remainingTimeLabel} remaining</p>
+            <p className="text-xs text-muted">{remainingTimeLabel} remaining • {unmatchedExtraCount} unmatched extras • {missedPlannedCount} missed planned</p>
           </div>
 
           <div className="text-right">

--- a/app/(protected)/settings/integrations/activity-uploads-panel.tsx
+++ b/app/(protected)/settings/integrations/activity-uploads-panel.tsx
@@ -11,7 +11,7 @@ type UploadRow = {
   status: "uploaded" | "parsed" | "matched" | "error";
   error_message: string | null;
   completed_activities: { id: string; sport_type: string; duration_sec: number; distance_m: number | null; schedule_status: "scheduled" | "unscheduled" }[];
-  session_activity_links: { planned_session_id: string | null }[];
+  session_activity_links: { planned_session_id: string | null; confirmation_status: "suggested" | "confirmed" | "rejected" }[];
 };
 
 type PlannedSession = { id: string; date: string; sport: string; type: string; duration: number };
@@ -125,14 +125,16 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions }: { init
           <tbody>
             {uploads.map((upload) => {
               const activity = upload.completed_activities[0];
-              const linked = activity?.schedule_status === "scheduled" || upload.status === "matched" || upload.session_activity_links.some((link) => Boolean(link.planned_session_id));
+              const hasConfirmedLink = upload.session_activity_links.some((link) => Boolean(link.planned_session_id) && link.confirmation_status === "confirmed");
+              const hasSuggestion = upload.session_activity_links.some((link) => Boolean(link.planned_session_id) && link.confirmation_status === "suggested");
+              const linked = activity?.schedule_status === "scheduled" || upload.status === "matched" || hasConfirmedLink;
               return (
                 <tr key={upload.id} className="border-t border-white/10">
                   <td className="py-2">{formatUploadDate(upload.created_at)}</td>
                   <td>{activity?.sport_type ?? "—"}</td>
                   <td>{fmtDuration(activity?.duration_sec)}</td>
                   <td>{activity?.distance_m ? `${(Number(activity.distance_m) / 1000).toFixed(2)} km` : "—"}</td>
-                  <td>{upload.status === "error" ? "Error" : linked ? "Scheduled" : "Unscheduled"}</td>
+                  <td>{upload.status === "error" ? "Error" : linked ? "Scheduled" : hasSuggestion ? "Suggested" : "Unscheduled"}</td>
                   <td className="space-x-2 text-xs">
                     {activity?.id ? <Link className="text-cyan-300 underline" href={`/activities/${activity.id}`}>View activity</Link> : <button className="text-cyan-300 underline" onClick={() => setDetailId(upload.id)}>View details</button>}
                     {!linked && upload.status !== "error" ? (
@@ -193,7 +195,7 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions }: { init
                         const response = await fetch(`/api/uploads/activities/${attachFor.id}/attach`, {
                           method: "POST",
                           headers: { "Content-Type": "application/json" },
-                          body: JSON.stringify({ plannedSessionId: candidate.id })
+                          body: JSON.stringify({ plannedSessionId: candidate.id, mode: "override", actor: "athlete" })
                         });
 
                         if (!response.ok) {

--- a/app/(protected)/settings/integrations/page.tsx
+++ b/app/(protected)/settings/integrations/page.tsx
@@ -9,7 +9,7 @@ type UploadRow = {
   status: "uploaded" | "parsed" | "matched" | "error";
   error_message: string | null;
   completed_activities: { id: string; sport_type: string; duration_sec: number; distance_m: number | null; schedule_status: "scheduled" | "unscheduled" }[];
-  session_activity_links: { planned_session_id: string | null }[];
+  session_activity_links: { planned_session_id: string | null; confirmation_status: "suggested" | "confirmed" | "rejected" }[];
 };
 
 type PlannedCandidate = {
@@ -59,7 +59,7 @@ export default async function IntegrationsPage() {
     uploadIds.length
       ? supabase
           .from("session_activity_links")
-          .select("planned_session_id,completed_activity_id")
+          .select("planned_session_id,completed_activity_id,confirmation_status")
           .eq("user_id", user.id)
       : Promise.resolve({ data: [] as any[] }),
     supabase
@@ -100,7 +100,7 @@ export default async function IntegrationsPage() {
   const linksByActivityId = new Map<string, UploadRow["session_activity_links"]>();
   (links ?? []).forEach((link: any) => {
     const list = linksByActivityId.get(link.completed_activity_id) ?? [];
-    list.push({ planned_session_id: link.planned_session_id });
+    list.push({ planned_session_id: link.planned_session_id, confirmation_status: link.confirmation_status ?? "confirmed" });
     linksByActivityId.set(link.completed_activity_id, list);
   });
 

--- a/app/api/uploads/activities/[uploadId]/attach/route.ts
+++ b/app/api/uploads/activities/[uploadId]/attach/route.ts
@@ -2,7 +2,11 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
 
-const schema = z.object({ plannedSessionId: z.string().uuid() });
+const schema = z.object({
+  plannedSessionId: z.string().uuid(),
+  actor: z.enum(["coach", "athlete"]).default("athlete"),
+  mode: z.enum(["confirm", "override"]).default("override")
+});
 
 export async function POST(request: Request, { params }: { params: { uploadId: string } }) {
   const supabase = await createClient();
@@ -38,7 +42,15 @@ export async function POST(request: Request, { params }: { params: { uploadId: s
     completed_activity_id: activity.id,
     link_type: "manual",
     confidence: 1,
-    match_reason: { source: "manual_attach" }
+    match_reason: { source: "manual_attach" },
+    confirmation_status: "confirmed",
+    matched_by: user.id,
+    matched_at: new Date().toISOString(),
+    match_method: body.data.mode === "confirm"
+      ? body.data.actor === "coach"
+        ? "coach_confirmed"
+        : "athlete_confirmed"
+      : "manual_override"
   });
 
   if (error) return NextResponse.json({ error: error.message }, { status: 400 });

--- a/app/api/uploads/activities/route.ts
+++ b/app/api/uploads/activities/route.ts
@@ -1,8 +1,8 @@
 import { Buffer } from "node:buffer";
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { pickAutoMatch, scoreCandidate } from "@/lib/workouts/activity-matching";
 import { parseFitFile, parseTcxFile, sha256Hex } from "@/lib/workouts/activity-parser";
+import { pickBestSuggestion, suggestSessionMatches } from "@/lib/workouts/matching-service";
 
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
 const acceptedExtensions = [".fit", ".tcx"];
@@ -107,49 +107,46 @@ export async function POST(request: Request) {
       .gte("date", windowStart.slice(0, 10))
       .lte("date", windowEnd.slice(0, 10));
 
-    const scored = (candidates ?? []).map((candidate) =>
-      scoreCandidate(
-        {
-          sportType: createdActivity.sport_type,
-          startTimeUtc: createdActivity.start_time_utc,
-          durationSec: createdActivity.duration_sec,
-          distanceM: Number(createdActivity.distance_m ?? 0)
-        },
-        {
-          id: candidate.id,
-          sport: candidate.sport,
-          startTimeUtc: `${candidate.date}T06:00:00.000Z`,
-          targetDurationSec: candidate.duration_minutes ? candidate.duration_minutes * 60 : null,
-          targetDistanceM: null
-        }
-      )
+    const suggestions = suggestSessionMatches(
+      {
+        id: createdActivity.id,
+        userId: user.id,
+        sportType: createdActivity.sport_type,
+        startTimeUtc: createdActivity.start_time_utc,
+        durationSec: createdActivity.duration_sec,
+        distanceM: Number(createdActivity.distance_m ?? 0)
+      },
+      (candidates ?? []).map((candidate) => ({
+        id: candidate.id,
+        userId: user.id,
+        date: candidate.date,
+        sport: candidate.sport,
+        type: candidate.sport,
+        durationMinutes: candidate.duration_minutes,
+        distanceM: null
+      }))
     );
 
-    const best = pickAutoMatch(scored);
-    let matched = false;
+    const best = pickBestSuggestion(suggestions);
+    let suggested = false;
     if (best) {
       const { error: linkError } = await supabase.from("session_activity_links").insert({
         user_id: user.id,
-        planned_session_id: best.candidateId,
+        planned_session_id: best.plannedSessionId,
         completed_activity_id: createdActivity.id,
         link_type: "auto",
-        confidence: Number(best.confidence.toFixed(2)),
-        match_reason: best.reason
+        confidence: best.confidence,
+        match_reason: best.reason,
+        confirmation_status: "suggested",
+        match_method: best.matchMethod
       });
 
       if (!linkError) {
-        matched = true;
-        await supabase
-          .from("completed_activities")
-          .update({ schedule_status: "scheduled" })
-          .eq("id", createdActivity.id)
-          .eq("user_id", user.id);
-
-        await supabase.from("activity_uploads").update({ status: "matched" }).eq("id", upload.id).eq("user_id", user.id);
+        suggested = true;
       }
     }
 
-    return NextResponse.json({ uploadId: upload.id, completedActivityId: createdActivity.id, matched });
+    return NextResponse.json({ uploadId: upload.id, completedActivityId: createdActivity.id, suggested });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Failed to parse file";
     await supabase.from("activity_uploads").update({ status: "error", error_message: message }).eq("id", upload.id).eq("user_id", user.id);

--- a/lib/workouts/activity-details.ts
+++ b/lib/workouts/activity-details.ts
@@ -65,12 +65,12 @@ export async function loadActivityDetails(activityId: string): Promise<ActivityD
 
   const { data: existingLinks } = await supabase
     .from("session_activity_links")
-    .select("planned_session_id,confidence")
+    .select("planned_session_id,confidence,confirmation_status")
     .eq("user_id", user.id)
     .eq("completed_activity_id", activity.id)
     .limit(1);
 
-  const link = existingLinks?.[0] ?? null;
+  const link = existingLinks?.find((item: any) => item.confirmation_status === "confirmed") ?? null;
   const activityStart = new Date(activity.start_time_utc);
   const windowStart = new Date(activityStart.getTime() - 6 * 3600 * 1000).toISOString();
   const windowEnd = new Date(activityStart.getTime() + 6 * 3600 * 1000).toISOString();

--- a/lib/workouts/activity-matching.test.ts
+++ b/lib/workouts/activity-matching.test.ts
@@ -55,5 +55,5 @@ test("score candidate tolerates missing distance", () => {
     { id: "s1", sport: "strength", startTimeUtc: "2026-02-22T10:05:00.000Z", targetDurationSec: 3000 }
   );
 
-  assert.ok(score.confidence > 0.7);
+  expect(score.confidence).toBeGreaterThan(0.7);
 });

--- a/lib/workouts/matching-service.test.ts
+++ b/lib/workouts/matching-service.test.ts
@@ -1,0 +1,81 @@
+import { pickBestSuggestion, suggestSessionMatches } from './matching-service';
+
+describe('matching service', () => {
+  test('keeps matching non-blocking by returning suggestions without forcing confirmation', () => {
+    const suggestions = suggestSessionMatches(
+      {
+        id: 'a1',
+        userId: 'user-1',
+        sportType: 'run',
+        startTimeUtc: '2026-03-10T06:30:00.000Z',
+        durationSec: 3600,
+        distanceM: 10000
+      },
+      [
+        {
+          id: 's1',
+          userId: 'user-1',
+          date: '2026-03-10',
+          sport: 'run',
+          type: 'run',
+          durationMinutes: 58,
+          distanceM: 10000,
+          startTimeUtc: '2026-03-10T06:00:00.000Z'
+        }
+      ]
+    );
+
+    expect(suggestions).toHaveLength(1);
+    expect(suggestions[0]?.matchMethod).toBe('tolerance_auto');
+    expect(suggestions[0]?.confidence).toBeGreaterThan(0.8);
+  });
+
+  test('filters out candidates that fail athlete/date/type/duration tolerances', () => {
+    const suggestions = suggestSessionMatches(
+      {
+        id: 'a1',
+        userId: 'athlete-1',
+        sportType: 'bike',
+        startTimeUtc: '2026-03-10T06:30:00.000Z',
+        durationSec: 5400
+      },
+      [
+        {
+          id: 'wrong-user',
+          userId: 'athlete-2',
+          date: '2026-03-10',
+          sport: 'bike',
+          type: 'bike',
+          durationMinutes: 90
+        },
+        {
+          id: 'wrong-sport',
+          userId: 'athlete-1',
+          date: '2026-03-10',
+          sport: 'run',
+          type: 'run',
+          durationMinutes: 90
+        },
+        {
+          id: 'wrong-duration',
+          userId: 'athlete-1',
+          date: '2026-03-10',
+          sport: 'bike',
+          type: 'bike',
+          durationMinutes: 40
+        }
+      ]
+    );
+
+    expect(suggestions).toHaveLength(0);
+  });
+
+  test('selects only clear best suggestion', () => {
+    const best = pickBestSuggestion([
+      { plannedSessionId: 's1', confidence: 0.93, reason: {}, matchMethod: 'tolerance_auto' },
+      { plannedSessionId: 's2', confidence: 0.65, reason: {}, matchMethod: 'tolerance_auto' }
+    ]);
+
+    expect(best?.plannedSessionId).toBe('s1');
+  });
+});

--- a/lib/workouts/matching-service.ts
+++ b/lib/workouts/matching-service.ts
@@ -1,0 +1,117 @@
+import { pickAutoMatch, scoreCandidate } from "@/lib/workouts/activity-matching";
+
+export type ActivityForMatching = {
+  id: string;
+  userId: string;
+  sportType: string;
+  startTimeUtc: string;
+  durationSec: number;
+  distanceM?: number | null;
+};
+
+export type PlannedSessionForMatching = {
+  id: string;
+  userId: string;
+  date: string;
+  sport: string;
+  type: string;
+  durationMinutes: number | null;
+  distanceM?: number | null;
+  startTimeUtc?: string | null;
+};
+
+export type MatchSuggestion = {
+  plannedSessionId: string;
+  confidence: number;
+  matchMethod: "tolerance_auto";
+  reason: Record<string, number | string | boolean>;
+};
+
+const DEFAULT_TOLERANCES = {
+  dateWindowHours: 18,
+  durationDeltaPct: 0.35,
+  minConfidence: 0.65
+};
+
+function toCandidateStartTime(session: PlannedSessionForMatching) {
+  return session.startTimeUtc ?? `${session.date}T06:00:00.000Z`;
+}
+
+export function suggestSessionMatches(activity: ActivityForMatching, candidates: PlannedSessionForMatching[]): MatchSuggestion[] {
+  const activityStartMs = Date.parse(activity.startTimeUtc);
+
+  const eligible = candidates.filter((candidate) => {
+    if (candidate.userId !== activity.userId) {
+      return false;
+    }
+
+    if (candidate.sport !== activity.sportType) {
+      return false;
+    }
+
+    const candidateStartMs = Date.parse(toCandidateStartTime(candidate));
+    const hourDiff = Math.abs(activityStartMs - candidateStartMs) / 3_600_000;
+    if (hourDiff > DEFAULT_TOLERANCES.dateWindowHours) {
+      return false;
+    }
+
+    if (candidate.durationMinutes && candidate.durationMinutes > 0) {
+      const plannedDurationSec = candidate.durationMinutes * 60;
+      const durationDelta = Math.abs(activity.durationSec - plannedDurationSec) / plannedDurationSec;
+      if (durationDelta > DEFAULT_TOLERANCES.durationDeltaPct) {
+        return false;
+      }
+    }
+
+    return true;
+  });
+
+  return eligible
+    .map((candidate) => {
+      const scored = scoreCandidate(
+        {
+          sportType: activity.sportType,
+          startTimeUtc: activity.startTimeUtc,
+          durationSec: activity.durationSec,
+          distanceM: Number(activity.distanceM ?? 0)
+        },
+        {
+          id: candidate.id,
+          sport: candidate.sport,
+          startTimeUtc: toCandidateStartTime(candidate),
+          targetDurationSec: candidate.durationMinutes ? candidate.durationMinutes * 60 : null,
+          targetDistanceM: Number(candidate.distanceM ?? 0) || null
+        }
+      );
+
+      return {
+        plannedSessionId: candidate.id,
+        confidence: Number(scored.confidence.toFixed(2)),
+        reason: {
+          ...scored.reason,
+          durationWithinTolerance: true,
+          dateWithinTolerance: true,
+          typeMatches: candidate.type === activity.sportType
+        },
+        matchMethod: "tolerance_auto" as const
+      };
+    })
+    .filter((suggestion) => suggestion.confidence >= DEFAULT_TOLERANCES.minConfidence)
+    .sort((a, b) => b.confidence - a.confidence);
+}
+
+export function pickBestSuggestion(suggestions: MatchSuggestion[]) {
+  const selected = pickAutoMatch(
+    suggestions.map((suggestion) => ({
+      candidateId: suggestion.plannedSessionId,
+      confidence: suggestion.confidence,
+      reason: suggestion.reason
+    }))
+  );
+
+  if (!selected) {
+    return null;
+  }
+
+  return suggestions.find((item) => item.plannedSessionId === selected.candidateId) ?? null;
+}

--- a/supabase/migrations/202603010002_non_blocking_matching_audit.sql
+++ b/supabase/migrations/202603010002_non_blocking_matching_audit.sql
@@ -1,0 +1,24 @@
+alter table public.session_activity_links
+  add column if not exists confirmation_status text
+    check (confirmation_status in ('suggested','confirmed','rejected'))
+    default 'confirmed',
+  add column if not exists matched_by uuid references auth.users(id) on delete set null,
+  add column if not exists matched_at timestamptz,
+  add column if not exists match_method text
+    check (match_method in ('tolerance_auto','coach_confirmed','athlete_confirmed','manual_override','unmatched'));
+
+update public.session_activity_links
+set confirmation_status = coalesce(confirmation_status, 'confirmed'),
+    matched_at = coalesce(matched_at, created_at),
+    match_method = coalesce(match_method, case when link_type = 'auto' then 'tolerance_auto' else 'manual_override' end)
+where confirmation_status is null
+   or match_method is null;
+
+alter table public.session_activity_links
+  alter column confirmation_status set not null;
+
+create index if not exists session_activity_links_confirmation_idx
+  on public.session_activity_links(user_id, confirmation_status, created_at desc);
+
+create index if not exists session_activity_links_match_method_idx
+  on public.session_activity_links(user_id, match_method, created_at desc);


### PR DESCRIPTION
### Motivation

- Allow ingested activities to be visible immediately while still suggesting links to planned sessions rather than forcing automatic scheduling.  
- Provide confidence-scored suggestions using athlete/date/type/duration tolerances so coaches/athletes can confirm or override matches.  
- Capture audit metadata for reporting and historical analysis of how matches were made.  
- Distinguish unmatched extra activities from missed planned sessions in compliance metrics.

### Description

- Added a dedicated matching service `lib/workouts/matching-service.ts` that applies athlete/date/type/duration tolerances, scores candidates using `scoreCandidate`, and returns ranked `tolerance_auto` suggestions.  
- Changed ingestion in `app/api/uploads/activities/route.ts` to persist top suggestions as `session_activity_links` with `confirmation_status = 'suggested'` (and `match_method`/`confidence`/`match_reason`) while keeping the activity `schedule_status = 'unscheduled'`.  
- Introduced an audit migration `supabase/migrations/202603010002_non_blocking_matching_audit.sql` to add `confirmation_status`, `matched_by`, `matched_at`, and `match_method` to `session_activity_links` and to backfill/index values for reporting.  
- Updated manual attach/link flows and activity actions (`app/api/uploads/activities/[uploadId]/attach/route.ts` and `app/(protected)/activities/[activityId]/actions.ts`) to record `confirmation_status`, `matched_by`, `matched_at`, and `match_method`, and to set `schedule_status`/`is_unplanned` appropriately.  
- Updated UI and loaders (`app/(protected)/settings/integrations/*.tsx`, `lib/workouts/activity-details.ts`, and `app/(protected)/dashboard/*`) to treat suggested links separately from confirmed links and to surface suggestion state to users.  
- Updated dashboard compliance calculations to compute `missedPlannedSessions` and `unmatchedExtraSessions` and surfaced both counts in the progress glance component.  
- Added unit tests for the new service in `lib/workouts/matching-service.test.ts` and small adjustments to `lib/workouts/activity-matching.test.ts` for consistent assertions.

### Testing

- Ran `npm run typecheck` and it completed successfully.  
- Ran the unit tests with `npm test -- lib/workouts/activity-matching.test.ts lib/workouts/matching-service.test.ts` and both test suites passed.  
- Ran `npm run lint` (Next.js lint) with no ESLint errors.  
- Attempted to run the dev server (`next dev`) and capture UI screenshots, but runtime rendering of protected pages failed in this environment due to missing Supabase environment variables (expected for local dev), so full integration verification of the UI was not possible here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a5da6178833284da22fb77281c98)