### PR TITLE
Add first-pass completed session diagnosis engine

### DIFF
--- a/lib/coach/session-diagnosis.test.ts
+++ b/lib/coach/session-diagnosis.test.ts
@@ -1,0 +1,117 @@
+import { diagnoseCompletedSession } from "./session-diagnosis";
+
+describe("diagnoseCompletedSession", () => {
+  test("flags easy endurance session as missed when too hard, drifted, and variable", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "run",
+        intentCategory: "Easy Z2 run",
+        plannedDurationSec: 3600,
+        targetBands: { hr: { max: 145 } }
+      },
+      actual: {
+        durationSec: 3600,
+        avgHr: 158,
+        timeAboveTargetPct: 0.32,
+        variabilityIndex: 1.15,
+        splitMetrics: { firstHalfAvgHr: 150, lastHalfAvgHr: 162 }
+      }
+    });
+
+    expect(diagnosis.intentMatchStatus).toBe("missed_intent");
+    expect(diagnosis.diagnosisConfidence).toBe("high");
+  });
+
+  test("flags recovery session compliance issues", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "bike",
+        intentCategory: "Recovery spin",
+        targetBands: { power: { max: 170 } }
+      },
+      actual: {
+        avgPower: 190,
+        variabilityIndex: 1.14
+      }
+    });
+
+    expect(diagnosis.intentMatchStatus).toBe("missed_intent");
+    expect(diagnosis.executionSummary).toMatch(/Recovery intent/);
+  });
+
+  test("detects threshold under-target and incomplete reps", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "run",
+        intentCategory: "Threshold intervals",
+        plannedDurationSec: 4200,
+        plannedIntervals: 6,
+        targetBands: { hr: { min: 165, max: 175 } }
+      },
+      actual: {
+        durationSec: 3500,
+        avgHr: 152,
+        completedIntervals: 4,
+        variabilityIndex: 1.21
+      }
+    });
+
+    expect(diagnosis.intentMatchStatus).toBe("missed_intent");
+    expect(diagnosis.recommendedNextAction).toMatch(/recoveries|structure/i);
+  });
+
+  test("detects long endurance started too hard and faded", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "run",
+        intentCategory: "Long endurance run",
+        plannedDurationSec: 9000
+      },
+      actual: {
+        durationSec: 7600,
+        timeAboveTargetPct: 0.25,
+        splitMetrics: {
+          firstHalfAvgHr: 160,
+          lastHalfAvgHr: 148,
+          firstHalfPaceSPerKm: 300,
+          lastHalfPaceSPerKm: 345
+        }
+      }
+    });
+
+    expect(diagnosis.intentMatchStatus).toBe("missed_intent");
+    expect(diagnosis.whyItMatters).toMatch(/Pacing errors/);
+  });
+
+  test("handles swim sessions with sparse metrics using duration and completion", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "swim",
+        intentCategory: "Aerobic swim",
+        plannedDurationSec: 3000,
+        plannedIntervals: 10
+      },
+      actual: {
+        durationSec: 2900,
+        completedIntervals: 10
+      }
+    });
+
+    expect(diagnosis.intentMatchStatus).toBe("matched_intent");
+    expect(diagnosis.diagnosisConfidence).toBe("medium");
+  });
+
+  test("degrades gracefully with unknown intent and sparse data", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "other",
+        intentCategory: null
+      },
+      actual: {}
+    });
+
+    expect(diagnosis.intentMatchStatus).toBe("partial_intent");
+    expect(diagnosis.diagnosisConfidence).toBe("low");
+    expect(diagnosis.whyItMatters).toMatch(/Low data quality/);
+  });
+});

--- a/lib/coach/session-diagnosis.ts
+++ b/lib/coach/session-diagnosis.ts
@@ -1,0 +1,386 @@
+export type Sport = "swim" | "bike" | "run" | "strength" | "other";
+
+export type IntentMatchStatus = "matched_intent" | "partial_intent" | "missed_intent";
+export type DiagnosisConfidence = "high" | "medium" | "low";
+
+export type PlannedTargetBand = {
+  hr?: { min?: number; max?: number };
+  power?: { min?: number; max?: number };
+  pace?: { min?: number; max?: number };
+};
+
+export type PlannedSessionDiagnosisInput = {
+  sport?: Sport;
+  plannedDurationSec?: number | null;
+  intentCategory?: string | null;
+  targetBands?: PlannedTargetBand | null;
+  plannedIntervals?: number | null;
+};
+
+export type SplitMetrics = {
+  firstHalfAvgHr?: number;
+  lastHalfAvgHr?: number;
+  firstHalfAvgPower?: number;
+  lastHalfAvgPower?: number;
+  firstHalfPaceSPerKm?: number;
+  lastHalfPaceSPerKm?: number;
+};
+
+export type CompletedSessionDiagnosisInput = {
+  durationSec?: number | null;
+  avgHr?: number | null;
+  avgPower?: number | null;
+  avgPaceSPerKm?: number | null;
+  variabilityIndex?: number | null;
+  timeAboveTargetPct?: number | null;
+  intervalCompletionPct?: number | null;
+  completedIntervals?: number | null;
+  splitMetrics?: SplitMetrics | null;
+  metrics?: Record<string, number | null | undefined>;
+};
+
+export type SessionDiagnosisInput = {
+  planned: PlannedSessionDiagnosisInput;
+  actual: CompletedSessionDiagnosisInput;
+};
+
+export type SessionDiagnosis = {
+  intentMatchStatus: IntentMatchStatus;
+  executionSummary: string;
+  whyItMatters: string;
+  recommendedNextAction: string;
+  diagnosisConfidence: DiagnosisConfidence;
+};
+
+type IntentBucket = "easy_endurance" | "recovery" | "threshold_quality" | "long_endurance" | "swim_strength" | "unknown";
+
+type IssueKey =
+  | "too_hard"
+  | "too_variable"
+  | "high_hr"
+  | "late_drift"
+  | "under_target"
+  | "over_target"
+  | "incomplete_reps"
+  | "shortened"
+  | "inconsistent_execution"
+  | "started_too_hard"
+  | "faded_late"
+  | "sparse_data";
+
+type DiagnosisDraft = {
+  status: IntentMatchStatus;
+  issues: IssueKey[];
+  evidenceCount: number;
+};
+
+function toIntentBucket(input: PlannedSessionDiagnosisInput): IntentBucket {
+  const text = `${input.intentCategory ?? ""}`.toLowerCase();
+  const sport = input.sport ?? "other";
+
+  if (/recovery/.test(text)) return "recovery";
+  if (/threshold|tempo|vo2|interval|quality|anaerobic/.test(text)) return "threshold_quality";
+  if (/long/.test(text)) return "long_endurance";
+  if (sport === "swim" || sport === "strength") return "swim_strength";
+  if (/easy|endurance|aerobic|z2|base/.test(text)) return "easy_endurance";
+  return "unknown";
+}
+
+function getMetric(actual: CompletedSessionDiagnosisInput, key: string): number | null {
+  const direct = (actual as unknown as Record<string, number | null | undefined>)[key];
+  if (typeof direct === "number") return direct;
+  const nested = actual.metrics?.[key];
+  return typeof nested === "number" ? nested : null;
+}
+
+function ratio(numerator: number | null | undefined, denominator: number | null | undefined): number | null {
+  if (!numerator || !denominator || denominator <= 0) return null;
+  return numerator / denominator;
+}
+
+function evaluateEasyEndurance(input: SessionDiagnosisInput): DiagnosisDraft {
+  const issues: IssueKey[] = [];
+  let evidenceCount = 0;
+  const avgHr = input.actual.avgHr ?? getMetric(input.actual, "avg_hr");
+  const avgPower = input.actual.avgPower ?? getMetric(input.actual, "avg_power");
+  const targetHrMax = input.planned.targetBands?.hr?.max;
+  const targetPowerMax = input.planned.targetBands?.power?.max;
+  const timeAbove = input.actual.timeAboveTargetPct;
+  const drift = ratio(input.actual.splitMetrics?.lastHalfAvgHr, input.actual.splitMetrics?.firstHalfAvgHr);
+  const variability = input.actual.variabilityIndex;
+
+  if (typeof timeAbove === "number") {
+    evidenceCount += 1;
+    if (timeAbove >= 0.25) issues.push("too_hard");
+  }
+
+  if (targetHrMax && avgHr) {
+    evidenceCount += 1;
+    if (avgHr > targetHrMax * 1.05) issues.push("high_hr");
+  }
+
+  if (targetPowerMax && avgPower) {
+    evidenceCount += 1;
+    if (avgPower > targetPowerMax * 1.08) issues.push("too_hard");
+  }
+
+  if (drift) {
+    evidenceCount += 1;
+    if (drift > 1.06) issues.push("late_drift");
+  }
+
+  if (variability) {
+    evidenceCount += 1;
+    if (variability > 1.12) issues.push("too_variable");
+  }
+
+  if (issues.length >= 3) return { status: "missed_intent", issues, evidenceCount };
+  if (issues.length >= 1) return { status: "partial_intent", issues, evidenceCount };
+  return { status: "matched_intent", issues, evidenceCount };
+}
+
+function evaluateRecovery(input: SessionDiagnosisInput): DiagnosisDraft {
+  const draft = evaluateEasyEndurance(input);
+  const upgradedIssues = [...draft.issues];
+
+  if (draft.status !== "matched_intent") {
+    if (!upgradedIssues.includes("too_hard")) upgradedIssues.push("too_hard");
+  }
+
+  const status: IntentMatchStatus = upgradedIssues.length >= 2 ? "missed_intent" : draft.status;
+  return { status, issues: upgradedIssues, evidenceCount: draft.evidenceCount };
+}
+
+function evaluateThreshold(input: SessionDiagnosisInput): DiagnosisDraft {
+  const issues: IssueKey[] = [];
+  let evidenceCount = 0;
+  const avgHr = input.actual.avgHr ?? getMetric(input.actual, "avg_hr");
+  const avgPower = input.actual.avgPower ?? getMetric(input.actual, "avg_power");
+  const targetHr = input.planned.targetBands?.hr;
+  const targetPower = input.planned.targetBands?.power;
+  const completion =
+    input.actual.intervalCompletionPct ??
+    ratio(input.actual.completedIntervals, input.planned.plannedIntervals) ??
+    null;
+  const durationCompletion = ratio(input.actual.durationSec, input.planned.plannedDurationSec ?? null);
+  const variability = input.actual.variabilityIndex;
+
+  if (targetPower?.min && avgPower) {
+    evidenceCount += 1;
+    if (avgPower < targetPower.min * 0.92) issues.push("under_target");
+  }
+
+  if (targetPower?.max && avgPower) {
+    evidenceCount += 1;
+    if (avgPower > targetPower.max * 1.06) issues.push("over_target");
+  }
+
+  if (targetHr?.min && avgHr) {
+    evidenceCount += 1;
+    if (avgHr < targetHr.min * 0.92) issues.push("under_target");
+  }
+
+  if (targetHr?.max && avgHr) {
+    evidenceCount += 1;
+    if (avgHr > targetHr.max * 1.06) issues.push("over_target");
+  }
+
+  if (typeof completion === "number") {
+    evidenceCount += 1;
+    if (completion < 0.85) issues.push("incomplete_reps");
+  }
+
+  if (typeof durationCompletion === "number") {
+    evidenceCount += 1;
+    if (durationCompletion < 0.85) issues.push("shortened");
+  }
+
+  if (typeof variability === "number") {
+    evidenceCount += 1;
+    if (variability > 1.18) issues.push("inconsistent_execution");
+  }
+
+  if (issues.length >= 3) return { status: "missed_intent", issues, evidenceCount };
+  if (issues.length >= 1) return { status: "partial_intent", issues, evidenceCount };
+  return { status: "matched_intent", issues, evidenceCount };
+}
+
+function evaluateLongEndurance(input: SessionDiagnosisInput): DiagnosisDraft {
+  const issues: IssueKey[] = [];
+  let evidenceCount = 0;
+
+  const hrRise = ratio(input.actual.splitMetrics?.firstHalfAvgHr, input.actual.splitMetrics?.lastHalfAvgHr);
+  const paceFade = ratio(input.actual.splitMetrics?.lastHalfPaceSPerKm, input.actual.splitMetrics?.firstHalfPaceSPerKm);
+  const durationCompletion = ratio(input.actual.durationSec, input.planned.plannedDurationSec ?? null);
+
+  if (hrRise) {
+    evidenceCount += 1;
+    if (hrRise > 1.06) issues.push("started_too_hard");
+  }
+
+  if (paceFade) {
+    evidenceCount += 1;
+    if (paceFade > 1.12) issues.push("faded_late");
+  }
+
+  if (typeof input.actual.timeAboveTargetPct === "number") {
+    evidenceCount += 1;
+    if (input.actual.timeAboveTargetPct > 0.2) issues.push("too_hard");
+  }
+
+  if (typeof durationCompletion === "number") {
+    evidenceCount += 1;
+    if (durationCompletion < 0.9) issues.push("shortened");
+  }
+
+  if (issues.length >= 3) return { status: "missed_intent", issues, evidenceCount };
+  if (issues.length >= 1) return { status: "partial_intent", issues, evidenceCount };
+  return { status: "matched_intent", issues, evidenceCount };
+}
+
+function evaluateSwimStrength(input: SessionDiagnosisInput): DiagnosisDraft {
+  const issues: IssueKey[] = [];
+  let evidenceCount = 0;
+
+  const completion =
+    input.actual.intervalCompletionPct ??
+    ratio(input.actual.completedIntervals, input.planned.plannedIntervals) ??
+    null;
+  const durationCompletion = ratio(input.actual.durationSec, input.planned.plannedDurationSec ?? null);
+
+  if (typeof completion === "number") {
+    evidenceCount += 1;
+    if (completion < 0.8) issues.push("incomplete_reps");
+  }
+
+  if (typeof durationCompletion === "number") {
+    evidenceCount += 1;
+    if (durationCompletion < 0.8) issues.push("shortened");
+  }
+
+  if (issues.length >= 2) return { status: "missed_intent", issues, evidenceCount };
+  if (issues.length === 1) return { status: "partial_intent", issues, evidenceCount };
+  return { status: "matched_intent", issues, evidenceCount };
+}
+
+function evaluateUnknown(input: SessionDiagnosisInput): DiagnosisDraft {
+  const durationCompletion = ratio(input.actual.durationSec, input.planned.plannedDurationSec ?? null);
+
+  if (typeof durationCompletion !== "number") {
+    return { status: "partial_intent", issues: ["sparse_data"], evidenceCount: 0 };
+  }
+
+  if (durationCompletion >= 0.9) return { status: "matched_intent", issues: [], evidenceCount: 1 };
+  if (durationCompletion >= 0.75) return { status: "partial_intent", issues: ["shortened"], evidenceCount: 1 };
+  return { status: "missed_intent", issues: ["shortened"], evidenceCount: 1 };
+}
+
+function getConfidence(evidenceCount: number): DiagnosisConfidence {
+  if (evidenceCount >= 4) return "high";
+  if (evidenceCount >= 2) return "medium";
+  return "low";
+}
+
+function getSummary(status: IntentMatchStatus, issues: IssueKey[], bucket: IntentBucket): string {
+  if (status === "matched_intent") {
+    return "Execution stayed aligned with the planned intent.";
+  }
+
+  const issueText: Record<IssueKey, string> = {
+    too_hard: "effort ran too hard for the planned day",
+    too_variable: "effort fluctuated more than intended",
+    high_hr: "heart rate sat above the intended aerobic range",
+    late_drift: "effort drifted upward in the second half",
+    under_target: "quality work sat below target",
+    over_target: "quality work overshot the target",
+    incomplete_reps: "planned reps were not fully completed",
+    shortened: "session finished shorter than planned",
+    inconsistent_execution: "interval execution was inconsistent",
+    started_too_hard: "the session started too aggressively",
+    faded_late: "late-session fade suggests pacing or fueling issues",
+    sparse_data: "available data is too limited for a strict diagnosis"
+  };
+
+  const topIssue = issueText[issues[0] ?? "sparse_data"];
+
+  if (bucket === "recovery") {
+    return `Recovery intent was not fully met: ${topIssue}.`;
+  }
+
+  return status === "missed_intent"
+    ? `Session missed intent: ${topIssue}.`
+    : `Session partially matched intent: ${topIssue}.`;
+}
+
+function getWhyItMatters(issues: IssueKey[]): string {
+  if (issues.includes("faded_late") || issues.includes("started_too_hard")) {
+    return "Pacing errors in longer sessions can compromise durability and race-day execution.";
+  }
+
+  if (issues.includes("too_hard") || issues.includes("high_hr")) {
+    return "Repeatedly overcooking easy days can blunt adaptation and increase fatigue carryover.";
+  }
+
+  if (issues.includes("under_target") || issues.includes("incomplete_reps")) {
+    return "Missing quality targets reduces the specific stimulus this workout was meant to deliver.";
+  }
+
+  if (issues.includes("sparse_data")) {
+    return "Low data quality means this diagnosis should be treated as directional, not definitive.";
+  }
+
+  return "Execution drift from intent can lower the training value of the session.";
+}
+
+function getNextAction(issues: IssueKey[], bucket: IntentBucket): string {
+  if (issues.includes("too_hard") || issues.includes("high_hr")) {
+    return "On the next similar session, cap intensity early and keep the first third deliberately easy.";
+  }
+
+  if (issues.includes("under_target")) {
+    return "Repeat this quality set with slightly longer recoveries so you can hit target output consistently.";
+  }
+
+  if (issues.includes("over_target")) {
+    return "Start the first rep 2-3% easier and build only if control stays solid through the final reps.";
+  }
+
+  if (issues.includes("incomplete_reps") || issues.includes("shortened")) {
+    return "Keep the next session structure intact, even if you reduce intensity modestly to complete all work.";
+  }
+
+  if (issues.includes("faded_late") || issues.includes("started_too_hard")) {
+    return "Open long sessions more conservatively and plan fueling earlier to protect late-session quality.";
+  }
+
+  if (bucket === "swim_strength") {
+    return "Prioritize full session completion and smooth execution before adding extra intensity.";
+  }
+
+  return "Use this result as feedback and aim for tighter control against the planned intent next time.";
+}
+
+export function diagnoseCompletedSession(input: SessionDiagnosisInput): SessionDiagnosis {
+  const bucket = toIntentBucket(input.planned);
+
+  const draft =
+    bucket === "easy_endurance"
+      ? evaluateEasyEndurance(input)
+      : bucket === "recovery"
+        ? evaluateRecovery(input)
+        : bucket === "threshold_quality"
+          ? evaluateThreshold(input)
+          : bucket === "long_endurance"
+            ? evaluateLongEndurance(input)
+            : bucket === "swim_strength"
+              ? evaluateSwimStrength(input)
+              : evaluateUnknown(input);
+
+  return {
+    intentMatchStatus: draft.status,
+    executionSummary: getSummary(draft.status, draft.issues, bucket),
+    whyItMatters: getWhyItMatters(draft.issues),
+    recommendedNextAction: getNextAction(draft.issues, bucket),
+    diagnosisConfidence: getConfidence(draft.evidenceCount)
+  };
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable coach-layer diagnosis that evaluates a completed session against its planned intent and returns a UI-friendly view model (intent match, short summary, why it matters, next action, and confidence). 
- Support high-value, athlete-readable first-pass cases (easy/endurance, recovery, threshold/quality, long endurance, swim/strength) while degrading cleanly when metrics are sparse. 
- Keep the logic modular and integration-ready so later UI work can consume the outputs without layout changes.

### Description
- Add `lib/coach/session-diagnosis.ts` which exports `diagnoseCompletedSession({ planned, actual })` plus explicit TypeScript models for planned inputs, actual metrics, and the diagnosis output fields (`intentMatchStatus`, `executionSummary`, `whyItMatters`, `recommendedNextAction`, `diagnosisConfidence`).
- Implement bucketed evaluation logic for intent categories: `easy_endurance`, `recovery`, `threshold_quality`, `long_endurance`, `swim_strength`, and a conservative `unknown` fallback, with concrete issue detectors (e.g. too hard, late drift, under/over target, incomplete reps, faded late).
- Add sparse-data behavior and confidence scaling where available evidence controls `diagnosisConfidence` (`high|medium|low`) and unknown/signal-light sessions yield cautious `partial_intent`/`sparse_data` responses rather than overconfident claims.
- Add unit tests `lib/coach/session-diagnosis.test.ts` covering MVP scenarios (easy/run recovery/threshold/long/swim and sparse-data fallback) and document expected outputs and assumptions about available metrics (intent category, duration, intervals, HR/power/pace bands or summary metrics).

### Testing
- Ran unit tests with `npm test -- lib/coach/session-diagnosis.test.ts` and all tests passed (6 tests in the suite). 
- Ran static type checks with `npm run typecheck` and `tsc --noEmit` succeeded with no errors. 
- Tests validate the implemented diagnosis cases and sparse-data degradation behavior using the provided fixtures and assertions.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b00fb3c8008332a5a4ff5452d2d2ae)