### PR TITLE
Add `sport-luxe` theme preset with restrained coral accents

### DIFF
--- a/app/(protected)/dashboard/week-progress-card.tsx
+++ b/app/(protected)/dashboard/week-progress-card.tsx
@@ -140,7 +140,7 @@ export function WeekProgressCard({
                         </span>
                       ) : isCompletedDiscipline ? (
                         <span className="inline-flex h-5 items-center gap-1 rounded-full border border-[hsl(var(--success)/0.25)] bg-[hsl(var(--success)/0.08)] px-2 text-[11px] font-medium text-[hsl(var(--fg-muted))]">
-                          <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--success)/0.62)]" />
+                          <span aria-hidden className="inline-flex h-3 w-3 items-center justify-center rounded-full bg-[hsl(var(--success)/0.18)] text-[9px] leading-none text-[hsl(var(--success)/0.78)]">✓</span>
                           Complete
                         </span>
                       ) : null}

--- a/app/(protected)/settings/theme-picker.tsx
+++ b/app/(protected)/settings/theme-picker.tsx
@@ -18,6 +18,11 @@ const THEME_OPTIONS: ThemeOption[] = [
     label: "Clinical Coral",
     value: "clinical-coral",
     description: "Cool clinical surfaces with restrained coral accents."
+  },
+  {
+    label: "Sport Luxe",
+    value: "sport-luxe",
+    description: "Premium warm-neutral surfaces with confident coral highlights."
   }
 ];
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -103,6 +103,57 @@
   --ring-color: var(--ring);
 }
 
+:root[data-theme="sport-luxe"] {
+  color-scheme: light;
+  --surface: 32 28% 95%;
+  --surface-elevated: 0 0% 100%;
+  --surface-soft: 30 24% 97%;
+  --surface-1: var(--surface-elevated);
+  --surface-2: 28 18% 93%;
+
+  --text-primary: 216 27% 19%;
+  --text-secondary: 215 14% 33%;
+  --text-tertiary: 214 10% 48%;
+
+  --accent-performance: 14 82% 58%;
+  --accent-recovery: 197 34% 43%;
+
+  --signal-ready: 152 35% 41%;
+  --signal-load: 37 78% 47%;
+  --signal-risk: 8 64% 55%;
+  --signal-recovery: 201 31% 45%;
+  --signal-neutral: 214 12% 56%;
+
+  --success: var(--signal-ready);
+  --warning: var(--signal-load);
+  --danger: var(--signal-risk);
+
+  --chart-1: 14 82% 58%;
+  --chart-2: 196 44% 45%;
+  --chart-3: 224 31% 54%;
+  --chart-4: 266 29% 60%;
+  --chart-5: 212 10% 58%;
+
+  --ai-accent-core: var(--accent-performance);
+  --ai-accent-glow: 18 62% 88%;
+
+  --bg: var(--surface);
+  --bg-elevated: var(--surface-elevated);
+  --bg-card: var(--surface-soft);
+  --fg: var(--text-primary);
+  --fg-muted: var(--text-secondary);
+  --border: 30 14% 84%;
+  --ring: var(--accent-performance);
+  --accent: var(--ai-accent-core);
+  --accent-soft: 20 52% 92%;
+
+  --background: var(--bg);
+  --card: var(--bg-elevated);
+  --muted-foreground: var(--fg-muted);
+  --border-color: var(--border);
+  --ring-color: var(--ring);
+}
+
 @media (prefers-color-scheme: dark) {
   :root {
     color-scheme: dark;
@@ -156,6 +207,49 @@
     --border: 217 16% 30%;
     --ring: 18 90% 64%;
     --accent-soft: 214 22% 22%;
+
+    --background: var(--bg);
+    --card: var(--bg-elevated);
+    --muted-foreground: var(--fg-muted);
+    --border-color: var(--border);
+    --ring-color: var(--ring);
+  }
+
+  :root[data-theme="sport-luxe"] {
+    color-scheme: dark;
+    --surface: 220 18% 10%;
+    --surface-elevated: 220 19% 13%;
+    --surface-soft: 220 16% 16%;
+    --surface-1: var(--surface-elevated);
+    --surface-2: 220 14% 19%;
+
+    --text-primary: 213 22% 93%;
+    --text-secondary: 214 12% 76%;
+    --text-tertiary: 214 11% 62%;
+
+    --accent-performance: 14 84% 65%;
+    --accent-recovery: 193 42% 65%;
+
+    --signal-ready: 152 44% 55%;
+    --signal-load: 38 86% 60%;
+    --signal-risk: 8 78% 67%;
+    --signal-recovery: 194 44% 63%;
+    --signal-neutral: 214 11% 68%;
+
+    --success: var(--signal-ready);
+    --warning: var(--signal-load);
+    --danger: var(--signal-risk);
+
+    --chart-1: 14 84% 65%;
+    --chart-2: 193 48% 64%;
+    --chart-3: 222 58% 67%;
+    --chart-4: 266 53% 70%;
+    --chart-5: 212 14% 66%;
+
+    --ai-accent-glow: 17 48% 26%;
+    --border: 218 14% 31%;
+    --ring: var(--accent-performance);
+    --accent-soft: 218 18% 24%;
 
     --background: var(--bg);
     --card: var(--bg-elevated);
@@ -268,6 +362,73 @@
     border-color: hsl(var(--border));
     background: hsl(var(--bg-elevated));
     box-shadow: 0 1px 2px hsl(215 25% 18% / 0.08);
+  }
+
+  :root[data-theme="sport-luxe"] .surface {
+    border-color: hsl(var(--border) / 0.7);
+    box-shadow: 0 1px 3px hsl(220 24% 12% / 0.06);
+  }
+
+  :root[data-theme="sport-luxe"] .surface-subtle {
+    border-color: hsl(var(--border) / 0.36);
+    background: hsl(var(--surface-2) / 0.56);
+    box-shadow: none;
+  }
+
+  :root[data-theme="sport-luxe"] .next-action-card {
+    border-top: 2px solid transparent;
+    border-image: linear-gradient(90deg, hsl(var(--accent-performance) / 0.5), hsl(var(--accent-recovery) / 0.18)) 1;
+  }
+
+  :root[data-theme="sport-luxe"] .app-shell::before,
+  :root[data-theme="sport-luxe"] .shell-header::before {
+    background: none;
+    opacity: 0;
+    animation: none;
+  }
+
+  :root[data-theme="sport-luxe"] .priority-title {
+    @apply relative inline-block pb-1;
+  }
+
+  :root[data-theme="sport-luxe"] .priority-title::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    bottom: 0;
+    width: 1.75rem;
+    height: 2px;
+    border-radius: 999px;
+    background: hsl(var(--accent-performance) / 0.62);
+  }
+
+  :root[data-theme="sport-luxe"] .status-chip-planned {
+    border-color: hsl(var(--signal-neutral) / 0.34);
+    background: hsl(var(--signal-neutral) / 0.1);
+  }
+
+  :root[data-theme="sport-luxe"] .status-chip-completed {
+    border-color: hsl(var(--signal-ready) / 0.34);
+    background: hsl(var(--signal-ready) / 0.12);
+    color: hsl(var(--signal-ready));
+  }
+
+  :root[data-theme="sport-luxe"] .status-chip-skipped {
+    border-color: hsl(var(--signal-load) / 0.36);
+    background: hsl(var(--signal-load) / 0.14);
+    color: hsl(var(--signal-load));
+  }
+
+  :root[data-theme="sport-luxe"] .progress-track {
+    background: hsl(var(--signal-neutral) / 0.2);
+  }
+
+  :root[data-theme="sport-luxe"] .progress-fill-recovery {
+    background: hsl(var(--accent-performance));
+  }
+
+  :root[data-theme="sport-luxe"] .progress-fill-load {
+    background: hsl(var(--signal-load));
   }
 
 


### PR DESCRIPTION
### Motivation
- Introduce a premium, sporty theme that keeps the core coral brand color while maintaining a clean, warm-neutral background and subdued accents. 
- Enforce strict decorative limits so the theme remains quiet: only theme tokens and minimal decorative styling with at most one very subtle gradient use.

### Description
- Add a new token preset `:root[data-theme="sport-luxe"]` (light + dark variants) in `app/globals.css` that defines warm neutral surfaces, coral-focused `--accent` tokens, and adjusted signal/semantic colors. 
- Apply sport-luxe-specific component tweaks in `app/globals.css` to make cards white with soft borders/shadows, tune status chips (neutral/passive, amber warnings, muted green success), and set progress bars to a neutral track with coral as the focus fill. 
- Implement the single allowed gradient as a very subtle top border gradient on `.next-action-card` and explicitly disable ambient/header gradients for this theme to keep the palette restrained. 
- Add the thin accent motif (small underline) under section titles via `.priority-title::after`, add `Sport Luxe` to the theme picker in `app/(protected)/settings/theme-picker.tsx`, and update the completed badge in `app/(protected)/dashboard/week-progress-card.tsx` to use a subtle check motif.

### Testing
- Ran `npm run lint` and it completed with no warnings or errors. 
- Ran `npm run typecheck` (`tsc --noEmit`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4b970d2348332aaf5d19cd4ab1650)