### PR TITLE
Normalize missing FormData values for optional session fields

### DIFF
--- a/app/(protected)/plan/actions.ts
+++ b/app/(protected)/plan/actions.ts
@@ -88,6 +88,11 @@ function isMissingTableError(error: { code?: string; message?: string } | null, 
   return (error.message ?? "").toLowerCase().includes(`could not find the table '${tableName.toLowerCase()}' in the schema cache`);
 }
 
+function getOptionalFormValue(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return value === null ? undefined : value;
+}
+
 async function getAuthedClient() {
   const supabase = await createClient();
   const {
@@ -619,15 +624,15 @@ export async function createSessionAction(formData: FormData) {
     weekId: formData.get("weekId"),
     date: formData.get("date"),
     sport: formData.get("sport"),
-    sessionType: formData.get("sessionType"),
-    target: formData.get("target"),
+    sessionType: getOptionalFormValue(formData, "sessionType"),
+    target: getOptionalFormValue(formData, "target"),
     durationMinutes: formData.get("durationMinutes"),
-    notes: formData.get("notes"),
-    distanceValue: formData.get("distanceValue"),
-    distanceUnit: formData.get("distanceUnit"),
-    dayOrder: formData.get("dayOrder"),
-    isKey: formData.get("isKey"),
-    sessionRole: formData.get("sessionRole")
+    notes: getOptionalFormValue(formData, "notes"),
+    distanceValue: getOptionalFormValue(formData, "distanceValue"),
+    distanceUnit: getOptionalFormValue(formData, "distanceUnit"),
+    dayOrder: getOptionalFormValue(formData, "dayOrder"),
+    isKey: getOptionalFormValue(formData, "isKey"),
+    sessionRole: getOptionalFormValue(formData, "sessionRole")
   });
 
   const { supabase, user } = await getAuthedClient();
@@ -675,15 +680,15 @@ export async function updateSessionAction(formData: FormData) {
     weekId: formData.get("weekId"),
     date: formData.get("date"),
     sport: formData.get("sport"),
-    sessionType: formData.get("sessionType"),
-    target: formData.get("target"),
+    sessionType: getOptionalFormValue(formData, "sessionType"),
+    target: getOptionalFormValue(formData, "target"),
     durationMinutes: formData.get("durationMinutes"),
-    notes: formData.get("notes"),
-    distanceValue: formData.get("distanceValue"),
-    distanceUnit: formData.get("distanceUnit"),
+    notes: getOptionalFormValue(formData, "notes"),
+    distanceValue: getOptionalFormValue(formData, "distanceValue"),
+    distanceUnit: getOptionalFormValue(formData, "distanceUnit"),
     status: formData.get("status"),
-    isKey: formData.get("isKey"),
-    sessionRole: formData.get("sessionRole")
+    isKey: getOptionalFormValue(formData, "isKey"),
+    sessionRole: getOptionalFormValue(formData, "sessionRole")
   });
 
   const { supabase, user } = await getAuthedClient();


### PR DESCRIPTION
### Motivation
- Fix a runtime Zod validation error when creating/updating a session caused by `FormData.get` returning `null` for omitted fields, which breaks union/coercion schemas like `distanceValue`/`distanceUnit`.
- Ensure optional session inputs are parsed consistently so empty or absent form fields don't produce `invalid_union` or `too_small` errors.

### Description
- Add `getOptionalFormValue(formData, key)` which converts `FormData.get` results of `null` to `undefined` so optional Zod fields behave as intended. 
- Use the helper in `createSessionAction` for `sessionType`, `target`, `notes`, `distanceValue`, `distanceUnit`, `dayOrder`, `isKey`, and `sessionRole` to normalize missing values. 
- Apply the same normalization in `updateSessionAction` to keep create/update behavior consistent and preserve existing canonical payload handling.

### Testing
- Ran type checking with `npm run typecheck`, which completed successfully. 
- Ran linting with `npm run lint` (Next.js ESLint), which reported no warnings or errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69af29b334fc8332a7f935538324b3ad)