### PR TITLE
Add 'clinical-coral' theme and refactor color classes to use CSS tokens

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -222,12 +222,12 @@ export default async function DashboardPage({
       label: getDisciplineMeta(sport).label,
       color:
         sport === "swim"
-          ? "#56B6D9"
+          ? "hsl(var(--chart-2))"
           : sport === "bike"
-            ? "#6BAA75"
+            ? "hsl(var(--chart-3))"
             : sport === "run"
-              ? "#C48772"
-              : "#9A86C8"
+              ? "hsl(var(--chart-1))"
+              : "hsl(var(--chart-4))"
     };
   }).sort((a, b) => (b.planned - b.completed) - (a.planned - a.completed));
 
@@ -305,15 +305,15 @@ export default async function DashboardPage({
               <h1 className="priority-title">Today: {nextPendingTodaySession.type}</h1>
               <p className="priority-subtitle">
                 {nextPendingTodaySession.duration_minutes} min • {getDisciplineMeta(nextPendingTodaySession.sport).label}
-                {nextPendingTodaySession.is_key ? <span className="ml-2 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted">Key session</span> : null}
+                {nextPendingTodaySession.is_key ? <span className="ml-2 rounded-full border border-border bg-card px-2 py-0.5 text-[11px] font-semibold uppercase tracking-[0.08em] text-muted-foreground">Key session</span> : null}
               </p>
-              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState, nextPendingTodaySession)}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{getWhyTodayMattersCopy(nextActionState, nextPendingTodaySession)}</p>
             </>
           ) : overdueKeySession ? (
             <>
               <h1 className="priority-title">Key session missed: {overdueKeySession.type}</h1>
               <p className="priority-subtitle">Reschedule now to protect this week&apos;s intent.</p>
-              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState, overdueKeySession)}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{getWhyTodayMattersCopy(nextActionState, overdueKeySession)}</p>
             </>
           ) : completedTodaySessions.length > 0 ? (
             <>
@@ -322,7 +322,7 @@ export default async function DashboardPage({
                 {completedTodaySummary}
                 {completedTodaySessions.length > 2 ? ` • +${completedTodaySessions.length - 2} more completed` : ""}
               </p>
-              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState)}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{getWhyTodayMattersCopy(nextActionState)}</p>
             </>
           ) : (
             <>
@@ -331,7 +331,7 @@ export default async function DashboardPage({
                 Keep momentum by pulling one session forward
                 {hasGapSuggestion ? ` — 30–45m easy ${biggestGap!.label.toLowerCase()} is the best fit.` : "."}
               </p>
-              <p className="mt-1 text-sm text-muted">{getWhyTodayMattersCopy(nextActionState)}</p>
+              <p className="mt-1 text-sm text-muted-foreground">{getWhyTodayMattersCopy(nextActionState)}</p>
             </>
           )}
           <div className="mt-3 flex flex-wrap items-center justify-between gap-2">
@@ -359,7 +359,7 @@ export default async function DashboardPage({
               ) : null}
             </div>
             {!nextPendingTodaySession && !overdueKeySession && completedTodaySessions.length === 0 ? (
-              <Link href="/calendar" className="text-xs text-muted underline underline-offset-2">Why no session?</Link>
+              <Link href="/calendar" className="text-xs text-muted-foreground underline underline-offset-2">Why no session?</Link>
             ) : null}
           </div>
         </article>

--- a/app/(protected)/dashboard/progress-glance-card.tsx
+++ b/app/(protected)/dashboard/progress-glance-card.tsx
@@ -23,18 +23,18 @@ export function ProgressGlanceCard({
   const statusClassName = statusLabel === "Ahead"
     ? "signal-ready"
     : statusLabel === "On track"
-      ? "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"
+      ? "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] text-[hsl(var(--fg))]"
       : "signal-load";
 
   return (
     <Link href="#week-progress-details" className="block">
-      <article className="surface p-4 transition hover:border-[hsl(var(--fg)/0.22)]">
+      <article className="surface p-4 transition hover:border-border">
         <div className="flex items-center gap-4">
           <div className="relative flex h-14 w-14 shrink-0 items-center justify-center rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))]">
             <div
               className="absolute inset-0 rounded-full"
               style={{
-                background: `conic-gradient(hsl(var(--signal-recovery) / 0.76) ${ringPct * 3.6}deg, hsl(var(--surface-2)) 0deg)`
+                background: `conic-gradient(hsl(var(--signal-recovery) / 0.72) ${ringPct * 3.6}deg, hsl(var(--surface-2)) 0deg)`
               }}
             />
             <div className="relative flex h-10 w-10 items-center justify-center rounded-full bg-[hsl(var(--surface-1))] text-xs font-semibold">
@@ -44,7 +44,7 @@ export function ProgressGlanceCard({
 
           <div className="min-w-0 flex-1">
             <p className="text-sm font-semibold text-[hsl(var(--fg))]">{completedTimeLabel} / {plannedTimeLabel}</p>
-            <p className="text-xs text-muted">{remainingTimeLabel} remaining • {unmatchedExtraCount} unmatched extras • {missedPlannedCount} missed planned</p>
+            <p className="text-xs text-muted-foreground">{remainingTimeLabel} remaining • {unmatchedExtraCount} unmatched extras • {missedPlannedCount} missed planned</p>
           </div>
 
           <div className="text-right">

--- a/app/(protected)/dashboard/week-progress-card.tsx
+++ b/app/(protected)/dashboard/week-progress-card.tsx
@@ -63,8 +63,8 @@ export function WeekProgressCard({
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">Week Progress</h2>
         {showStatusChip ? (
-          <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${overMinutes > 0 ? "signal-chip signal-load" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"}`}>
-            {overMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--signal-load))]" /> : null}
+          <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-sm font-semibold ${remainingMinutes > 0 ? "signal-chip signal-load" : overMinutes > 0 ? "signal-chip signal-ready" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] text-[hsl(var(--fg))]"}`}>
+            {remainingMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--signal-load))]" /> : null}
             <span>{chipLabel}</span>
           </span>
         ) : null}
@@ -77,7 +77,7 @@ export function WeekProgressCard({
             <button
               type="button"
               onClick={() => setHideEmpty((current) => !current)}
-              className="text-xs text-muted underline-offset-2 hover:text-[hsl(var(--fg))] hover:underline"
+              className="text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
               aria-pressed={!hideEmpty}
             >
               {hideEmpty ? `Show empty (+${emptyCount})` : "Hide empty"}
@@ -86,7 +86,7 @@ export function WeekProgressCard({
         </div>
 
         {visibleDisciplines.length === 0 ? (
-          <p className="text-xs text-muted">No planned minutes.</p>
+          <p className="text-xs text-muted-foreground">No planned minutes.</p>
         ) : (
           <div className="space-y-3">
             {visibleDisciplines.map((item) => {
@@ -106,7 +106,7 @@ export function WeekProgressCard({
                       <span className="font-medium text-[hsl(var(--fg))]">{item.label}</span>
                     </div>
                     <div className="ml-auto flex items-center justify-end gap-2">
-                      <div className="w-[96px] text-right text-xs text-muted tabular-nums" style={{ fontVariantNumeric: "tabular-nums" }}>
+                      <div className="w-[96px] text-right text-xs text-muted-foreground tabular-nums" style={{ fontVariantNumeric: "tabular-nums" }}>
                         {Math.round(item.completedMinutes)} / {Math.round(item.plannedMinutes)} min
                       </div>
                       {chipLabel ? (
@@ -123,8 +123,7 @@ export function WeekProgressCard({
                         className="progress-fill-load absolute inset-y-0 right-0 rounded-r-full"
                         style={{
                           width: `${overTailWidthPx}px`,
-                          opacity: 0.8,
-                          backgroundImage: "repeating-linear-gradient(45deg, rgba(255,255,255,0.22) 0px, rgba(255,255,255,0.22) 6px, rgba(255,255,255,0.05) 6px, rgba(255,255,255,0.05) 12px)"
+                          opacity: 1
                         }}
                       />
                     ) : null}
@@ -136,7 +135,7 @@ export function WeekProgressCard({
         )}
       </div>
 
-      <a href="#coach-focus" className="mt-4 inline-block text-xs text-muted underline-offset-2 hover:text-[hsl(var(--fg))] hover:underline">
+      <a href="#coach-focus" className="mt-4 inline-block text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline">
         {biggestGap && biggestGap.discGapMinutes > 0
           ? `Focus: ${biggestGap.label} +${formatMinutes(biggestGap.discGapMinutes)} (tap for why)`
           : "Focus: On track (tap for details)"}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -97,15 +97,15 @@ export default async function ProtectedLayout({ children }: { children: React.Re
             </div>
 
             <div className="hidden xl:block surface-subtle p-3">
-              <p className="text-xs uppercase tracking-[0.14em] text-muted">Training week</p>
+              <p className="text-xs uppercase tracking-[0.14em] text-muted-foreground">Training week</p>
               {weekContext ? (
                 <>
                   <p className="mt-2 text-sm font-semibold">Week {weekContext.week_index} · {weekContext.focus}</p>
-                  <p className="mt-1 text-xs text-muted">Starts {weekContext.week_start_date}</p>
-                  <p className="mt-1 text-xs text-muted">Target: {weekContext.target_minutes ? `${weekContext.target_minutes} min` : "not set"}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">Starts {weekContext.week_start_date}</p>
+                  <p className="mt-1 text-xs text-muted-foreground">Target: {weekContext.target_minutes ? `${weekContext.target_minutes} min` : "not set"}</p>
                 </>
               ) : (
-                <p className="mt-2 text-sm text-muted">Create or activate a plan to see week context.</p>
+                <p className="mt-2 text-sm text-muted-foreground">Create or activate a plan to see week context.</p>
               )}
               <Link href="/plan/builder" className="mt-3 inline-flex text-xs text-accent underline">Manage plan</Link>
             </div>

--- a/app/(protected)/shell-nav.tsx
+++ b/app/(protected)/shell-nav.tsx
@@ -33,7 +33,7 @@ export function ShellNavRail({ compact = false }: { compact?: boolean }) {
             ) : (
               <>
                 <span className="block font-medium">{item.label}</span>
-                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted">{item.semanticLabel}</span>
+                <span className="block text-[11px] uppercase tracking-[0.12em] text-muted-foreground">{item.semanticLabel}</span>
               </>
             )}
           </Link>
@@ -56,7 +56,7 @@ export function MobileBottomTabs() {
               key={item.href}
               href={item.href}
               title={`${item.label} · ${item.semanticLabel}`}
-              className={`rounded-lg px-2 py-2 text-center text-xs font-medium ${active ? "bg-[hsl(var(--accent-performance)/0.14)] text-[hsl(var(--accent-performance))]" : "text-muted"}`}
+              className={`rounded-lg px-2 py-2 text-center text-xs font-medium ${active ? "bg-[hsl(var(--accent-performance)/0.14)] text-[hsl(var(--accent-performance))]" : "text-muted-foreground"}`}
             >
               <span className="block">{item.label}</span>
               <span className="block text-[10px] uppercase tracking-[0.12em]">{item.semanticLabel}</span>

--- a/app/(protected)/theme-picker.tsx
+++ b/app/(protected)/theme-picker.tsx
@@ -6,6 +6,7 @@ const STORAGE_KEY = "tri.theme";
 
 const THEMES = [
   { value: "coach-studio", label: "Coach Studio" },
+  { value: "clinical-coral", label: "Clinical Coral" },
   { value: "ember-night", label: "Ember Night" }
 ] as const;
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -152,6 +152,69 @@
   --chart-5: 221 20% 72%;
 }
 
+:root[data-theme="clinical-coral"] {
+  --background: 210 25% 97%;
+  --foreground: 218 28% 18%;
+  --card: 0 0% 100%;
+  --card-foreground: 218 28% 18%;
+  --muted: 210 24% 94%;
+  --muted-foreground: 216 18% 34%;
+  --border: 215 18% 82%;
+  --input: 215 18% 82%;
+  --primary: 15 82% 58%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 15 82% 58%;
+  --chart-1: 15 82% 58%;
+  --chart-2: 204 40% 52%;
+  --chart-3: 188 32% 46%;
+  --chart-4: 254 30% 56%;
+  --chart-5: 220 14% 48%;
+  --success: 150 52% 36%;
+  --warning: 38 84% 52%;
+  --danger: 2 69% 56%;
+  --surface-2: 210 22% 95%;
+  --accent-recovery: 194 34% 44%;
+  --ai-accent-glow: 207 38% 72%;
+  --signal-neutral: 216 16% 54%;
+}
+
+:root[data-theme="clinical-coral"][data-color-scheme="dark"] {
+  color-scheme: dark;
+  --background: 222 24% 11%;
+  --foreground: 210 22% 94%;
+  --card: 221 20% 14%;
+  --card-foreground: 210 22% 94%;
+  --muted: 221 16% 18%;
+  --muted-foreground: 216 12% 70%;
+  --border: 217 14% 29%;
+  --input: 217 14% 29%;
+  --primary: 15 82% 60%;
+  --primary-foreground: 0 0% 100%;
+  --ring: 15 82% 60%;
+  --chart-1: 15 82% 60%;
+  --chart-2: 206 48% 62%;
+  --chart-3: 188 36% 56%;
+  --chart-4: 255 38% 66%;
+  --chart-5: 220 16% 66%;
+  --success: 151 46% 52%;
+  --warning: 38 84% 58%;
+  --danger: 2 70% 64%;
+  --surface-2: 221 18% 16%;
+  --accent-recovery: 185 34% 54%;
+  --ai-accent-glow: 208 48% 24%;
+  --signal-neutral: 216 12% 70%;
+}
+
+:root[data-theme="clinical-coral"] .app-shell::before {
+  background: linear-gradient(165deg, hsl(var(--bg)) 12%, hsl(var(--bg-elevated)) 88%);
+  animation: none;
+}
+
+:root[data-theme="clinical-coral"] .shell-header::before {
+  background: none;
+  opacity: 0;
+}
+
 @media (prefers-color-scheme: dark) {
   :root:not([data-color-scheme]) {
     color-scheme: dark;
@@ -283,7 +346,7 @@
   .surface {
     background: hsl(var(--bg-elevated));
     border: 1px solid hsl(var(--border));
-    @apply rounded-2xl shadow-[0_10px_40px_-24px_rgba(0,0,0,0.8)];
+    @apply rounded-2xl shadow-sm;
     transition:
       border-color var(--motion-standard) var(--motion-ease),
       box-shadow var(--motion-standard) var(--motion-ease),
@@ -291,7 +354,7 @@
   }
 
   .surface:hover {
-    border-color: hsl(var(--ai-accent-core) / 0.38);
+    border-color: hsl(var(--border));
   }
 
   .surface-subtle {
@@ -306,11 +369,9 @@
 
   .priority-card-primary {
     @apply surface p-6 md:p-7;
-    border-color: hsl(var(--accent-performance) / 0.45);
-    background:
-      linear-gradient(145deg, hsl(var(--bg-elevated)) 35%, hsl(var(--accent-performance) / 0.08) 100%),
-      hsl(var(--bg-elevated));
-    box-shadow: 0 20px 45px -30px hsl(var(--accent-performance) / 0.7);
+    background: hsl(var(--bg-elevated));
+    border-color: hsl(var(--border));
+    border-left: 2px solid hsl(var(--accent-performance));
   }
 
   .priority-card-secondary {
@@ -319,11 +380,8 @@
 
   .priority-card-emphasis {
     @apply surface p-5 md:p-6;
-    border-color: hsl(var(--accent-performance) / 0.4);
-    background:
-      linear-gradient(150deg, hsl(var(--bg-elevated)) 55%, hsl(var(--accent-performance) / 0.07) 100%),
-      hsl(var(--bg-elevated));
-    box-shadow: 0 16px 34px -24px hsl(var(--accent-performance) / 0.6);
+    border-color: hsl(var(--border));
+    background: hsl(var(--bg-elevated));
   }
 
   .priority-card-supporting {
@@ -343,18 +401,9 @@
   }
 
   .btn-primary {
-    @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white;
-    border: 1px solid hsl(var(--accent-performance) / 0.65);
-    background:
-      linear-gradient(135deg, hsl(var(--accent-performance)) 0%, hsl(var(--accent-performance) / 0.82) 100%),
-      repeating-linear-gradient(
-        115deg,
-        hsl(0 0% 100% / 0.16) 0,
-        hsl(0 0% 100% / 0.16) 1px,
-        transparent 1px,
-        transparent 5px
-      );
-    box-shadow: 0 12px 26px -14px hsl(var(--accent-performance) / 0.88);
+    @apply inline-flex items-center justify-center rounded-xl px-4 py-2 text-sm font-semibold text-white shadow-sm;
+    border: 1px solid hsl(var(--accent-performance) / 0.7);
+    background: hsl(var(--accent-performance));
   }
 
   .btn-primary:hover {
@@ -400,8 +449,8 @@
   .btn-primary:focus-visible,
   .btn-secondary:focus-visible,
   .surface:focus-within {
-    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.35);
-    border-color: hsl(var(--ring) / 0.55);
+    box-shadow: 0 0 0 2px hsl(var(--ring) / 0.28);
+    border-color: hsl(var(--ring) / 0.5);
   }
 
   .label-base {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,8 +13,8 @@ export default function RootLayout({
 }>) {
   const themeInitScript = `(() => {
     const storageKey = "tri.theme";
-    const fallbackTheme = "coach-studio";
-    const supportedThemes = new Set(["coach-studio", "ember-night"]);
+    const fallbackTheme = "clinical-coral";
+    const supportedThemes = new Set(["coach-studio", "clinical-coral", "ember-night"]);
     const storedTheme = window.localStorage.getItem(storageKey);
     const theme = storedTheme && supportedThemes.has(storedTheme) ? storedTheme : fallbackTheme;
     const colorScheme = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light";
@@ -24,7 +24,7 @@ export default function RootLayout({
   })();`;
 
   return (
-    <html lang="en" data-theme="coach-studio">
+    <html lang="en" data-theme="clinical-coral">
       <head>
         <script dangerouslySetInnerHTML={{ __html: themeInitScript }} />
       </head>


### PR DESCRIPTION
### Motivation

- Introduce a new visual theme and improve theming consistency by replacing hard-coded colors with CSS token usage and refined utility classes.
- Improve contrast and foreground/background mappings so components correctly inherit theme-aware foreground and muted styles.

### Description

- Add a new `clinical-coral` theme with light and dark variable sets in `globals.css`, plus small layout adjustments (shell/header backgrounds) for the theme. 
- Expose the new theme in the theme picker by adding `clinical-coral` to `THEMES` and update the client theme apply logic to support it.
- Make `clinical-coral` the default theme in the root HTML initialization and set the initial `data-theme` attribute accordingly.
- Replace several hard-coded color literals with CSS variables (e.g. chart colors) and swap many `text-muted`/`text-*` usages to `text-muted-foreground`/`text-foreground` to align with the updated token naming.
- Tweak UI tokens and surface styles in `globals.css`: reduce heavy shadows, simplify primary button background/border, adjust focus ring opacity, and normalize border colors and hover states.
- Component-specific tweaks: update `progress-glance-card`, `week-progress-card`, `dashboard/page.tsx`, `shell-nav.tsx`, and layout files to use the new tokens, refine conic-gradient opacity, adjust week chip logic and progress-fill visuals, and change several utility class names for consistent foreground/muted styles.

### Testing

- Ran a project build with `pnpm build` which completed successfully.
- Ran lint/type-check via `pnpm lint` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4ae80a40483329089a8a96339b5a2)