### PR TITLE
Polish Execution Score visual presentation in Coach and Calendar details

### DIFF
--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -685,10 +685,27 @@ function DetailsModal({ session, onClose }: { session: CalendarSession; onClose:
         <p className="text-muted">State: {state}</p>
         {executionScore !== null && executionScoreBand ? (
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
-            <p className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Execution Score</p>
+            <div className="flex flex-wrap items-center justify-between gap-2">
+              <p className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Execution Score</p>
+              <span
+                className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] ${
+                  executionScoreBand === "On target"
+                    ? "border-[hsl(var(--success)/0.3)] bg-[hsl(var(--success)/0.08)] text-[hsl(var(--success))]"
+                    : executionScoreBand === "Partial match"
+                      ? "border-[hsl(var(--warning)/0.3)] bg-[hsl(var(--warning)/0.08)] text-[hsl(var(--warning))]"
+                      : "border-[hsl(var(--danger)/0.3)] bg-[hsl(var(--danger)/0.08)] text-[hsl(var(--danger))]"
+                }`}
+              >
+                {executionScoreBand}
+              </span>
+            </div>
             <p className="mt-1 text-base font-semibold text-[hsl(var(--text-primary))]">{executionScore} · {executionScoreBand}{provisional ? " · Provisional" : ""}</p>
-            {executionSummary ? <p className="mt-2 text-xs text-muted">{executionSummary}</p> : null}
-            {nextAction ? <p className="mt-2 text-xs font-medium text-[hsl(var(--text-primary))]">Next step: {nextAction}</p> : null}
+            {(executionSummary || nextAction) ? (
+              <div className="mt-2 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-2.5 py-2">
+                {executionSummary ? <p className="text-xs text-muted">{executionSummary}</p> : null}
+                {nextAction ? <p className="mt-1 text-xs font-medium text-[hsl(var(--text-primary))]">Next step: {nextAction}</p> : null}
+              </div>
+            ) : null}
           </div>
         ) : null}
         {session.notes ? <p className="rounded-lg bg-[hsl(var(--surface-subtle))] p-2 text-xs text-muted">{session.notes}</p> : null}

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -125,6 +125,16 @@ function statusChip(status: IntentMatchStatus): { label: string; className: stri
   return { label: "Missed intent", className: "signal-risk" };
 }
 
+function executionScoreBandTone(band: SessionDiagnosis["executionScoreBand"]): string {
+  if (band === "On target") {
+    return "border-[hsl(var(--success)/0.3)] bg-[hsl(var(--success)/0.08)] text-[hsl(var(--success))]";
+  }
+  if (band === "Partial match") {
+    return "border-[hsl(var(--warning)/0.3)] bg-[hsl(var(--warning)/0.08)] text-[hsl(var(--warning))]";
+  }
+  return "border-[hsl(var(--danger)/0.3)] bg-[hsl(var(--danger)/0.08)] text-[hsl(var(--danger))]";
+}
+
 export function CoachChat({ diagnosisSessions, initialPrompt }: { diagnosisSessions: SessionDiagnosis[]; initialPrompt?: string }) {
   const [messages, setMessages] = useState<Message[]>([defaultAssistantMessage]);
   const [summary, setSummary] = useState<CoachSummary | null>(null);
@@ -338,10 +348,13 @@ export function CoachChat({ diagnosisSessions, initialPrompt }: { diagnosisSessi
                     <p className="text-sm font-semibold text-[hsl(var(--text-primary))]">{session.sessionName}</p>
                     <div className="flex items-center gap-2">
                       {session.executionScore !== null && session.executionScoreBand ? (
-                        <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-2.5 py-1 text-[11px] font-medium text-[hsl(var(--text-secondary))]">
-                          Execution Score {session.executionScore} · {session.executionScoreBand}
-                          {session.executionScoreProvisional ? " · Provisional" : ""}
-                        </span>
+                        <div className="rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--surface-2))] px-2.5 py-2 text-right">
+                          <p className="text-[10px] uppercase tracking-[0.14em] text-tertiary">Execution Score</p>
+                          <p className="mt-1 text-sm font-semibold text-[hsl(var(--text-primary))]">
+                            {session.executionScore} · {session.executionScoreBand}
+                            {session.executionScoreProvisional ? " · Provisional" : ""}
+                          </p>
+                        </div>
                       ) : null}
                       <span className={`signal-chip ${status.className}`}>{status.label}</span>
                     </div>
@@ -351,17 +364,24 @@ export function CoachChat({ diagnosisSessions, initialPrompt }: { diagnosisSessi
                       <dt className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Planned</dt>
                       <dd className="text-[hsl(var(--text-secondary))]">{session.plannedIntent}</dd>
                     </div>
-                    <div>
+                    <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2.5">
+                      {session.executionScoreBand ? (
+                        <span
+                          className={`inline-flex rounded-full border px-2 py-0.5 text-[10px] font-medium uppercase tracking-[0.08em] ${executionScoreBandTone(session.executionScoreBand)}`}
+                        >
+                          {session.executionScoreBand}
+                        </span>
+                      ) : null}
                       <dt className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Actual</dt>
-                      <dd className="text-[hsl(var(--text-secondary))]">{session.executionSummary}</dd>
+                      <dd className="mt-1 text-[hsl(var(--text-secondary))]">{session.executionSummary}</dd>
                     </div>
                     <div>
                       <dt className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Why it matters</dt>
                       <dd className="text-[hsl(var(--text-secondary))]">{session.whyItMatters}</dd>
                     </div>
-                    <div>
+                    <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2.5">
                       <dt className="text-[11px] uppercase tracking-[0.14em] text-tertiary">Next time</dt>
-                      <dd className="font-medium text-[hsl(var(--text-primary))]">{session.nextAction}</dd>
+                      <dd className="mt-1 font-medium text-[hsl(var(--text-primary))]">{session.nextAction}</dd>
                     </div>
                     {session.confidenceNote ? (
                       <div>


### PR DESCRIPTION
### Motivation
- Improve the visual presentation of the existing Execution Score so it reads as a premium, coaching-led, easily scannable UI element without changing score logic or adding new surfaces.
- Reduce gamified/badge-like styling and make the score, brief explanation, and next-step tip feel like a single coherent coaching block.

### Description
- Refactored flagged-session cards in the Coach surface to show a compact header: clear `Execution Score` label and a `score · band` value in a restrained rounded container, with provisional state preserved.
- Added a muted band pill and helper function `executionScoreBandTone` to apply subtle border/background/text tones for `On target`, `Partial match`, and `Missed intent` instead of loud/gamified colors.
- Grouped the `Actual` summary and `Next time` coaching tip into subtle bordered containers so the explanation and next-step read as one cohesive coaching block.
- Applied the same compact hierarchy and band pill to the Calendar session Details modal so the Execution Score presentation is consistent between Coach and Calendar details.

### Testing
- Ran `npm run lint` which completed with no ESLint warnings or errors (success).
- Launched a dev server and ran an automated Playwright capture to produce screenshots; the server started but full page render validation was blocked by missing Supabase environment variables, so the visual artifacts were produced but the page content could not be fully validated (environment-limited).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08b627f9c8332a785b17ecd38bbaa)