### PR TITLE
Add shared training semantics and lifecycle state helpers

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -3,6 +3,7 @@ import { isValidIsoDate } from "@/lib/date/iso";
 import { WeekCalendar } from "./week-calendar";
 import { computeWeekMinuteTotals, computeWeekSessionCounts } from "@/lib/training/week-metrics";
 import { buildCalendarDisplayItems } from "@/lib/calendar/day-items";
+import type { SessionLifecycleState } from "@/lib/training/semantics";
 
 type Session = {
   id: string;
@@ -12,7 +13,7 @@ type Session = {
   duration_minutes: number | null;
   notes: string | null;
   created_at: string;
-  status?: "planned" | "completed" | "skipped";
+  status?: SessionLifecycleState;
   is_key?: boolean | null;
 };
 

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -5,9 +5,10 @@ import Link from "next/link";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { SessionStatusChip } from "@/lib/ui/status-chip";
+import { getDayStateLabel, type SessionLifecycleState } from "@/lib/training/semantics";
 import { clearSkippedAction, markSkippedAction, moveSessionAction, quickAddSessionAction } from "@/app/(protected)/calendar/actions";
 
-type SessionStatus = "planned" | "completed" | "skipped";
+type SessionStatus = SessionLifecycleState;
 type FilterStatus = "all" | SessionStatus | "extra" | "moved";
 type SportFilter = "all" | "swim" | "bike" | "run" | "strength";
 
@@ -95,7 +96,7 @@ function getSessionState(session: CalendarSession, recentMoves: RecentMove[]) {
     return "moved" as const;
   }
   if (session.linkedActivityCount && session.linkedActivityCount > 0 && session.status === "completed") {
-    return "assigned" as const;
+    return "assigned_from_upload" as const;
   }
   return session.status;
 }
@@ -108,7 +109,7 @@ function SessionActionMenu({
   onToggleSkip
 }: {
   session: CalendarSession;
-  state: "planned" | "completed" | "skipped" | "extra" | "moved" | "assigned";
+  state: "planned" | "completed" | "skipped" | "extra" | "moved" | "assigned_from_upload" | "unmatched_upload";
   onMove: () => void;
   onOpen: () => void;
   onToggleSkip: () => void;
@@ -356,20 +357,20 @@ export function WeekCalendar({
           const isPast = day.iso < todayIso;
           const needsAttention = Boolean(metrics && (metrics.skipped > 0 || (isPast && metrics.hasPlanned && !metrics.fullyDone)));
           const dayLabel = isToday
-            ? "Today"
+            ? getDayStateLabel("today")
             : needsAttention
-              ? "Needs attention"
+              ? getDayStateLabel("needs_attention")
               : metrics?.fullyDone
-                ? "Complete"
+                ? getDayStateLabel("complete")
                 : metrics?.isRest
-                  ? "Rest day"
+                  ? getDayStateLabel("rest_day")
                   : metrics?.availableDay
-                    ? "Available"
+                    ? getDayStateLabel("available")
                     : metrics?.openCapacity
-                      ? "Open capacity"
+                      ? getDayStateLabel("open_capacity")
                       : isFuture && metrics?.hasPlanned
-                        ? "Planned"
-                        : "Planned";
+                        ? getDayStateLabel("planned")
+                        : getDayStateLabel("planned");
           const dayTone = needsAttention ? "text-[hsl(var(--signal-risk))]" : isToday ? "text-accent" : "text-muted";
 
           return (
@@ -403,7 +404,7 @@ export function WeekCalendar({
                           ? "border-[hsl(var(--signal-load)/0.45)] bg-[hsl(var(--signal-load)/0.08)]"
                           : state === "extra"
                             ? "border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.10)]"
-                            : state === "assigned"
+                            : state === "assigned_from_upload"
                               ? "border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.1)]"
                               : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]";
 
@@ -412,8 +413,8 @@ export function WeekCalendar({
                       <span className="rounded-full border border-[hsl(var(--signal-load)/0.4)] px-1.5 py-0.5 text-[10px] text-[hsl(var(--signal-load))]">Extra</span>
                     ) : state === "moved" ? (
                       <span className="rounded-full border border-[hsl(var(--signal-load)/0.4)] px-1.5 py-0.5 text-[10px] text-[hsl(var(--signal-load))]">Moved</span>
-                    ) : state === "assigned" ? (
-                      <span className="rounded-full border border-[hsl(var(--accent-performance)/0.4)] px-1.5 py-0.5 text-[10px] text-accent/95">Assigned</span>
+                    ) : state === "assigned_from_upload" ? (
+                      <span className="rounded-full border border-[hsl(var(--accent-performance)/0.4)] px-1.5 py-0.5 text-[10px] text-accent/95">Assigned from upload</span>
                     ) : (
                       <SessionStatusChip status={session.status} compact />
                     );

--- a/lib/calendar/day-items.test.ts
+++ b/lib/calendar/day-items.test.ts
@@ -66,7 +66,7 @@ describe("buildCalendarDisplayItems", () => {
     expect(items[0]).toMatchObject({
       id: "activity:a2",
       date: "2026-03-03",
-      status: "completed",
+      status: "unmatched_upload",
       displayType: "completed_activity"
     });
   });

--- a/lib/calendar/day-items.ts
+++ b/lib/calendar/day-items.ts
@@ -1,3 +1,5 @@
+import type { SessionLifecycleState } from "@/lib/training/semantics";
+
 export type CalendarSessionRecord = {
   id: string;
   date: string;
@@ -6,7 +8,7 @@ export type CalendarSessionRecord = {
   duration_minutes: number | null;
   notes: string | null;
   created_at: string;
-  status?: "planned" | "completed" | "skipped";
+  status?: SessionLifecycleState;
   is_key?: boolean | null;
 };
 
@@ -38,7 +40,7 @@ export type CalendarDisplayItem = {
   duration: number;
   notes: string | null;
   created_at: string;
-  status: "planned" | "completed" | "skipped";
+  status: SessionLifecycleState;
   linkedActivityCount: number;
   linkedStats: { durationMin: number; distanceKm: number; avgHr: number | null; avgPower: number | null } | null;
   unassignedSameDayCount: number;
@@ -188,7 +190,7 @@ export function buildCalendarDisplayItems(input: {
       duration: item.duration_min,
       notes: null,
       created_at: item.created_at,
-      status: "completed",
+      status: "unmatched_upload",
       linkedActivityCount: 1,
       linkedStats: {
         durationMin: item.duration_min,

--- a/lib/plans/skip-notes.ts
+++ b/lib/plans/skip-notes.ts
@@ -1,8 +1,10 @@
+import type { SessionLifecycleState } from "@/lib/training/semantics";
+
 const SKIP_TAG_PATTERN = /\[skipped\s\d{4}-\d{2}-\d{2}\]/i;
 const SKIP_TAG_REMOVE_PATTERN = /\n?\[skipped\s\d{4}-\d{2}-\d{2}\]/gi;
 
 export function appendSkipTag(notes: string | null | undefined, now: Date): string {
-  const currentNotes = notes ?? '';
+  const currentNotes = notes ?? "";
 
   if (SKIP_TAG_PATTERN.test(currentNotes)) {
     return currentNotes;
@@ -13,16 +15,16 @@ export function appendSkipTag(notes: string | null | undefined, now: Date): stri
 }
 
 export function clearSkipTag(notes: string | null | undefined): string | null {
-  const nextNotes = (notes ?? '').replace(SKIP_TAG_REMOVE_PATTERN, '').trim();
+  const nextNotes = (notes ?? "").replace(SKIP_TAG_REMOVE_PATTERN, "").trim();
   return nextNotes || null;
 }
 
 export function syncSkipTagForStatus(
   notes: string | null | undefined,
-  status: 'planned' | 'completed' | 'skipped',
+  status: SessionLifecycleState,
   now: Date
 ): string | null {
-  if (status === 'skipped') {
+  if (status === "skipped") {
     return appendSkipTag(notes, now);
   }
 

--- a/lib/training/semantics.test.ts
+++ b/lib/training/semantics.test.ts
@@ -1,0 +1,32 @@
+import {
+  DAY_STATE_LABELS,
+  EXECUTION_RESULT_LABELS,
+  getExecutionResultLabel,
+  getSessionIntentLabel,
+  getSessionLifecycleLabel,
+  getSessionRoleLabel,
+  SESSION_INTENT_CATEGORIES,
+  SESSION_LIFECYCLE_LABELS,
+  SESSION_LIFECYCLE_TONES
+} from "./semantics";
+
+describe("training semantics", () => {
+  it("exposes labels for all session lifecycle states", () => {
+    expect(SESSION_LIFECYCLE_LABELS.assigned_from_upload).toBe("Assigned from upload");
+    expect(SESSION_LIFECYCLE_LABELS.unmatched_upload).toBe("Unmatched upload");
+    expect(getSessionLifecycleLabel("moved")).toBe("Moved");
+  });
+
+  it("exposes day, role, and intent labels", () => {
+    expect(DAY_STATE_LABELS.needs_attention).toBe("Needs attention");
+    expect(getSessionRoleLabel("supporting")).toBe("Supporting");
+    expect(getSessionIntentLabel("z2_endurance")).toBe("Z2 endurance");
+    expect(SESSION_INTENT_CATEGORIES).toContain("technique_swim");
+  });
+
+  it("exposes execution labels and shared tone mapping", () => {
+    expect(getExecutionResultLabel("partial_intent")).toBe("Partial intent");
+    expect(EXECUTION_RESULT_LABELS.missed_intent).toBe("Missed intent");
+    expect(SESSION_LIFECYCLE_TONES.unmatched_upload).toBe("attention");
+  });
+});

--- a/lib/training/semantics.ts
+++ b/lib/training/semantics.ts
@@ -1,0 +1,147 @@
+/**
+ * Shared product vocabulary for planning and execution states.
+ *
+ * Keep page-level view models aligned by importing these types and helper
+ * functions instead of redefining local string unions.
+ */
+
+export const SESSION_LIFECYCLE_STATES = [
+  "planned",
+  "completed",
+  "skipped",
+  "moved",
+  "extra",
+  "assigned_from_upload",
+  "unmatched_upload"
+] as const;
+
+export type SessionLifecycleState = (typeof SESSION_LIFECYCLE_STATES)[number];
+
+export const DAY_STATES = [
+  "today",
+  "planned",
+  "complete",
+  "rest_day",
+  "available",
+  "open_capacity",
+  "needs_attention"
+] as const;
+
+export type DayState = (typeof DAY_STATES)[number];
+
+export const SESSION_ROLE_STATES = ["key", "supporting", "recovery", "optional"] as const;
+
+export type SessionRoleState = (typeof SESSION_ROLE_STATES)[number];
+
+export const SESSION_INTENT_CATEGORIES = [
+  "z2_endurance",
+  "recovery",
+  "threshold",
+  "aerobic_swim",
+  "technique_swim",
+  "strength_maintenance",
+  "long_endurance",
+  "tempo",
+  "intervals",
+  "easy_run",
+  "easy_bike",
+  "endurance_ride",
+  "endurance_swim"
+] as const;
+
+export type SessionIntentCategory = (typeof SESSION_INTENT_CATEGORIES)[number];
+
+export const EXECUTION_RESULT_STATES = ["matched_intent", "partial_intent", "missed_intent"] as const;
+
+export type ExecutionResultState = (typeof EXECUTION_RESULT_STATES)[number];
+
+export const SESSION_LIFECYCLE_LABELS: Record<SessionLifecycleState, string> = {
+  planned: "Planned",
+  completed: "Completed",
+  skipped: "Skipped",
+  moved: "Moved",
+  extra: "Extra",
+  assigned_from_upload: "Assigned from upload",
+  unmatched_upload: "Unmatched upload"
+};
+
+export const DAY_STATE_LABELS: Record<DayState, string> = {
+  today: "Today",
+  planned: "Planned",
+  complete: "Complete",
+  rest_day: "Rest day",
+  available: "Available",
+  open_capacity: "Open capacity",
+  needs_attention: "Needs attention"
+};
+
+export const SESSION_ROLE_LABELS: Record<SessionRoleState, string> = {
+  key: "Key",
+  supporting: "Supporting",
+  recovery: "Recovery",
+  optional: "Optional"
+};
+
+export const SESSION_INTENT_LABELS: Record<SessionIntentCategory, string> = {
+  z2_endurance: "Z2 endurance",
+  recovery: "Recovery",
+  threshold: "Threshold",
+  aerobic_swim: "Aerobic swim",
+  technique_swim: "Technique swim",
+  strength_maintenance: "Strength maintenance",
+  long_endurance: "Long endurance",
+  tempo: "Tempo",
+  intervals: "Intervals",
+  easy_run: "Easy run",
+  easy_bike: "Easy bike",
+  endurance_ride: "Endurance ride",
+  endurance_swim: "Endurance swim"
+};
+
+export const EXECUTION_RESULT_LABELS: Record<ExecutionResultState, string> = {
+  matched_intent: "Matched intent",
+  partial_intent: "Partial intent",
+  missed_intent: "Missed intent"
+};
+
+export type StateTone = "neutral" | "success" | "warning" | "attention" | "info";
+
+export const SESSION_LIFECYCLE_TONES: Record<SessionLifecycleState, StateTone> = {
+  planned: "neutral",
+  completed: "success",
+  skipped: "warning",
+  moved: "info",
+  extra: "info",
+  assigned_from_upload: "success",
+  unmatched_upload: "attention"
+};
+
+export const DAY_STATE_TONES: Record<DayState, StateTone> = {
+  today: "info",
+  planned: "neutral",
+  complete: "success",
+  rest_day: "neutral",
+  available: "info",
+  open_capacity: "warning",
+  needs_attention: "attention"
+};
+
+export function getSessionLifecycleLabel(state: SessionLifecycleState) {
+  return SESSION_LIFECYCLE_LABELS[state];
+}
+
+export function getDayStateLabel(state: DayState) {
+  return DAY_STATE_LABELS[state];
+}
+
+export function getSessionRoleLabel(state: SessionRoleState) {
+  return SESSION_ROLE_LABELS[state];
+}
+
+export function getSessionIntentLabel(state: SessionIntentCategory) {
+  return SESSION_INTENT_LABELS[state];
+}
+
+export function getExecutionResultLabel(state: ExecutionResultState) {
+  return EXECUTION_RESULT_LABELS[state];
+}

--- a/lib/training/week-metrics.ts
+++ b/lib/training/week-metrics.ts
@@ -1,4 +1,6 @@
-export type SessionStatus = "planned" | "completed" | "skipped";
+import type { SessionLifecycleState } from "@/lib/training/semantics";
+
+export type SessionStatus = SessionLifecycleState;
 
 export type WeekMetricSession = {
   id: string;

--- a/lib/ui/status-chip.tsx
+++ b/lib/ui/status-chip.tsx
@@ -1,11 +1,25 @@
 import type { ReactNode } from "react";
 
-export type SessionStatus = "planned" | "completed" | "skipped";
+import {
+  getSessionLifecycleLabel,
+  type SessionLifecycleState,
+  SESSION_LIFECYCLE_TONES
+} from "@/lib/training/semantics";
+
+export type SessionStatus = SessionLifecycleState;
 
 const statusMeta: Record<SessionStatus, { label: string; icon: ReactNode; className: string }> = {
-  planned: { label: "Planned", icon: "◌", className: "status-chip-planned" },
-  completed: { label: "Completed", icon: "✓", className: "status-chip-completed" },
-  skipped: { label: "Skipped", icon: "—", className: "status-chip-skipped" }
+  planned: { label: getSessionLifecycleLabel("planned"), icon: "◌", className: "status-chip-planned" },
+  completed: { label: getSessionLifecycleLabel("completed"), icon: "✓", className: "status-chip-completed" },
+  skipped: { label: getSessionLifecycleLabel("skipped"), icon: "—", className: "status-chip-skipped" },
+  moved: { label: getSessionLifecycleLabel("moved"), icon: "↔", className: "status-chip-moved" },
+  extra: { label: getSessionLifecycleLabel("extra"), icon: "+", className: "status-chip-extra" },
+  assigned_from_upload: {
+    label: getSessionLifecycleLabel("assigned_from_upload"),
+    icon: "↳",
+    className: "status-chip-assigned"
+  },
+  unmatched_upload: { label: getSessionLifecycleLabel("unmatched_upload"), icon: "?", className: "status-chip-unmatched" }
 };
 
 export function getSessionStatusMeta(status: SessionStatus) {
@@ -22,9 +36,13 @@ export function SessionStatusChip({
   compact?: boolean;
 }) {
   const meta = getSessionStatusMeta(status);
+  const toneClass = `status-chip-tone-${SESSION_LIFECYCLE_TONES[status]}`;
 
   return (
-    <span className={`status-chip ${meta.className} ${compact ? "status-chip-compact" : ""} ${className}`.trim()} aria-label={meta.label}>
+    <span
+      className={`status-chip ${meta.className} ${toneClass} ${compact ? "status-chip-compact" : ""} ${className}`.trim()}
+      aria-label={meta.label}
+    >
       <span aria-hidden="true">{meta.icon}</span>
       {compact ? null : <span>{meta.label}</span>}
     </span>


### PR DESCRIPTION
### Motivation
- Provide a single source-of-truth for session/day/intent/role/execution states so Dashboard, Plan, Calendar, and Coach share consistent types, labels, and tone/variant mappings without duplicating ad-hoc string unions.
- Surface human-readable label helpers and a small style-tone mapping so view layers can render consistent text and style variants without page-level string literals.

### Description
- Introduces `lib/training/semantics.ts` which defines typed state vocabularies for session lifecycle states, day states, session roles, session intent categories, execution result states, plus label maps and `StateTone` mappings and `get*Label` helpers.
- Updates `lib/ui/status-chip.tsx` to consume the shared `SessionLifecycleState`, use the shared labels, emit a tone CSS class via `SESSION_LIFECYCLE_TONES`, and support the expanded lifecycle states (`moved`, `extra`, `assigned_from_upload`, `unmatched_upload`).
- Adapts calendar and related view-models: `lib/calendar/day-items.ts` now uses shared lifecycle typing and maps unlinked uploaded activities to `unmatched_upload`, and `app/(protected)/calendar/week-calendar.tsx` and `app/(protected)/calendar/page.tsx` were updated to use `SessionLifecycleState` and `getDayStateLabel` (without UI layout changes) and standardize the assigned-from-upload wording.
- Small adapters: `lib/plans/skip-notes.ts` and `lib/training/week-metrics.ts` now import the shared lifecycle type, and tests/fixtures were updated and extended (`lib/calendar/day-items.test.ts` and new `lib/training/semantics.test.ts`) to cover the new semantics.

### Testing
- Ran `npm test` and all test suites passed (42 tests across 14 suites) after updates.
- Ran `npm run typecheck` (`tsc --noEmit`) and the project typecheck completed with no errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b0041d2b548332a070f90defc5c77c)