### PR TITLE
Add first-pass Execution Score model and UI surfaces

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -18,7 +18,7 @@ type Session = {
   intent_category?: string | null;
   session_role?: "key" | "supporting" | "recovery" | "optional" | "Key" | "Supporting" | "Recovery" | "Optional" | null;
   source_metadata?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
-  execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
+  execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null; executionScore?: number | null; execution_score?: number | null; executionScoreBand?: string | null; execution_score_band?: string | null; executionScoreSummary?: string | null; recommendedNextAction?: string | null; recommended_next_action?: string | null; executionScoreProvisional?: boolean | null; execution_score_provisional?: boolean | null } | null;
   duration_minutes: number | null;
   notes: string | null;
   created_at: string;

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -25,7 +25,7 @@ type CalendarSession = {
   intentCategory?: string | null;
   role?: "key" | "supporting" | "recovery" | "optional" | null;
   source?: { uploadId?: string | null; assignmentId?: string | null; assignedBy?: "planner" | "upload" | "coach" | null } | null;
-  executionResult?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null } | null;
+  executionResult?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null; executionScore?: number | null; execution_score?: number | null; executionScoreBand?: string | null; execution_score_band?: string | null; executionScoreSummary?: string | null; recommendedNextAction?: string | null; recommended_next_action?: string | null; executionScoreProvisional?: boolean | null; execution_score_provisional?: boolean | null } | null;
   duration: number;
   notes: string | null;
   created_at: string;
@@ -656,6 +656,14 @@ function AssignUploadModal({
 
 function DetailsModal({ session, onClose }: { session: CalendarSession; onClose: () => void }) {
   const state = session.displayType === "completed_activity" ? "Extra workout" : session.status;
+  const executionScoreRaw = session.executionResult?.executionScore ?? session.executionResult?.execution_score;
+  const executionScore = typeof executionScoreRaw === "number" ? Math.round(executionScoreRaw) : null;
+  const executionScoreBandRaw = session.executionResult?.executionScoreBand ?? session.executionResult?.execution_score_band;
+  const executionScoreBand = typeof executionScoreBandRaw === "string" ? executionScoreBandRaw : null;
+  const executionSummary = session.executionResult?.executionScoreSummary ?? session.executionResult?.summary;
+  const nextAction = session.executionResult?.recommendedNextAction ?? session.executionResult?.recommended_next_action;
+  const provisional = Boolean(session.executionResult?.executionScoreProvisional ?? session.executionResult?.execution_score_provisional);
+
   return (
     <TaskSheet
       onClose={onClose}
@@ -664,6 +672,14 @@ function DetailsModal({ session, onClose }: { session: CalendarSession; onClose:
     >
       <div className="space-y-3 text-sm">
         <p className="text-muted">State: {state}</p>
+        {executionScore !== null && executionScoreBand ? (
+          <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
+            <p className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Execution Score</p>
+            <p className="mt-1 text-base font-semibold text-[hsl(var(--text-primary))]">{executionScore} · {executionScoreBand}{provisional ? " · Provisional" : ""}</p>
+            {executionSummary ? <p className="mt-2 text-xs text-muted">{executionSummary}</p> : null}
+            {nextAction ? <p className="mt-2 text-xs font-medium text-[hsl(var(--text-primary))]">Next step: {nextAction}</p> : null}
+          </div>
+        ) : null}
         {session.notes ? <p className="rounded-lg bg-[hsl(var(--surface-subtle))] p-2 text-xs text-muted">{session.notes}</p> : null}
         <div className="sticky bottom-0 pt-2 text-right">
           <button onClick={onClose} className="btn-secondary px-2 py-1 text-xs">Close</button>

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -330,7 +330,15 @@ export function CoachChat({ diagnosisSessions }: { diagnosisSessions: SessionDia
                 <article key={session.id} className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-1))] p-4">
                   <div className="flex flex-wrap items-start justify-between gap-2">
                     <p className="text-sm font-semibold text-[hsl(var(--text-primary))]">{session.sessionName}</p>
-                    <span className={`signal-chip ${status.className}`}>{status.label}</span>
+                    <div className="flex items-center gap-2">
+                      {session.executionScore !== null && session.executionScoreBand ? (
+                        <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-2.5 py-1 text-[11px] font-medium text-[hsl(var(--text-secondary))]">
+                          Execution Score {session.executionScore} · {session.executionScoreBand}
+                          {session.executionScoreProvisional ? " · Provisional" : ""}
+                        </span>
+                      ) : null}
+                      <span className={`signal-chip ${status.className}`}>{status.label}</span>
+                    </div>
                   </div>
                   <dl className="mt-3 space-y-2 text-sm">
                     <div>

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -29,6 +29,7 @@ function mapDiagnosedSession(row: SessionRow): CoachDiagnosisSession | null {
   const sessionName = (row.session_name ?? row.type ?? `${row.sport} session`).trim();
   const plannedIntent = (row.intent_category ?? row.type ?? `${row.sport} training`).trim();
   const executionSummary =
+    (typeof result.executionScoreSummary === "string" && result.executionScoreSummary) ||
     (typeof result.executionSummary === "string" && result.executionSummary) ||
     (typeof result.summary === "string" && result.summary) ||
     "Execution details will sharpen with additional completed sessions.";
@@ -49,6 +50,23 @@ function mapDiagnosedSession(row: SessionRow): CoachDiagnosisSession | null {
     ? result.evidence.filter((item): item is string => typeof item === "string" && item.length > 0).slice(0, 3)
     : [];
 
+  const executionScoreRaw = typeof result.executionScore === "number" ? result.executionScore : result.execution_score;
+  const executionScore = typeof executionScoreRaw === "number" ? Math.max(0, Math.min(100, Math.round(executionScoreRaw))) : null;
+  const executionScoreBandRaw = typeof result.executionScoreBand === "string" ? result.executionScoreBand : result.execution_score_band;
+  const executionScoreBand =
+    executionScoreBandRaw === "On target" || executionScoreBandRaw === "Partial match" || executionScoreBandRaw === "Missed intent"
+      ? executionScoreBandRaw
+      : executionScore === null
+        ? null
+        : executionScore >= 85
+          ? "On target"
+          : executionScore >= 65
+            ? "Partial match"
+            : "Missed intent";
+  const executionScoreProvisionalRaw =
+    typeof result.executionScoreProvisional === "boolean" ? result.executionScoreProvisional : result.execution_score_provisional;
+  const executionScoreProvisional = typeof executionScoreProvisionalRaw === "boolean" ? executionScoreProvisionalRaw : false;
+
   const confidenceRaw = typeof result.diagnosisConfidence === "string" ? result.diagnosisConfidence : result.diagnosis_confidence;
   const confidenceNote = typeof confidenceRaw === "string" ? `Diagnosis confidence: ${confidenceRaw}` : undefined;
 
@@ -60,6 +78,9 @@ function mapDiagnosedSession(row: SessionRow): CoachDiagnosisSession | null {
     plannedIntent,
     executionSummary,
     status,
+    executionScore,
+    executionScoreBand,
+    executionScoreProvisional,
     whyItMatters,
     nextAction,
     confidenceNote,

--- a/app/(protected)/coach/types.ts
+++ b/app/(protected)/coach/types.ts
@@ -4,6 +4,9 @@ export type CoachDiagnosisSession = {
   plannedIntent: string;
   executionSummary: string;
   status: "matched" | "partial" | "missed";
+  executionScore: number | null;
+  executionScoreBand: "On target" | "Partial match" | "Missed intent" | null;
+  executionScoreProvisional: boolean;
   whyItMatters: string;
   nextAction: string;
   confidenceNote?: string;

--- a/lib/calendar/day-items.test.ts
+++ b/lib/calendar/day-items.test.ts
@@ -17,6 +17,7 @@ describe("buildCalendarDisplayItems", () => {
       activities: [
         {
           id: "a1",
+          upload_id: null,
           sport_type: "run",
           start_time_utc: "2026-03-02T12:00:00.000Z",
           duration_sec: 2700,
@@ -47,6 +48,7 @@ describe("buildCalendarDisplayItems", () => {
       activities: [
         {
           id: "a2",
+          upload_id: null,
           sport_type: "bike",
           start_time_utc: "2026-03-03T08:00:00.000Z",
           duration_sec: 3600,
@@ -87,6 +89,7 @@ describe("buildCalendarDisplayItems", () => {
       activities: [
         {
           id: "a3",
+          upload_id: null,
           sport_type: "run",
           start_time_utc: "2026-03-03T04:30:00.000Z",
           duration_sec: 1800,

--- a/lib/coach/session-diagnosis.test.ts
+++ b/lib/coach/session-diagnosis.test.ts
@@ -19,6 +19,8 @@ describe("diagnoseCompletedSession", () => {
     });
 
     expect(diagnosis.intentMatchStatus).toBe("missed_intent");
+    expect(diagnosis.executionScoreBand).toBe("Missed intent");
+    expect(diagnosis.executionScore).toBeLessThan(65);
     expect(diagnosis.diagnosisConfidence).toBe("high");
   });
 
@@ -98,6 +100,7 @@ describe("diagnoseCompletedSession", () => {
     });
 
     expect(diagnosis.intentMatchStatus).toBe("matched_intent");
+    expect(diagnosis.executionScoreBand).toBe("On target");
     expect(diagnosis.diagnosisConfidence).toBe("medium");
   });
 
@@ -111,6 +114,8 @@ describe("diagnoseCompletedSession", () => {
     });
 
     expect(diagnosis.intentMatchStatus).toBe("partial_intent");
+    expect(diagnosis.executionScore).toBeNull();
+    expect(diagnosis.executionScoreProvisional).toBe(true);
     expect(diagnosis.diagnosisConfidence).toBe("low");
     expect(diagnosis.whyItMatters).toMatch(/Low data quality/);
   });

--- a/lib/coach/session-diagnosis.ts
+++ b/lib/coach/session-diagnosis.ts
@@ -2,6 +2,7 @@ export type Sport = "swim" | "bike" | "run" | "strength" | "other";
 
 export type IntentMatchStatus = "matched_intent" | "partial_intent" | "missed_intent";
 export type DiagnosisConfidence = "high" | "medium" | "low";
+export type ExecutionScoreBand = "On target" | "Partial match" | "Missed intent";
 
 export type PlannedTargetBand = {
   hr?: { min?: number; max?: number };
@@ -46,10 +47,14 @@ export type SessionDiagnosisInput = {
 
 export type SessionDiagnosis = {
   intentMatchStatus: IntentMatchStatus;
+  executionScore: number | null;
+  executionScoreBand: ExecutionScoreBand | null;
+  executionScoreSummary: string;
   executionSummary: string;
   whyItMatters: string;
   recommendedNextAction: string;
   diagnosisConfidence: DiagnosisConfidence;
+  executionScoreProvisional: boolean;
 };
 
 type IntentBucket = "easy_endurance" | "recovery" | "threshold_quality" | "long_endurance" | "swim_strength" | "unknown";
@@ -281,6 +286,38 @@ function getConfidence(evidenceCount: number): DiagnosisConfidence {
   return "low";
 }
 
+function getExecutionScoreBand(score: number): ExecutionScoreBand {
+  if (score >= 85) return "On target";
+  if (score >= 65) return "Partial match";
+  return "Missed intent";
+}
+
+function getIssuePenalty(bucket: IntentBucket, issue: IssueKey): number {
+  const weightedPenalty: Record<IntentBucket, Partial<Record<IssueKey, number>>> = {
+    easy_endurance: { too_hard: 22, high_hr: 18, late_drift: 14, too_variable: 10, shortened: 10 },
+    recovery: { too_hard: 28, high_hr: 22, too_variable: 12, late_drift: 10 },
+    threshold_quality: { incomplete_reps: 24, under_target: 18, over_target: 16, inconsistent_execution: 14, shortened: 14 },
+    long_endurance: { started_too_hard: 20, faded_late: 20, shortened: 16, too_hard: 14 },
+    swim_strength: { incomplete_reps: 22, shortened: 18 },
+    unknown: { shortened: 18, sparse_data: 16 }
+  };
+
+  return weightedPenalty[bucket][issue] ?? 12;
+}
+
+function deriveExecutionScore(bucket: IntentBucket, draft: DiagnosisDraft): { score: number | null; band: ExecutionScoreBand | null; provisional: boolean } {
+  if (draft.evidenceCount === 0) {
+    return { score: null, band: null, provisional: true };
+  }
+
+  const uniqueIssues = [...new Set(draft.issues)];
+  const totalPenalty = uniqueIssues.reduce((sum, issue) => sum + getIssuePenalty(bucket, issue), 0);
+  const statusPenalty = draft.status === "missed_intent" ? 8 : draft.status === "partial_intent" ? 3 : 0;
+  const evidenceRelief = Math.min(4, draft.evidenceCount);
+  const score = Math.max(0, Math.min(100, Math.round(100 - totalPenalty - statusPenalty + evidenceRelief)));
+  return { score, band: getExecutionScoreBand(score), provisional: draft.evidenceCount < 2 };
+}
+
 function getSummary(status: IntentMatchStatus, issues: IssueKey[], bucket: IntentBucket): string {
   if (status === "matched_intent") {
     return "Execution stayed aligned with the planned intent.";
@@ -376,11 +413,18 @@ export function diagnoseCompletedSession(input: SessionDiagnosisInput): SessionD
               ? evaluateSwimStrength(input)
               : evaluateUnknown(input);
 
+  const score = deriveExecutionScore(bucket, draft);
+  const summary = getSummary(draft.status, draft.issues, bucket);
+
   return {
     intentMatchStatus: draft.status,
-    executionSummary: getSummary(draft.status, draft.issues, bucket),
+    executionScore: score.score,
+    executionScoreBand: score.band,
+    executionScoreSummary: summary,
+    executionSummary: summary,
     whyItMatters: getWhyItMatters(draft.issues),
     recommendedNextAction: getNextAction(draft.issues, bucket),
-    diagnosisConfidence: getConfidence(draft.evidenceCount)
+    diagnosisConfidence: getConfidence(draft.evidenceCount),
+    executionScoreProvisional: score.provisional
   };
 }


### PR DESCRIPTION
### Motivation
- Provide athletes with a compact, coach-led "Execution Score" that communicates how closely a completed session met its intended training purpose. 
- Surface a simple, non-gamified signal in the session review and coach workflows so coaches and athletes can quickly see what went well and what to change next. 

### Description
- Added an `Execution Score` to the diagnosis model by extending `SessionDiagnosis` with `executionScore` (0–100), `executionScoreBand` (`On target` / `Partial match` / `Missed intent`), `executionScoreSummary`, and `executionScoreProvisional` for low-evidence cases. 
- Derived the score from the existing intent-bucket diagnosis output using weighted, bucket-aware penalties per issue and simple band thresholds (>=85 On target, 65–84 Partial match, <65 Missed intent). 
- Exposed the score in the most important athlete surfaces: the calendar session details modal (session review) and the coach "Sessions needing attention" cards, and updated the coach mapping/types to carry the new fields. 
- Added and adjusted tests and types: extended `lib/coach/session-diagnosis.test.ts` to assert score/band/provisional behavior and fixed `lib/calendar/day-items.test.ts` fixtures so typecheck stays green. 

### Testing
- Ran unit tests with `npm test -- lib/coach/session-diagnosis.test.ts lib/calendar/day-items.test.ts` and both test suites passed. 
- Ran static type checking with `npm run typecheck` and the project typecheck succeeded. 
- The change adds automated coverage for score generation and low-data/provisional behavior in the diagnosis tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b07b6ac08483329a1909189e2b67ef)