### PR TITLE
Remove unused 'Primary nav' text from protected sidebar

### DIFF
--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -93,10 +93,7 @@ export default async function ProtectedLayout({ children }: { children: React.Re
               <ShellNavRail compact />
             </div>
             <div className="hidden xl:block">
-              <p className="text-xs uppercase tracking-[0.16em] text-accent">Primary nav</p>
-              <div className="mt-2">
-                <ShellNavRail />
-              </div>
+              <ShellNavRail />
             </div>
 
             <div className="hidden xl:block surface-subtle p-3">


### PR DESCRIPTION
### Motivation
- The desktop sidebar included an unnecessary "Primary nav" helper label which added visual clutter, so it was removed to simplify the layout.

### Description
- Updated `app/(protected)/layout.tsx` to remove the `<p className="text-xs uppercase tracking-[0.16em] text-accent">Primary nav</p>` and its wrapper, rendering `ShellNavRail` directly instead.

### Testing
- Ran `npm run lint` (Next.js ESLint) which completed with no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a6df87788332a29112b7c007ba48)