### PR TITLE
Set Carbon Coach as default visual style

### DIFF
--- a/app/(protected)/settings/theme-picker.tsx
+++ b/app/(protected)/settings/theme-picker.tsx
@@ -27,7 +27,7 @@ const THEME_OPTIONS: ThemeOption[] = [
 ];
 
 const STORAGE_KEY = "tri-theme";
-const DEFAULT_THEME = "clinical-coral";
+const DEFAULT_THEME = "carbon-coach";
 
 export function ThemePicker() {
   const [theme, setTheme] = useState(DEFAULT_THEME);

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -12,7 +12,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" data-theme="clinical-coral">
+    <html lang="en" data-theme="carbon-coach">
       <body>{children}</body>
     </html>
   );


### PR DESCRIPTION
### Motivation
- Make the app use the `carbon-coach` visual style by default so first paint and users without a saved preference see the Carbon Coach theme.

### Description
- Change `data-theme` in `app/layout.tsx` from `clinical-coral` to `carbon-coach` and update `DEFAULT_THEME` in `app/(protected)/settings/theme-picker.tsx` to `carbon-coach` so the theme picker and initial render are consistent.

### Testing
- Ran `npm run typecheck` which completed without errors. 
- Launched the app with `npm run dev` and captured a Playwright screenshot to validate the default style visually, both of which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a4bd89148c8332a0a43e9c7287c079)