### PR TITLE
Distinguish planned vs unscheduled (extra) work in calendar & reports

### DIFF
--- a/app/(protected)/activities/[activityId]/page.tsx
+++ b/app/(protected)/activities/[activityId]/page.tsx
@@ -62,7 +62,9 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
                 <div className="mt-2 flex gap-2 text-xs">
                   <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">{activity.source === "upload" ? "Garmin upload" : "Synced"}</span>
                   <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">{linkedSession ? "Linked" : "Unassigned"}</span>
+                  {!linkedSession ? <span className="rounded-full border border-[hsl(var(--signal-risk)/0.5)] bg-[hsl(var(--signal-risk)/0.12)] px-2 py-1 text-[hsl(var(--signal-risk))]">Unscheduled</span> : null}
                 </div>
+                {!linkedSession ? <p className="mt-2 text-xs text-muted">This uploaded activity counts as extra work even without a planned slot.</p> : null}
               </div>
             </div>
           </article>

--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -152,8 +152,11 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     weekEndExclusive: weekEnd
   });
 
+  const plannedSessions = sessions.filter((item) => item.displayType === "planned_session");
+  const extraSessionCount = sessions.filter((item) => item.displayType === "completed_activity").length;
+
   const countMetrics = computeWeekSessionCounts(
-    sessions.map((session) => ({
+    plannedSessions.map((session) => ({
       id: session.id,
       date: session.date,
       sport: session.sport,
@@ -163,7 +166,7 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     }))
   );
   const minuteMetrics = computeWeekMinuteTotals(
-    sessions.map((session) => ({
+    plannedSessions.map((session) => ({
       id: session.id,
       date: session.date,
       sport: session.sport,
@@ -172,7 +175,6 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       isKey: session.is_key
     }))
   );
-  const unmatchedUploads = sessions.filter((item) => item.displayType === "completed_activity").length;
   const todayIso = new Date().toISOString().slice(0, 10);
   const nextTodaySession = sessions.find((session) => session.date === todayIso && session.status === "planned") ?? null;
 
@@ -183,10 +185,11 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
         weekDays={weekDays}
         sessions={sessions}
         executionLabel={nextTodaySession ? `Next key session: ${nextTodaySession.type}` : "No planned session today"}
-        executionSubtext={unmatchedUploads > 0 ? `${unmatchedUploads} uploads need matching.` : "Uploads and schedule aligned"}
+        executionSubtext={extraSessionCount > 0 ? `${extraSessionCount} unscheduled uploads count as extra work.` : "Uploads and schedule aligned"}
         completedCount={countMetrics.completedCount}
         plannedTotalCount={countMetrics.plannedTotalCount}
         skippedCount={countMetrics.skippedCount}
+        extraSessionCount={extraSessionCount}
         plannedRemainingCount={countMetrics.plannedRemainingCount}
         plannedMinutes={minuteMetrics.plannedMinutes}
         completedMinutes={minuteMetrics.completedMinutes}

--- a/app/(protected)/calendar/week-calendar.test.tsx
+++ b/app/(protected)/calendar/week-calendar.test.tsx
@@ -1,0 +1,84 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { WeekCalendar } from "./week-calendar";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: jest.fn() })
+}));
+
+jest.mock("./actions", () => ({
+  clearSkippedAction: jest.fn(),
+  markSkippedAction: jest.fn(),
+  moveSessionAction: jest.fn(),
+  quickAddSessionAction: jest.fn(),
+  swapSessionDayAction: jest.fn(),
+  updateSessionAction: jest.fn()
+}));
+
+const weekDays = [
+  { iso: "2026-03-02", weekday: "Mon", label: "Mar 2" },
+  { iso: "2026-03-03", weekday: "Tue", label: "Mar 3" },
+  { iso: "2026-03-04", weekday: "Wed", label: "Mar 4" },
+  { iso: "2026-03-05", weekday: "Thu", label: "Mar 5" },
+  { iso: "2026-03-06", weekday: "Fri", label: "Mar 6" },
+  { iso: "2026-03-07", weekday: "Sat", label: "Mar 7" },
+  { iso: "2026-03-08", weekday: "Sun", label: "Mar 8" }
+];
+
+const sessions = [
+  {
+    id: "s1",
+    date: "2026-03-02",
+    sport: "run",
+    type: "Tempo",
+    duration: 45,
+    notes: null,
+    created_at: "2026-03-01T00:00:00.000Z",
+    status: "planned" as const,
+    displayType: "planned_session" as const,
+    is_key: false
+  },
+  {
+    id: "activity:a1",
+    date: "2026-03-02",
+    sport: "run",
+    type: "Completed activity",
+    duration: 35,
+    notes: null,
+    created_at: "2026-03-02T08:00:00.000Z",
+    status: "completed" as const,
+    displayType: "completed_activity" as const,
+    linkedActivityCount: 1,
+    linkedStats: { durationMin: 35, distanceKm: 7, avgHr: 150, avgPower: null },
+    is_key: false
+  }
+];
+
+describe("WeekCalendar", () => {
+  it("renders extra session label and filters unscheduled sessions", () => {
+    render(
+      <WeekCalendar
+        weekDays={weekDays}
+        sessions={sessions}
+        executionLabel="Execution"
+        completedCount={1}
+        plannedTotalCount={1}
+        skippedCount={0}
+        extraSessionCount={1}
+        plannedRemainingCount={1}
+        plannedMinutes={45}
+        completedMinutes={35}
+        remainingMinutes={10}
+      />
+    );
+
+    expect(screen.getByText("Extra session")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Work filter"), { target: { value: "unscheduled" } });
+    expect(screen.queryByText("Tempo")).not.toBeInTheDocument();
+    expect(screen.getByText("Completed activity")).toBeInTheDocument();
+
+    fireEvent.change(screen.getByLabelText("Work filter"), { target: { value: "planned" } });
+    expect(screen.getByText("Tempo")).toBeInTheDocument();
+    expect(screen.queryByText("Completed activity")).not.toBeInTheDocument();
+  });
+});

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -30,6 +30,7 @@ import {
 type SessionStatus = "planned" | "completed" | "skipped";
 type FilterStatus = "all" | SessionStatus;
 type SportFilter = "all" | "swim" | "bike" | "run" | "strength";
+type WorkFilter = "all" | "planned" | "unscheduled";
 
 type CalendarSession = {
   id: string;
@@ -107,6 +108,7 @@ export function WeekCalendar({
   completedCount,
   plannedTotalCount,
   skippedCount,
+  extraSessionCount,
   plannedRemainingCount,
   plannedMinutes,
   completedMinutes,
@@ -119,6 +121,7 @@ export function WeekCalendar({
   completedCount: number;
   plannedTotalCount: number;
   skippedCount: number;
+  extraSessionCount: number;
   plannedRemainingCount: number;
   plannedMinutes: number;
   completedMinutes: number;
@@ -127,6 +130,7 @@ export function WeekCalendar({
   const router = useRouter();
   const [sportFilter, setSportFilter] = useState<SportFilter>("all");
   const [statusFilter, setStatusFilter] = useState<FilterStatus>("all");
+  const [workFilter, setWorkFilter] = useState<WorkFilter>("all");
   const [expandedDays, setExpandedDays] = useState<Record<string, boolean>>({});
   const [quickAddState, setQuickAddState] = useState<{ initialDate: string; allowDaySelection: boolean } | null>(null);
   const [swapSource, setSwapSource] = useState<CalendarSession | null>(null);
@@ -175,11 +179,15 @@ export function WeekCalendar({
         if (!session) return false;
         const sportMatch = sportFilter === "all" || session.sport === sportFilter;
         const statusMatch = statusFilter === "all" || session.status === statusFilter;
-        return sportMatch && statusMatch;
+        const workMatch =
+          workFilter === "all" ||
+          (workFilter === "planned" && session.displayType === "planned_session") ||
+          (workFilter === "unscheduled" && session.displayType === "completed_activity");
+        return sportMatch && statusMatch && workMatch;
       });
       return acc;
     }, {});
-  }, [orderByDay, sessionsById, sportFilter, statusFilter, weekDays]);
+  }, [orderByDay, sessionsById, sportFilter, statusFilter, weekDays, workFilter]);
 
 
   const progressBySport = useMemo(
@@ -350,6 +358,7 @@ export function WeekCalendar({
           <span className="signal-chip signal-ready">Completed {completedCount}</span>
           <span className="signal-chip signal-load">Planned {plannedTotalCount}</span>
           <span className="signal-chip signal-risk">Skipped {skippedCount}</span>
+          <span className="signal-chip border-[hsl(var(--signal-risk)/0.45)] bg-[hsl(var(--signal-risk)/0.12)] text-[hsl(var(--signal-risk))]">Extra sessions {extraSessionCount}</span>
         </div>
       </div>
 
@@ -357,6 +366,11 @@ export function WeekCalendar({
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className="text-xs uppercase tracking-[0.14em] text-accent">Week of {dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))}–{dayFormatter.format(new Date(`${weekDays[6].iso}T00:00:00.000Z`))}</p>
           <div className="flex items-center gap-2">
+            <select aria-label="Work filter" value={workFilter} onChange={(e) => setWorkFilter(e.target.value as WorkFilter)} className="input-base w-auto py-1 text-xs">
+              <option value="all">All work</option>
+              <option value="planned">Planned only</option>
+              <option value="unscheduled">Unscheduled only</option>
+            </select>
             <select aria-label="Status filter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as FilterStatus)} className="input-base w-auto py-1 text-xs">
               <option value="all">All statuses</option>
               <option value="planned">Pending</option>
@@ -447,9 +461,12 @@ export function WeekCalendar({
                   <SortableContext items={ids} strategy={verticalListSortingStrategy}>
                     <div className="mt-2 space-y-2">
                       {visibleIds.length === 0 ? (
-                        <button onClick={() => setQuickAddState({ initialDate: day.iso, allowDaySelection: false })} className="w-full rounded-xl border border-dashed border-[hsl(var(--border))] px-2 py-6 text-xs text-muted hover:border-[hsl(var(--accent-performance)/0.45)] hover:text-accent">
-                          + Add
-                        </button>
+                        <div className="space-y-2">
+                          <button onClick={() => setQuickAddState({ initialDate: day.iso, allowDaySelection: false })} className="w-full rounded-xl border border-dashed border-[hsl(var(--border))] px-2 py-6 text-xs text-muted hover:border-[hsl(var(--accent-performance)/0.45)] hover:text-accent">
+                            + Add
+                          </button>
+                          <p className="text-[11px] text-muted">Uploaded sessions still count, even with no planned slot.</p>
+                        </div>
                       ) : (
                         visibleIds.map((id) => {
                           const session = sessionsById[id];
@@ -719,6 +736,7 @@ function SortableSessionCard({
           <div className="flex min-w-0 flex-wrap items-center gap-1.5">
             <span title={`${discipline.label} · ${discipline.shape}`} className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] ${discipline.className} ${discipline.textureClassName}`}><span aria-hidden="true">{discipline.icon}</span><span>{discipline.label}</span></span>
             <SessionStatusChip status={session.status} compact />
+            {session.displayType === "completed_activity" ? <span className="rounded-full border border-[hsl(var(--signal-risk)/0.55)] px-2 py-0.5 text-[10px] font-semibold text-[hsl(var(--signal-risk))]">Extra session</span> : null}
             {session.is_key ? <span className="rounded-full border border-[hsl(var(--accent-performance)/0.5)] px-2 py-0.5 text-[10px] font-semibold text-accent">Key</span> : null}
           </div>
           <div className="flex items-center gap-1.5">
@@ -878,6 +896,7 @@ function SessionDetailDrawer({
           <button className="btn-secondary px-2 py-1 text-xs" onClick={onClose}>Close</button>
         </div>
         <p className="mt-1 text-xs text-muted">{buildSessionTitle(session)} • {dayFormatter.format(new Date(`${session.date}T00:00:00.000Z`))}</p>
+        {session.displayType === "completed_activity" ? <p className="mt-1 text-xs text-[hsl(var(--signal-risk))]">Unscheduled upload: this counts as extra work and does not replace planned completion.</p> : null}
         <div className="mt-4 space-y-3">
           <label className="block">
             <span className="label-base mb-1 text-xs">Title</span>

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -206,7 +206,9 @@ export default async function DashboardPage({
 
   const minuteMetrics = computeWeekMinuteTotals(weekMetricSessions);
   const missedPlannedSessions = sessions.filter((session) => session.status === "planned").length;
-  const unmatchedExtraSessions = uploadedActivities.filter((activity) => (activity.schedule_status === "unscheduled" || !linkedActivityIds.has(activity.id)) && !activity.is_unplanned).length;
+  const extraActivities = uploadedActivities.filter((activity) => (activity.schedule_status === "unscheduled" || !linkedActivityIds.has(activity.id)) && !activity.is_unplanned);
+  const unmatchedExtraSessions = extraActivities.length;
+  const extraMinutesTotal = extraActivities.reduce((sum, activity) => sum + Math.round((activity.duration_sec ?? 0) / 60), 0);
   const totals = { planned: minuteMetrics.plannedMinutes, completed: minuteMetrics.completedMinutes };
 
   const progressBySport = sports.map((sport) => {
@@ -214,11 +216,15 @@ export default async function DashboardPage({
     const completed = sessions
       .filter((session) => session.sport === sport)
       .reduce((sum, session) => sum + getCompletedMinutes(session), 0);
+    const extraMinutes = extraActivities
+      .filter((activity) => activity.sport_type === sport)
+      .reduce((sum, activity) => sum + Math.round((activity.duration_sec ?? 0) / 60), 0);
 
     return {
       sport,
       planned,
       completed,
+      extraMinutes,
       label: getDisciplineMeta(sport).label,
       color:
         sport === "swim"
@@ -386,8 +392,10 @@ export default async function DashboardPage({
                   label: item.label,
                   plannedMinutes: item.planned,
                   completedMinutes: item.completed,
+                  extraMinutes: item.extraMinutes,
                   color: item.color
                 }))}
+                extraTotalMinutes={extraMinutesTotal}
                 showStatusChip={false}
               />
             </div>

--- a/app/(protected)/dashboard/progress-glance-card.tsx
+++ b/app/(protected)/dashboard/progress-glance-card.tsx
@@ -44,7 +44,7 @@ export function ProgressGlanceCard({
 
           <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold text-[hsl(var(--fg))]">{completedTimeLabel} / {plannedTimeLabel}</p>
-            <p className="text-xs text-muted">{remainingTimeLabel} remaining • {unmatchedExtraCount} unmatched extras • {missedPlannedCount} missed planned</p>
+            <p className="text-xs text-muted">{remainingTimeLabel} remaining • {unmatchedExtraCount} extra sessions (additive) • {missedPlannedCount} missed planned</p>
           </div>
 
           <div className="text-right">

--- a/app/(protected)/dashboard/week-progress-card.test.tsx
+++ b/app/(protected)/dashboard/week-progress-card.test.tsx
@@ -1,0 +1,28 @@
+import { fireEvent, render, screen } from "@testing-library/react";
+import { WeekProgressCard } from "./week-progress-card";
+
+describe("WeekProgressCard", () => {
+  it("filters planned vs unscheduled work", () => {
+    render(
+      <WeekProgressCard
+        plannedTotalMinutes={120}
+        completedTotalMinutes={90}
+        extraTotalMinutes={30}
+        disciplines={[
+          { key: "run", label: "Run", plannedMinutes: 120, completedMinutes: 90, extraMinutes: 30, color: "#fff" },
+          { key: "bike", label: "Bike", plannedMinutes: 0, completedMinutes: 0, extraMinutes: 15, color: "#000" }
+        ]}
+      />
+    );
+
+    expect(screen.getByText("Extra work: 30m")).toBeInTheDocument();
+    expect(screen.getByText("120 / 120 min")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Planned only" }));
+    expect(screen.getByText("90 / 120 min")).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: "Unscheduled only" }));
+    expect(screen.getByText("30 / 0 min")).toBeInTheDocument();
+    expect(screen.getByText("15 / 0 min")).toBeInTheDocument();
+  });
+});

--- a/app/(protected)/dashboard/week-progress-card.tsx
+++ b/app/(protected)/dashboard/week-progress-card.tsx
@@ -13,7 +13,8 @@ type Discipline = {
 type WeekProgressCardProps = {
   plannedTotalMinutes: number;
   completedTotalMinutes: number;
-  disciplines: Discipline[];
+  extraTotalMinutes?: number;
+  disciplines: Array<Discipline & { extraMinutes?: number }>;
   showStatusChip?: boolean;
 };
 
@@ -26,10 +27,12 @@ const clamp = (n: number, min: number, max: number) => Math.max(min, Math.min(ma
 export function WeekProgressCard({
   plannedTotalMinutes,
   completedTotalMinutes,
+  extraTotalMinutes = 0,
   disciplines,
   showStatusChip = true
 }: WeekProgressCardProps) {
   const [hideEmpty, setHideEmpty] = useState(true);
+  const [workFilter, setWorkFilter] = useState<"all" | "planned" | "unscheduled">("all");
 
   const remainingMinutes = plannedTotalMinutes - completedTotalMinutes;
   const overMinutes = Math.max(completedTotalMinutes - plannedTotalMinutes, 0);
@@ -37,23 +40,27 @@ export function WeekProgressCard({
   const disciplineRows = useMemo(
     () =>
       disciplines.map((discipline) => {
-        const discPercent = discipline.plannedMinutes > 0 ? discipline.completedMinutes / discipline.plannedMinutes : 0;
+        const visibleCompletedMinutes = workFilter === "planned" ? discipline.completedMinutes : workFilter === "unscheduled" ? discipline.extraMinutes ?? 0 : discipline.completedMinutes + (discipline.extraMinutes ?? 0);
+        const visiblePlannedMinutes = workFilter === "unscheduled" ? 0 : discipline.plannedMinutes;
+        const discPercent = visiblePlannedMinutes > 0 ? visibleCompletedMinutes / visiblePlannedMinutes : 0;
         const discPercentCapped = Math.min(discPercent, 1);
-        const discOverMinutes = Math.max(discipline.completedMinutes - discipline.plannedMinutes, 0);
-        const discGapMinutes = Math.max(discipline.plannedMinutes - discipline.completedMinutes, 0);
+        const discOverMinutes = Math.max(visibleCompletedMinutes - visiblePlannedMinutes, 0);
+        const discGapMinutes = Math.max(visiblePlannedMinutes - visibleCompletedMinutes, 0);
 
         return {
           ...discipline,
+          visibleCompletedMinutes,
+          visiblePlannedMinutes,
           discPercentCapped,
           discOverMinutes,
           discGapMinutes
         };
       }),
-    [disciplines]
+    [disciplines, workFilter]
   );
 
-  const emptyCount = disciplineRows.filter((item) => item.plannedMinutes === 0).length;
-  const visibleDisciplines = hideEmpty ? disciplineRows.filter((item) => item.plannedMinutes > 0) : disciplineRows;
+  const emptyCount = disciplineRows.filter((item) => item.visiblePlannedMinutes === 0 && (item.extraMinutes ?? 0) === 0).length;
+  const visibleDisciplines = hideEmpty ? disciplineRows.filter((item) => item.visiblePlannedMinutes > 0 || (item.extraMinutes ?? 0) > 0) : disciplineRows;
   const biggestGap = [...disciplineRows].sort((a, b) => b.discGapMinutes - a.discGapMinutes)[0];
 
   const chipLabel = remainingMinutes > 0 ? "Behind plan" : remainingMinutes === 0 ? "On target" : "Ahead of plan";
@@ -71,6 +78,21 @@ export function WeekProgressCard({
       </div>
 
       <div className="mt-4">
+        <div className="mb-3 flex flex-wrap items-center justify-between gap-2">
+          <div className="inline-flex rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] p-0.5 text-xs">
+            {(["all", "planned", "unscheduled"] as const).map((option) => (
+              <button
+                key={option}
+                type="button"
+                onClick={() => setWorkFilter(option)}
+                className={`rounded-full px-2.5 py-1 ${workFilter === option ? "bg-[hsl(var(--bg-card))] text-[hsl(var(--fg))]" : "text-muted"}`}
+              >
+                {option === "all" ? "All" : option === "planned" ? "Planned only" : "Unscheduled only"}
+              </button>
+            ))}
+          </div>
+          <p className="text-xs text-muted">Extra work: {formatMinutes(extraTotalMinutes)}</p>
+        </div>
         <div className="mb-2 flex items-center justify-between">
           <p className="text-sm font-semibold">By discipline</p>
           {emptyCount > 0 || !hideEmpty ? (
@@ -86,17 +108,17 @@ export function WeekProgressCard({
         </div>
 
         {visibleDisciplines.length === 0 ? (
-          <p className="text-xs text-muted">No planned minutes.</p>
+          <p className="text-xs text-muted">No sessions match this filter yet. Uploaded unscheduled sessions still count as extra work.</p>
         ) : (
           <div className="space-y-3">
             {visibleDisciplines.map((item) => {
               const chipLabel = item.discGapMinutes > 0 ? `Gap ${formatMinutes(item.discGapMinutes)}` : item.discOverMinutes > 0 ? `+${formatMinutes(item.discOverMinutes)}` : null;
-              const overTailWidthPx = item.plannedMinutes > 0
-                ? clamp(Math.round((item.discOverMinutes / item.plannedMinutes) * 120), 6, 24)
+              const overTailWidthPx = item.visiblePlannedMinutes > 0
+                ? clamp(Math.round((item.discOverMinutes / item.visiblePlannedMinutes) * 120), 6, 24)
                 : 0;
               const barAriaLabel = item.discOverMinutes > 0
-                ? `${item.label} ${Math.round(item.completedMinutes)} of ${Math.round(item.plannedMinutes)} minutes, over ${Math.round(item.discOverMinutes)} minutes`
-                : `${item.label} ${Math.round(item.completedMinutes)} of ${Math.round(item.plannedMinutes)} minutes, gap ${Math.round(item.discGapMinutes)} minutes`;
+                ? `${item.label} ${Math.round(item.visibleCompletedMinutes)} of ${Math.round(item.visiblePlannedMinutes)} minutes, over ${Math.round(item.discOverMinutes)} minutes`
+                : `${item.label} ${Math.round(item.visibleCompletedMinutes)} of ${Math.round(item.visiblePlannedMinutes)} minutes, gap ${Math.round(item.discGapMinutes)} minutes`;
 
               return (
                 <div key={item.key} className="rounded-lg px-2 py-1 transition hover:bg-[hsl(var(--bg-card))]">
@@ -107,7 +129,7 @@ export function WeekProgressCard({
                     </div>
                     <div className="ml-auto flex items-center justify-end gap-2">
                       <div className="w-[96px] text-right text-xs text-muted tabular-nums" style={{ fontVariantNumeric: "tabular-nums" }}>
-                        {Math.round(item.completedMinutes)} / {Math.round(item.plannedMinutes)} min
+                        {Math.round(item.visibleCompletedMinutes)} / {Math.round(item.visiblePlannedMinutes)} min
                       </div>
                       {chipLabel ? (
                         <span className={`inline-flex h-5 items-center rounded-full border px-2.5 text-xs font-medium ${item.discGapMinutes > 0 ? "signal-load" : item.discOverMinutes > 0 ? "signal-risk" : "signal-ready"}`}>

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -4,8 +4,8 @@ const createJestConfig = nextJest({ dir: './' });
 
 const customJestConfig = {
   setupFilesAfterEnv: ['<rootDir>/test/setup.ts'],
-  testEnvironment: 'node',
-  testMatch: ['**/*.test.ts'],
+  testEnvironment: 'jsdom',
+  testMatch: ['**/*.test.ts', '**/*.test.tsx'],
   collectCoverageFrom: ['lib/**/*.ts', '!lib/supabase/**', '!lib/env/**', '!lib/ui/**'],
   coverageThreshold: {
     global: {

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,3 +1,5 @@
+import '@testing-library/jest-dom';
+
 process.env.TZ = 'Europe/Dublin';
 
 jest.mock(


### PR DESCRIPTION
### Motivation
- Make it clear in the UI when work came from a planned session vs an uploaded/unscheduled activity so users can reason about compliance and extra work.
- Provide filters and labels so customers can view only planned work, only unscheduled extras, or both together.
- Ensure unscheduled uploads are treated as additive (extra) rather than replacing planned completion in compliance and reporting.
- Give contextual help/empty-state copy to explain that uploaded sessions count even when no planned slot exists.

### Description
- Calendar: added a `Work filter` (`All work` / `Planned only` / `Unscheduled only`) to `WeekCalendar`, added an `Extra sessions` chip in the weekly header, an `Extra session` badge on unscheduled activity cards, and explanatory copy in the session detail drawer and day empty-states; updated filtering logic to consider `displayType` when showing items (`app/(protected)/calendar/week-calendar.tsx`, `app/(protected)/calendar/page.tsx`).
- Reporting/dashboard: updated dashboard plumbing to compute planned-only counts/minutes and separately aggregate unscheduled uploads and extra minutes by sport, and passed totals into `WeekProgressCard`; updated `WeekProgressCard` to support planned/unscheduled/all toggles and show extra-work minutes; updated the progress glance copy to label extras as additive (`app/(protected)/dashboard/page.tsx`, `app/(protected)/dashboard/week-progress-card.tsx`, `app/(protected)/dashboard/progress-glance-card.tsx`).
- Activity details: show an `Unscheduled` badge and helper copy on unlinked uploads to clarify they are extra work (`app/(protected)/activities/[activityId]/page.tsx`).
- Tests & config: added UI tests for the calendar filter and the week progress card (`app/(protected)/calendar/week-calendar.test.tsx`, `app/(protected)/dashboard/week-progress-card.test.tsx`), enabled `.test.tsx` and `jsdom` in `jest.config.ts`, and added `@testing-library/jest-dom` setup (`test/setup.ts`).

### Testing
- Ran unit/UI tests with `npm test -- --runInBand` and all test suites passed (12 passed, 12 total).
- Ran type checking with `npm run typecheck` and `tsc --noEmit` succeeded with no errors.
- Attempted a local dev run and captured a browser screenshot, but the running Next dev server returned a 500 on the calendar route in this environment due to missing Supabase env vars (this did not affect tests which mock needed behavior).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4a8d7c7c88332b4d26b10b43529d5)