### PR TITLE
Handle missing sessions columns in calendar query fallback

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -89,7 +89,11 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     sessionData = query.data as unknown[] | null;
     sessionError = query.error;
 
-    if (sessionError && sessionError.code !== "PGRST205" && /(is_key|schema cache|42703)/i.test(sessionError.message ?? "")) {
+    const isMissingColumnError =
+      sessionError?.code === "42703" ||
+      /(is_key|session_name|status|schema cache|column .* does not exist|42703)/i.test(sessionError?.message ?? "");
+
+    if (sessionError && sessionError.code !== "PGRST205" && isMissingColumnError) {
       const fallbackQuery = await supabase
         .from("sessions")
         .select("id,date,sport,type,duration_minutes,notes,created_at,status")


### PR DESCRIPTION
### Motivation
- The calendar page can throw when the `sessions` table is missing newer columns like `session_name` or `status`, so the query should detect that and fall back to a reduced column set for older/legacy schemas.

### Description
- Broadened missing-column detection by adding an `isMissingColumnError` check that looks for Postgres code `42703` and common column-related messages and uses it to trigger the reduced `select` fallback in `app/(protected)/calendar/page.tsx`.

### Testing
- Ran `npm test -- lib/calendar/day-items.test.ts` and `npm run typecheck`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b06c32f9488332bd25479e1b031eb1)