### PR TITLE
Enrich session model and centralize display-name fallback

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -3,6 +3,7 @@ import { isValidIsoDate } from "@/lib/date/iso";
 import { WeekCalendar } from "./week-calendar";
 import { computeWeekMinuteTotals, computeWeekSessionCounts } from "@/lib/training/week-metrics";
 import { buildCalendarDisplayItems } from "@/lib/calendar/day-items";
+import { getSessionDisplayName } from "@/lib/training/session";
 import type { SessionLifecycleState } from "@/lib/training/semantics";
 
 type Session = {
@@ -10,6 +11,14 @@ type Session = {
   date: string;
   sport: string;
   type: string;
+  session_name?: string | null;
+  discipline?: string | null;
+  subtype?: string | null;
+  workout_type?: string | null;
+  intent_category?: string | null;
+  session_role?: "key" | "supporting" | "recovery" | "optional" | "Key" | "Supporting" | "Recovery" | "Optional" | null;
+  source_metadata?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
   duration_minutes: number | null;
   notes: string | null;
   created_at: string;
@@ -71,7 +80,7 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
   {
     const query = await supabase
       .from("sessions")
-      .select("id,date,sport,type,duration_minutes,notes,created_at,status,is_key")
+      .select("id,date,sport,type,session_name,discipline,subtype,workout_type,duration_minutes,intent_category,session_role,source_metadata,execution_result,notes,created_at,status,is_key")
       .gte("date", weekStart)
       .lt("date", weekEnd)
       .order("date", { ascending: true })
@@ -118,7 +127,15 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       notes: session.notes,
       created_at: session.created_at,
       status: undefined,
-      is_key: false
+      is_key: false,
+      session_name: null,
+      discipline: session.sport,
+      subtype: null,
+      workout_type: null,
+      intent_category: null,
+      session_role: null,
+      source_metadata: null,
+      execution_result: null
     }));
   } else if (sessionError) {
     throw new Error(sessionError.message ?? "Failed to load calendar sessions.");
@@ -185,7 +202,7 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       <WeekCalendar
         weekDays={weekDays}
         sessions={sessions}
-        executionLabel={nextTodaySession ? `Next key session: ${nextTodaySession.type}` : "No planned session today"}
+        executionLabel={nextTodaySession ? `Next key session: ${getSessionDisplayName(nextTodaySession)}` : "No planned session today"}
         executionSubtext={extraSessionCount > 0 ? `${extraSessionCount} unscheduled uploads count as extra work.` : "Uploads and schedule aligned"}
         completedCount={countMetrics.completedCount}
         plannedTotalCount={countMetrics.plannedTotalCount}

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -2,9 +2,10 @@
 
 import { useEffect, useMemo, useState, useTransition } from "react";
 import Link from "next/link";
-import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { SessionStatusChip } from "@/lib/ui/status-chip";
+import { getSessionDisplayName } from "@/lib/training/session";
 import { getDayStateLabel, type SessionLifecycleState } from "@/lib/training/semantics";
 import { clearSkippedAction, markSkippedAction, moveSessionAction, quickAddSessionAction } from "@/app/(protected)/calendar/actions";
 
@@ -17,6 +18,14 @@ type CalendarSession = {
   date: string;
   sport: string;
   type: string;
+  sessionName?: string | null;
+  discipline?: string | null;
+  subtype?: string | null;
+  workoutType?: string | null;
+  intentCategory?: string | null;
+  role?: "key" | "supporting" | "recovery" | "optional" | null;
+  source?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  executionResult?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
   duration: number;
   notes: string | null;
   created_at: string;
@@ -32,13 +41,6 @@ type WeekDay = { iso: string; weekday: string; label: string };
 type RecentMove = { sessionId: string; fromDate: string; toDate: string };
 
 const dayFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "2-digit", timeZone: "UTC" });
-const sportFallbackTitle: Record<string, string> = {
-  swim: "Aerobic Swim",
-  bike: "Endurance Ride",
-  run: "Easy Run",
-  strength: "General Strength"
-};
-
 
 function calendarDisciplineChipTone(sport: string) {
   const tones: Record<string, { bg: string; text: string; dot: string; border: string }> = {
@@ -75,17 +77,12 @@ function getActivityId(sessionId: string) {
 }
 
 function getSessionTitle(session: CalendarSession) {
-  const explicit = session.type?.trim();
-  if (explicit && explicit.toLowerCase() !== "session") {
-    return explicit;
-  }
-
-  const fallbackSubtype = sportFallbackTitle[session.sport];
-  if (fallbackSubtype) {
-    return fallbackSubtype;
-  }
-
-  return getDisciplineMeta(session.sport).label;
+  return getSessionDisplayName({
+    sessionName: session.sessionName ?? session.type,
+    discipline: session.discipline ?? session.sport,
+    subtype: session.subtype,
+    workoutType: session.workoutType
+  });
 }
 
 function getSessionState(session: CalendarSession, recentMoves: RecentMove[]) {

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
+import { getSessionDisplayName } from "@/lib/training/session";
 import { computeWeekMinuteTotals } from "@/lib/training/week-metrics";
 import { addDays, getMonday, weekRangeLabel } from "../week-context";
 
@@ -10,6 +11,13 @@ type Session = {
   date: string;
   sport: string;
   type: string;
+  session_name?: string | null;
+  subtype?: string | null;
+  workout_type?: string | null;
+  intent_category?: string | null;
+  session_role?: "key" | "supporting" | "recovery" | "optional" | "Key" | "Supporting" | "Recovery" | "Optional" | null;
+  source_metadata?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
   duration_minutes: number | null;
   notes: string | null;
   created_at: string;
@@ -100,17 +108,6 @@ function weekdayName(isoDate: string) {
   return new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "UTC" }).format(new Date(`${isoDate}T00:00:00.000Z`));
 }
 
-function getSessionDisplayName(session: Pick<Session, "type" | "sport">) {
-  const rawType = session.type?.trim() ?? "";
-  const isGenericType = /^(session|workout|training)$/i.test(rawType);
-
-  if (rawType && !isGenericType) {
-    return rawType;
-  }
-
-  return getDisciplineMeta(session.sport).label;
-}
-
 function getDayMeaningLabel(daySessions: Session[]) {
   const plannedSessions = daySessions.filter((session) => session.status === "planned");
   if (plannedSessions.length === 0) return null;
@@ -174,7 +171,7 @@ export default async function DashboardPage({
   if (activePlanId) {
     const primary = await supabase
       .from("sessions")
-      .select("id,plan_id,date,sport,type,duration_minutes,notes,created_at,status,is_key")
+      .select("id,plan_id,date,sport,type,session_name,subtype,workout_type,duration_minutes,intent_category,session_role,source_metadata,execution_result,notes,created_at,status,is_key")
       .eq("plan_id", activePlanId)
       .gte("date", weekStart)
       .lt("date", weekEnd)
@@ -334,7 +331,7 @@ export default async function DashboardPage({
   const attentionItem: ContextualItem | null = overdueKeySession
     ? {
         kicker: "Needs attention",
-        title: `Missed key session: ${overdueKeySession.type}`,
+        title: `Missed key session: ${getSessionDisplayName(overdueKeySession)}`,
         detail: "Missing this key session shifts too much load into the back half of the week.",
         cta: "Reschedule key session",
         href: `/calendar?focus=${overdueKeySession.id}`,

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -26,7 +26,15 @@ type Session = {
   date: string;
   sport: string;
   type: string;
+  session_name?: string | null;
+  discipline?: string | null;
+  subtype?: string | null;
+  workout_type?: string | null;
   target: string | null;
+  intent_category?: string | null;
+  session_role?: "key" | "supporting" | "recovery" | "optional" | "Key" | "Supporting" | "Recovery" | "Optional" | null;
+  source_metadata?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
   duration_minutes: number;
   day_order: number | null;
   notes: string | null;
@@ -34,7 +42,6 @@ type Session = {
   distance_unit: string | null;
   status: "planned" | "completed" | "skipped";
   is_key?: boolean | null;
-  session_role?: "Key" | "Supporting" | "Recovery" | "Optional" | null;
 };
 
 function buildPlanWeeks(startDateIso: string, durationWeeks: number, planId: string) {
@@ -117,7 +124,7 @@ export default async function PlanPage({ searchParams }: { searchParams?: { plan
   if (selectedPlan) {
     const primaryQuery = await supabase
       .from("sessions")
-      .select("id,plan_id,week_id,date,sport,type,target,duration_minutes,day_order,notes,distance_value,distance_unit,status,is_key,session_role")
+      .select("id,plan_id,week_id,date,sport,type,session_name,discipline,subtype,workout_type,target,duration_minutes,intent_category,session_role,source_metadata,execution_result,day_order,notes,distance_value,distance_unit,status,is_key")
       .eq("plan_id", selectedPlan.id)
       .order("date", { ascending: true })
       .order("day_order", { ascending: true, nullsFirst: false });
@@ -155,7 +162,15 @@ export default async function PlanPage({ searchParams }: { searchParams?: { plan
         sport: session.sport,
         type: session.type,
         duration_minutes: session.duration,
+        session_name: null,
+        discipline: session.sport,
+        subtype: null,
+        workout_type: null,
         target: null,
+        intent_category: null,
+        session_role: null,
+        source_metadata: null,
+        execution_result: null,
         day_order: null,
         notes: session.notes,
         distance_value: null,

--- a/app/(protected)/plan/plan-editor.tsx
+++ b/app/(protected)/plan/plan-editor.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from "react";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
+import { getOptionalSessionRoleLabel, getSessionDisplayName } from "@/lib/training/session";
 import {
   createSessionAction,
   deleteSessionAction,
@@ -23,7 +24,7 @@ type TrainingWeek = {
   target_minutes: number | null;
   target_tss: number | null;
 };
-type SessionRole = "Key" | "Supporting" | "Recovery" | "Optional";
+type SessionRole = "Key" | "Supporting" | "Recovery" | "Optional" | "key" | "supporting" | "recovery" | "optional";
 type Session = {
   id: string;
   plan_id: string;
@@ -31,7 +32,14 @@ type Session = {
   date: string;
   sport: string;
   type: string;
+  session_name?: string | null;
+  discipline?: string | null;
+  subtype?: string | null;
+  workout_type?: string | null;
   target: string | null;
+  intent_category?: string | null;
+  source_metadata?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
   duration_minutes: number;
   day_order: number | null;
   notes: string | null;
@@ -109,39 +117,6 @@ function resolveInitialWeekId(weeks: TrainingWeek[], explicitWeekId?: string) {
 
   const mostRecentPastWeek = [...byStartDate].reverse().find((week) => week.week_start_date < todayIso);
   return mostRecentPastWeek?.id ?? byStartDate[0].id;
-}
-
-function sessionRoleLabel(session: Session) {
-  if (session.session_role) return session.session_role;
-  if (session.is_key) return "Key";
-  return null;
-}
-
-function sessionTitle(session: Session) {
-  const explicit = session.type?.trim();
-  const discipline = getDisciplineMeta(session.sport).label;
-  const subtype = session.target?.trim();
-
-  const defaultBySport: Record<string, string> = {
-    swim: "Aerobic Swim",
-    bike: "Endurance Ride",
-    run: "Easy Run",
-    strength: "General Strength",
-    other: "Training Session"
-  };
-
-  const explicitLower = explicit?.toLowerCase() ?? "";
-  const isGenericExplicit = explicitLower === "session" || explicitLower === discipline.toLowerCase();
-
-  if (explicit && !isGenericExplicit) {
-    return explicit;
-  }
-
-  if (subtype && !/^z\d/i.test(subtype) && subtype.length <= 24) {
-    return `${subtype} ${discipline}`;
-  }
-
-  return defaultBySport[session.sport] ?? discipline;
 }
 
 function disciplineChipTone(sport: string) {
@@ -238,7 +213,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
   );
 
   const totalMinutes = weekSessions.reduce((sum, s) => sum + s.duration_minutes, 0);
-  const keySessions = weekSessions.filter((session) => sessionRoleLabel(session) === "Key").length;
+  const keySessions = weekSessions.filter((session) => getOptionalSessionRoleLabel(session) === "Key").length;
 
   const disciplineTotals = ["swim", "bike", "run", "strength", "other"]
     .map((sport) => ({
@@ -252,7 +227,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
         const iso = addDays(selectedWeek.week_start_date, index);
         const daySessions = weekSessions.filter((session) => session.date === iso);
         const totalDayMinutes = daySessions.reduce((sum, session) => sum + session.duration_minutes, 0);
-        const hasKeySession = daySessions.some((session) => sessionRoleLabel(session) === "Key");
+        const hasKeySession = daySessions.some((session) => getOptionalSessionRoleLabel(session) === "Key");
         return {
           iso,
           label: weekdayFormatter.format(new Date(`${iso}T00:00:00.000Z`)),
@@ -423,7 +398,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
               <div className="flex-1 space-y-1.5">
                 {day.sessions.map((session) => {
                   const meta = getDisciplineMeta(session.sport);
-                  const role = sessionRoleLabel(session);
+                  const role = getOptionalSessionRoleLabel(session);
                   return (
                     <button key={session.id} type="button" onClick={() => setActiveSessionId(session.id)} className="w-full rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-2 py-2 text-left hover:border-[hsl(var(--accent-performance)/0.5)]">
                       <div className="flex items-center justify-between gap-1">
@@ -440,7 +415,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
                         </span>
                         {role ? <span className="rounded-full border border-[hsl(var(--border))] px-1.5 py-0.5 text-[10px] text-muted">{role}</span> : null}
                       </div>
-                      <p className="mt-1 line-clamp-2 text-xs font-semibold leading-snug">{sessionTitle(session)}</p>
+                      <p className="mt-1 line-clamp-2 text-xs font-semibold leading-snug">{getSessionDisplayName({ sessionName: session.session_name ?? session.type, discipline: session.discipline ?? session.sport, subtype: session.subtype ?? session.target, workoutType: session.workout_type, intentCategory: session.intent_category, source: session.source_metadata, executionResult: session.execution_result })}</p>
                       <p className="text-[11px] text-muted">{session.duration_minutes} min{session.target ? ` · ${session.target}` : ""}</p>
                     </button>
                   );
@@ -461,7 +436,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
               </div>
               <div className="space-y-1.5">
                 {day.sessions.map((session) => {
-                  const role = sessionRoleLabel(session);
+                  const role = getOptionalSessionRoleLabel(session);
                   return (
                     <button key={session.id} type="button" onClick={() => setActiveSessionId(session.id)} className="w-full rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-2 py-2 text-left text-xs">
                       <div className="flex items-center justify-between gap-2">
@@ -478,7 +453,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
                         </span>
                         {role ? <span className="rounded-full border border-[hsl(var(--border))] px-1.5 py-0.5 text-[10px] text-muted">{role}</span> : null}
                       </div>
-                      <p className="mt-1 line-clamp-2 font-semibold leading-snug">{sessionTitle(session)}</p>
+                      <p className="mt-1 line-clamp-2 font-semibold leading-snug">{getSessionDisplayName({ sessionName: session.session_name ?? session.type, discipline: session.discipline ?? session.sport, subtype: session.subtype ?? session.target, workoutType: session.workout_type, intentCategory: session.intent_category, source: session.source_metadata, executionResult: session.execution_result })}</p>
                       <p className="text-muted">{session.duration_minutes} min</p>
                     </button>
                   );

--- a/lib/calendar/day-items.ts
+++ b/lib/calendar/day-items.ts
@@ -1,10 +1,19 @@
-import type { SessionLifecycleState } from "@/lib/training/semantics";
+import type { ExecutionResultState, SessionLifecycleState, SessionRoleState } from "@/lib/training/semantics";
+import { normalizeSessionModel } from "@/lib/training/session";
 
 export type CalendarSessionRecord = {
   id: string;
   date: string;
   sport: string;
   type: string;
+  session_name?: string | null;
+  discipline?: string | null;
+  subtype?: string | null;
+  workout_type?: string | null;
+  intent_category?: string | null;
+  session_role?: SessionRoleState | "Key" | "Supporting" | "Recovery" | "Optional" | null;
+  source_metadata?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  execution_result?: { status?: ExecutionResultState | null; summary?: string | null } | null;
   duration_minutes: number | null;
   notes: string | null;
   created_at: string;
@@ -37,6 +46,14 @@ export type CalendarDisplayItem = {
   date: string;
   sport: string;
   type: string;
+  sessionName: string | null;
+  discipline: string;
+  subtype: string | null;
+  workoutType: string | null;
+  intentCategory: string | null;
+  role: SessionRoleState | null;
+  source: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
+  executionResult: { status?: ExecutionResultState | null; summary?: string | null } | null;
   duration: number;
   notes: string | null;
   created_at: string;
@@ -153,6 +170,19 @@ export function buildCalendarDisplayItems(input: {
   }, {});
 
   const plannedItems: CalendarDisplayItem[] = sessions.map((session) => {
+    const normalizedSession = normalizeSessionModel({
+      sessionName: session.session_name,
+      discipline: session.discipline ?? session.sport,
+      subtype: session.subtype,
+      workoutType: session.workout_type,
+      type: session.type,
+      duration_minutes: session.duration_minutes,
+      intent_category: session.intent_category,
+      session_role: session.session_role,
+      sourceMetadata: session.source_metadata,
+      execution_result: session.execution_result,
+      is_key: session.is_key
+    });
     const linked = linkedBySession.get(session.id) ?? [];
     const linkedStats = linked[0]
       ? {
@@ -168,7 +198,15 @@ export function buildCalendarDisplayItems(input: {
       date: session.date,
       sport: session.sport,
       type: session.type,
-      duration: session.duration_minutes ?? 0,
+      sessionName: normalizedSession.sessionName,
+      discipline: normalizedSession.discipline,
+      subtype: normalizedSession.subtype,
+      workoutType: normalizedSession.workoutType,
+      intentCategory: normalizedSession.intentCategory,
+      role: normalizedSession.role,
+      source: normalizedSession.source,
+      executionResult: normalizedSession.executionResult,
+      duration: normalizedSession.durationMinutes,
       notes: session.notes,
       created_at: session.created_at,
       status: linked.length > 0 ? "completed" : fallbackStatus(session, completionLedger),
@@ -187,6 +225,14 @@ export function buildCalendarDisplayItems(input: {
       date: item.date,
       sport: item.sport,
       type: "Completed activity",
+      sessionName: "Completed activity",
+      discipline: item.sport,
+      subtype: null,
+      workoutType: null,
+      intentCategory: null,
+      role: null,
+      source: { uploadId: item.id, assignedBy: "upload" },
+      executionResult: null,
       duration: item.duration_min,
       notes: null,
       created_at: item.created_at,

--- a/lib/training/session.test.ts
+++ b/lib/training/session.test.ts
@@ -1,0 +1,37 @@
+import { getOptionalSessionRoleLabel, getSessionDisplayName, normalizeSessionModel } from "./session";
+
+describe("session helpers", () => {
+  it("prefers explicit session names when non-generic", () => {
+    expect(getSessionDisplayName({ sessionName: "Long Brick" })).toBe("Long Brick");
+  });
+
+  it("builds subtype + discipline fallback when explicit name is generic", () => {
+    expect(getSessionDisplayName({ sessionName: "Session", subtype: "Aerobic", discipline: "swim" })).toBe("Aerobic Swim");
+  });
+
+  it("falls back to discipline-only label and never returns generic Session", () => {
+    expect(getSessionDisplayName({ sessionName: "Session", discipline: "run" })).toBe("Run");
+  });
+
+  it("normalizes enriched session fields", () => {
+    expect(
+      normalizeSessionModel({
+        sport: "bike",
+        type: "Endurance",
+        duration_minutes: 90,
+        intent_category: "z2_endurance",
+        session_role: "Key"
+      })
+    ).toMatchObject({
+      discipline: "bike",
+      subtype: "Endurance",
+      durationMinutes: 90,
+      intentCategory: "z2_endurance",
+      role: "key"
+    });
+  });
+
+  it("returns null optional role label when role is unset", () => {
+    expect(getOptionalSessionRoleLabel({ sport: "run" })).toBeNull();
+  });
+});

--- a/lib/training/session.ts
+++ b/lib/training/session.ts
@@ -1,0 +1,106 @@
+import { getDisciplineMeta } from "@/lib/ui/discipline";
+import { getSessionRoleLabel, type ExecutionResultState, type SessionRoleState } from "@/lib/training/semantics";
+
+export type SessionSourceMetadata = {
+  uploadId?: string | null;
+  assignmentId?: string | null;
+  assignedBy?: "planner" | "upload" | "coach" | null;
+};
+
+export type SessionExecutionResultPlaceholder = {
+  status?: ExecutionResultState | null;
+  summary?: string | null;
+};
+
+export type SessionModelInput = {
+  sessionName?: string | null;
+  discipline?: string | null;
+  sport?: string | null;
+  subtype?: string | null;
+  workoutType?: string | null;
+  type?: string | null;
+  durationMinutes?: number | null;
+  duration_minutes?: number | null;
+  intentCategory?: string | null;
+  intent_category?: string | null;
+  role?: SessionRoleState | "Key" | "Supporting" | "Recovery" | "Optional" | null;
+  session_role?: SessionRoleState | "Key" | "Supporting" | "Recovery" | "Optional" | null;
+  is_key?: boolean | null;
+  source?: SessionSourceMetadata | null;
+  sourceMetadata?: SessionSourceMetadata | null;
+  executionResult?: SessionExecutionResultPlaceholder | null;
+  execution_result?: SessionExecutionResultPlaceholder | null;
+};
+
+export type EnrichedSessionModel = {
+  sessionName: string | null;
+  discipline: string;
+  subtype: string | null;
+  workoutType: string | null;
+  durationMinutes: number;
+  intentCategory: string | null;
+  role: SessionRoleState | null;
+  source: SessionSourceMetadata | null;
+  executionResult: SessionExecutionResultPlaceholder | null;
+};
+
+const GENERIC_SESSION_NAMES = new Set(["session", "workout", "training", "training session"]);
+
+function normalizeSessionRole(role: SessionModelInput["role"]): SessionRoleState | null {
+  if (!role) return null;
+  const normalized = role.toString().trim().toLowerCase();
+  if (normalized === "key" || normalized === "supporting" || normalized === "recovery" || normalized === "optional") {
+    return normalized;
+  }
+  return null;
+}
+
+function cleanValue(value?: string | null) {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+export function normalizeSessionModel(input: SessionModelInput): EnrichedSessionModel {
+  return {
+    sessionName: cleanValue(input.sessionName),
+    discipline: cleanValue(input.discipline) ?? cleanValue(input.sport) ?? "other",
+    subtype: cleanValue(input.subtype) ?? cleanValue(input.workoutType) ?? cleanValue(input.type),
+    workoutType: cleanValue(input.workoutType) ?? cleanValue(input.subtype) ?? cleanValue(input.type),
+    durationMinutes: Math.max(0, input.durationMinutes ?? input.duration_minutes ?? 0),
+    intentCategory: cleanValue(input.intentCategory) ?? cleanValue(input.intent_category),
+    role: normalizeSessionRole(input.role ?? input.session_role ?? (input.is_key ? "key" : null)),
+    source: input.source ?? input.sourceMetadata ?? null,
+    executionResult: input.executionResult ?? input.execution_result ?? null
+  };
+}
+
+export function getSessionDisplayName(input: SessionModelInput) {
+  const session = normalizeSessionModel(input);
+  const disciplineLabel = getDisciplineMeta(session.discipline).label;
+
+  const explicit = cleanValue(session.sessionName);
+  const explicitLower = explicit?.toLowerCase() ?? "";
+  if (explicit && !GENERIC_SESSION_NAMES.has(explicitLower)) {
+    return explicit;
+  }
+
+  const subtype = cleanValue(session.subtype);
+  if (subtype) {
+    const subtypeLower = subtype.toLowerCase();
+    if (subtypeLower.includes(disciplineLabel.toLowerCase())) {
+      return subtype;
+    }
+    return `${subtype} ${disciplineLabel}`;
+  }
+
+  if (disciplineLabel === "Bike") return "Bike";
+  if (disciplineLabel === "Run") return "Run";
+  if (disciplineLabel === "Swim") return "Swim";
+  if (disciplineLabel === "Strength") return "Strength";
+  return disciplineLabel;
+}
+
+export function getOptionalSessionRoleLabel(input: SessionModelInput) {
+  const role = normalizeSessionModel(input).role;
+  return role ? getSessionRoleLabel(role) : null;
+}


### PR DESCRIPTION
### Motivation
- Sessions need richer, consistent metadata so UI and coaching logic can rely on a single canonical model for naming, intent, roles, and future execution diagnosis. 
- Avoid scattered, page-by-page fallback naming and remove visible generic “Session” placeholders across Plan, Calendar, and Dashboard. 
- Support planner-authored optional roles and upload/assignment source metadata while preserving backward compatibility with older DB schemas. 

### Description
- Added a shared enrichment helper `lib/training/session.ts` that normalizes incoming session shapes, exposes `normalizeSessionModel`, `getSessionDisplayName`, and `getOptionalSessionRoleLabel`, and accepts legacy aliases (`type`, `sport`, `duration_minutes`, `session_role`, etc.).
- Centralized fallback naming in `getSessionDisplayName()` with priority: explicit non-generic `sessionName`, `subtype/workoutType + discipline` (deduped), then discipline-only fallbacks; generic names like “session”/“workout” are suppressed.
- Propagated enriched fields through data shaping and UI wiring by updating `lib/calendar/day-items.ts` (adds normalized fields to `CalendarDisplayItem`) and wiring the shared helpers into `app/(protected)/plan/plan-editor.tsx`, `app/(protected)/plan/page.tsx`, `app/(protected)/calendar/week-calendar.tsx`, `app/(protected)/calendar/page.tsx`, and `app/(protected)/dashboard/page.tsx` so existing placeholders no longer render.
- Represented optional planner-authored role as a normalized state (canonical lowercase `key|supporting|recovery|optional`), and exposed `getOptionalSessionRoleLabel()` which returns `null` when unset; UI surfaces call this helper to render role chips.
- Added focused unit tests `lib/training/session.test.ts` and extended calendar shaping to include enriched fields without redesigning pages.

### Testing
- Ran type check with `npm run typecheck` and it completed successfully.
- Ran unit tests with `npm test -- lib/training/session.test.ts lib/calendar/day-items.test.ts` and both suites passed.
- Started a local dev server (`npm run dev`) and captured a Playwright screenshot of `/calendar`, however protected page rendering in this container produced a runtime 500 due to missing Supabase environment variables (dev server booted but protected routes require `NEXT_PUBLIC_SUPABASE_*` to fully render).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b00a6a4dbc8332bdf15e0b1853742b)