### PR TITLE
Handle missing completed_activities.schedule_status in uploads API and add migration

### DIFF
--- a/app/api/uploads/activities/route.ts
+++ b/app/api/uploads/activities/route.ts
@@ -7,6 +7,10 @@ import { pickBestSuggestion, suggestSessionMatches } from "@/lib/workouts/matchi
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
 const acceptedExtensions = [".fit", ".tcx"];
 
+function isMissingScheduleStatus(errorMessage: string) {
+  return errorMessage.includes("schedule_status") && errorMessage.includes("schema cache");
+}
+
 function ext(name: string) {
   return name.slice(name.lastIndexOf(".")).toLowerCase();
 }
@@ -16,15 +20,40 @@ export async function GET() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
 
-  const { data, error } = await supabase
+  const baseSelect = "id,filename,file_type,file_size,status,error_message,created_at,completed_activities(id,sport_type,duration_sec,distance_m),session_activity_links(planned_session_id)";
+  const scheduleSelect = "id,filename,file_type,file_size,status,error_message,created_at,completed_activities(id,sport_type,duration_sec,distance_m,schedule_status),session_activity_links(planned_session_id)";
+
+  const { data: withStatus, error: withStatusError } = await supabase
     .from("activity_uploads")
-    .select("id,filename,file_type,file_size,status,error_message,created_at,completed_activities(id,sport_type,duration_sec,distance_m,schedule_status),session_activity_links(planned_session_id)")
+    .select(scheduleSelect)
     .eq("user_id", user.id)
     .order("created_at", { ascending: false })
     .limit(15);
 
-  if (error) return NextResponse.json({ error: error.message }, { status: 400 });
-  return NextResponse.json({ uploads: data ?? [] });
+  if (!withStatusError) return NextResponse.json({ uploads: withStatus ?? [] });
+
+  if (!isMissingScheduleStatus(withStatusError.message)) {
+    return NextResponse.json({ error: withStatusError.message }, { status: 400 });
+  }
+
+  const { data: legacyData, error: legacyError } = await supabase
+    .from("activity_uploads")
+    .select(baseSelect)
+    .eq("user_id", user.id)
+    .order("created_at", { ascending: false })
+    .limit(15);
+
+  if (legacyError) return NextResponse.json({ error: legacyError.message }, { status: 400 });
+
+  const uploads = (legacyData ?? []).map((upload) => ({
+    ...upload,
+    completed_activities: (upload.completed_activities ?? []).map((activity) => ({
+      ...activity,
+      schedule_status: "unscheduled" as const
+    }))
+  }));
+
+  return NextResponse.json({ uploads });
 }
 
 export async function POST(request: Request) {
@@ -86,10 +115,9 @@ export async function POST(request: Request) {
         avg_power: parsed.avgPower,
         calories: parsed.calories,
         parse_summary: parsed.parseSummary,
-        source: "upload",
-        schedule_status: "unscheduled"
+        source: "upload"
       })
-      .select("id,start_time_utc,sport_type,duration_sec,distance_m,schedule_status")
+      .select("id,start_time_utc,sport_type,duration_sec,distance_m")
       .single();
 
     if (activityError || !createdActivity) throw new Error(activityError?.message ?? "Could not save parsed activity");

--- a/supabase/migrations/202603030001_repair_completed_activities_schedule_status.sql
+++ b/supabase/migrations/202603030001_repair_completed_activities_schedule_status.sql
@@ -1,0 +1,35 @@
+alter table public.completed_activities
+  add column if not exists schedule_status text;
+
+update public.completed_activities ca
+set schedule_status = case
+  when exists (
+    select 1
+    from public.session_activity_links sal
+    where sal.completed_activity_id = ca.id
+      and sal.planned_session_id is not null
+  ) then 'scheduled'
+  else 'unscheduled'
+end
+where schedule_status is null
+   or schedule_status not in ('scheduled', 'unscheduled');
+
+alter table public.completed_activities
+  alter column schedule_status set default 'unscheduled';
+
+alter table public.completed_activities
+  alter column schedule_status set not null;
+
+do $$
+begin
+  if not exists (
+    select 1
+    from pg_constraint
+    where conname = 'completed_activities_schedule_status_check'
+      and conrelid = 'public.completed_activities'::regclass
+  ) then
+    alter table public.completed_activities
+      add constraint completed_activities_schedule_status_check
+      check (schedule_status in ('scheduled', 'unscheduled'));
+  end if;
+end $$;


### PR DESCRIPTION
### Motivation
- Make the uploads `GET` API resilient to databases that don't yet have the `schedule_status` column on `completed_activities` so older deployments don't error. 
- Ensure newly parsed activities no longer rely on explicitly setting `schedule_status` at insert time so the database default can be used once present. 
- Add a migration to create, backfill, default and constrain the `schedule_status` column to bring schemas up-to-date.

### Description
- Added a helper `isMissingScheduleStatus` and changed the `GET` handler to attempt a `select` that includes `schedule_status` and to gracefully fall back to a legacy `select` without it, mapping missing activity rows to `schedule_status: "unscheduled"` in the response. 
- Split the `select` projection into `baseSelect` and `scheduleSelect` strings and return the first result set unless the error indicates a missing `schedule_status` schema entry. 
- Removed explicit `schedule_status` assignment and selection from the `completed_activities` insert in the `POST` flow so the DB default can apply. 
- Added a SQL migration `supabase/migrations/202603030001_repair_completed_activities_schedule_status.sql` that adds the `schedule_status` column if missing, backfills values to `scheduled`/`unscheduled`, sets a default of `unscheduled`, makes it `NOT NULL`, and adds a check constraint.

### Testing
- Ran the automated test suite with `pnpm test` and all tests passed. 
- Ran a production build check with `pnpm build` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a742291b2c83329d1b5c5c4b722711)