### PR TITLE
Polish fallback session naming and copy consistency across core surfaces

### DIFF
--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -41,8 +41,8 @@ type WeekDay = { iso: string; weekday: string; label: string };
 type RecentMove = { sessionId: string; fromDate: string; toDate: string };
 type AdaptationIssueType = "unmatched_upload" | "skipped_reassign" | "moved_session" | "extra_workout";
 
-const dayFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "2-digit", timeZone: "UTC" });
-const uploadDateFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "2-digit", year: "numeric", timeZone: "UTC" });
+const dayFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
+const uploadDateFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
 
 function calendarDisciplineChipTone(sport: string) {
   const tones: Record<string, { bg: string; text: string; dot: string; border: string }> = {
@@ -311,7 +311,7 @@ export function WeekCalendar({
         <div className="flex items-center gap-2 text-xs">
           <p className="text-sm font-semibold">{dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))} – {dayFormatter.format(new Date(`${weekDays[6].iso}T00:00:00.000Z`))}</p>
           <Link href={withWeek(addDays(activeWeekStart, -7))} className="btn-secondary px-2 py-1 text-xs">Prev</Link>
-          <Link href={withWeek(currentWeekStart)} className="btn-secondary px-2 py-1 text-xs">Current</Link>
+          <Link href={withWeek(currentWeekStart)} className="btn-secondary px-2 py-1 text-xs">This week</Link>
           <Link href={withWeek(addDays(activeWeekStart, 7))} className="btn-secondary px-2 py-1 text-xs">Next</Link>
         </div>
         <div className="flex flex-wrap items-center gap-2 text-xs">
@@ -321,7 +321,7 @@ export function WeekCalendar({
           </select>
           <label className="sr-only" htmlFor="status-filter">Status filter</label>
           <select id="status-filter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as FilterStatus)} className="rounded-md border border-[hsl(var(--border))] bg-transparent px-2 py-1">
-            <option value="all">All states</option><option value="planned">Planned</option><option value="completed">Completed</option><option value="skipped">Skipped</option><option value="moved">Moved</option><option value="extra">Extra</option>
+            <option value="all">All statuses</option><option value="planned">Planned</option><option value="completed">Completed</option><option value="skipped">Skipped</option><option value="moved">Moved</option><option value="extra">Extra</option>
           </select>
           <button onClick={() => setQuickAddDate(weekDays[0]?.iso)} className="btn-primary px-2 py-1 text-xs">Add session</button>
           <span className="rounded-full border border-[hsl(var(--border)/0.8)] bg-[hsl(var(--surface-subtle)/0.45)] px-2 py-0.5 text-[11px] text-muted">{completedCount} completed · {plannedRemainingCount} remaining · {skippedCount} skipped · {extraSessionCount} extra</span>
@@ -330,12 +330,12 @@ export function WeekCalendar({
 
       {hasAdaptation ? (
         <section className="surface-subtle space-y-2 px-3 py-2">
-          <p className="text-xs uppercase tracking-[0.14em] text-accent">Adaptation strip</p>
+          <p className="text-xs uppercase tracking-[0.14em] text-accent">Adjustments to review</p>
           <div className="flex flex-wrap gap-1.5 text-xs">
             {unmatchedUploads.map((upload) => (
               <div key={upload.id} className="rounded-lg border border-[hsl(var(--accent-performance)/0.35)] bg-[hsl(var(--accent-performance)/0.08)] p-2">
                 <p className="font-semibold">Unmatched upload</p>
-                <p className="text-muted">{getDisciplineMeta(upload.sport).label} · {upload.duration} min · uploaded {uploadDateFormatter.format(new Date(`${upload.created_at}`))}</p>
+                <p className="text-muted">{getDisciplineMeta(upload.sport).label} · {upload.duration} min · logged {uploadDateFormatter.format(new Date(`${upload.created_at}`))}</p>
                 <div className="mt-1 flex gap-2">
                   {upload.source?.uploadId ? (
                     <button onClick={() => setAssignSource(upload)} className="text-accent hover:underline">Assign to planned</button>
@@ -357,7 +357,7 @@ export function WeekCalendar({
               <div key={session.id} className="rounded-lg border border-[hsl(var(--signal-risk)/0.35)] bg-[hsl(var(--signal-risk)/0.08)] p-2">
                 <p className="font-semibold">Skipped session</p>
                 <p className="text-muted">{weekDays.find((day) => day.iso === session.date)?.weekday} {getSessionTitle(session)} · {session.duration} min</p>
-                <p className="text-muted">Suggested day: {absorbDayLabel}</p>
+                <p className="text-muted">Suggested move: {absorbDayLabel}</p>
                 <div className="mt-1 flex gap-2">
                   <button onClick={() => setMoveSource(session)} className="text-accent hover:underline">Move to another day</button>
                   <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("skipped_reassign", session.id)])} className="text-muted hover:text-foreground">Confirm skip</button>
@@ -489,7 +489,7 @@ export function WeekCalendar({
                       <p className="mt-0.5 text-muted">{session.duration} min</p>
                       {session.displayType !== "completed_activity" && session.status === "completed" ? (
                         <Link href={`/sessions/${session.id}`} className="mt-1 inline-block text-[11px] text-accent hover:underline">
-                          Review session
+                          Open review
                         </Link>
                       ) : null}
                       <div className="mt-1.5 flex min-h-[1.2rem] items-center justify-end">{stateBadge}</div>
@@ -577,13 +577,13 @@ function MoveModal({ session, weekDays, onClose, onMove }: { session: CalendarSe
   const [date, setDate] = useState(session.date);
   const todayIso = new Date().toISOString().slice(0, 10);
   return (
-    <TaskSheet onClose={onClose} title={`Move ${getSessionTitle(session)}`} description="Reschedule this planned workout to another day in the week.">
+    <TaskSheet onClose={onClose} title={`Move ${getSessionTitle(session)}`} description="Move this planned session to a different day this week.">
       <div className="space-y-3">
         <select value={date} onChange={(e) => setDate(e.target.value)} className="w-full rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-sm">
           {weekDays.map((day) => (
             <option key={day.iso} value={day.iso}>
               {day.weekday} · {day.label}
-              {day.iso >= todayIso ? " · available" : ""}
+              {day.iso >= todayIso ? " · open" : ""}
             </option>
           ))}
         </select>
@@ -682,7 +682,7 @@ function DetailsModal({ session, onClose }: { session: CalendarSession; onClose:
       description={`${getDisciplineMeta(session.sport).label} · ${session.duration} min`}
     >
       <div className="space-y-3 text-sm">
-        <p className="text-muted">State: {state}</p>
+        <p className="text-muted">Status: {state}</p>
         {executionScore !== null && executionScoreBand ? (
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
             <div className="flex flex-wrap items-center justify-between gap-2">

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -1,6 +1,7 @@
 import { CoachChat } from "./coach-chat";
 import { createClient } from "@/lib/supabase/server";
 import type { CoachDiagnosisSession } from "./types";
+import { getSessionDisplayName } from "@/lib/training/session";
 
 type SessionRow = {
   id: string;
@@ -26,19 +27,23 @@ function mapDiagnosedSession(row: SessionRow): CoachDiagnosisSession | null {
 
   const result = row.execution_result;
   const status = toMatchStatus(result.status);
-  const sessionName = (row.session_name ?? row.type ?? `${row.sport} session`).trim();
-  const plannedIntent = (row.intent_category ?? row.type ?? `${row.sport} training`).trim();
+  const sessionName = getSessionDisplayName({
+    sessionName: row.session_name ?? row.type,
+    subtype: row.type,
+    discipline: row.sport
+  });
+  const plannedIntent = (row.intent_category ?? row.type ?? "Planned session intent").trim();
   const executionSummary =
     (typeof result.executionScoreSummary === "string" && result.executionScoreSummary) ||
     (typeof result.executionSummary === "string" && result.executionSummary) ||
     (typeof result.summary === "string" && result.summary) ||
-    "Execution details will sharpen with additional completed sessions.";
+    "Execution details will sharpen after a few more completed sessions.";
   const whyItMatters =
     (typeof result.whyItMatters === "string" && result.whyItMatters) ||
     (typeof result.why_it_matters === "string" && result.why_it_matters) ||
     (status === "missed"
       ? "Missing session intent repeatedly can reduce adaptation quality and increase fatigue carryover."
-      : "Small execution drift can compound across the week if left uncorrected.");
+      : "Small execution drift can build across the week if ignored.");
   const nextAction =
     (typeof result.recommendedNextAction === "string" && result.recommendedNextAction) ||
     (typeof result.recommended_next_action === "string" && result.recommended_next_action) ||
@@ -127,7 +132,7 @@ export default async function CoachPage({ searchParams }: { searchParams?: { pro
       <article className="surface p-4">
         <p className="text-xs uppercase tracking-[0.14em] text-accent">Coach</p>
         <h1 className="mt-1 text-lg font-semibold">Session execution coaching</h1>
-        <p className="mt-1 text-sm text-muted">See which completed sessions matched intent, what missed, and what to change next.</p>
+        <p className="mt-1 text-sm text-muted">See which completed sessions matched intent, what missed, and your next best adjustment.</p>
       </article>
       <CoachChat diagnosisSessions={diagnosisSessions} initialPrompt={searchParams?.prompt} />
     </section>

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -118,14 +118,14 @@ function getStatusChip(completionPct: number, expectedByTodayPct: number) {
 
 function getDefaultStatusInterpretation(statusLabel: string) {
   if (statusLabel === "On track") {
-    return "Progress is aligned with expected weekly load for today.";
+    return "You are aligned with expected progress for today.";
   }
 
   if (statusLabel === "Slightly behind") {
-    return "Slightly behind expected progress; prioritize consistency in the next 48 hours.";
+    return "You are slightly behind; focus on consistency over the next 48 hours.";
   }
 
-  return "Behind expected progress; protect key sessions and avoid compressing load late in the week.";
+  return "You are behind this week; protect key sessions and avoid cramming load late.";
 }
 
 function weekdayName(isoDate: string) {
@@ -630,7 +630,7 @@ export default async function DashboardPage({
               <h2 className="text-xl font-semibold">Today</h2>
               <p className="mt-1 text-sm text-muted">0 remaining · {completedTodaySessions.length} completed</p>
               <h3 className="mt-2 text-lg font-semibold">{toHoursAndMinutes(todayCompletedMinutes)} done</h3>
-              <p className="mt-2 text-sm text-muted">All scheduled sessions for today are complete. You are {resolvedStatusChip.label === "On track" ? "on track" : "still in reach"} this week.</p>
+              <p className="mt-2 text-sm text-muted">All scheduled sessions for today are complete. You are {resolvedStatusChip.label === "On track" ? "on track" : "still within reach"} this week.</p>
               <div className="mt-4 space-y-2">
                 {completedTodaySessions.map((session) => (
                   <div key={session.id} className="rounded-lg border border-[hsl(var(--success)/0.35)] bg-[hsl(var(--success)/0.08)] px-3 py-2">
@@ -649,7 +649,7 @@ export default async function DashboardPage({
               <h2 className="text-xl font-semibold">Today</h2>
               <p className="mt-1 text-sm text-muted">No sessions scheduled</p>
               <h3 className="mt-2 text-lg font-semibold">No sessions scheduled today</h3>
-              <p className="mt-2 text-sm text-muted">Use today for recovery.</p>
+              <p className="mt-2 text-sm text-muted">Use today for recovery and reset.</p>
               <div className="mt-4">
                 <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">View plan</Link>
               </div>

--- a/app/(protected)/plan/plan-editor.tsx
+++ b/app/(protected)/plan/plan-editor.tsx
@@ -437,7 +437,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
             </div>
           ) : null}
         </div>
-        {notePreview ? <p className="mt-3 text-xs text-muted">Week note: {notePreview}</p> : null}
+        {notePreview ? <p className="mt-3 text-xs text-muted">Week notes: {notePreview}</p> : null}
       </section>
 
       {weekActionOpen ? (

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -53,6 +53,8 @@ function getNumber(result: Record<string, unknown> | null | undefined, keys: str
   return null;
 }
 
+const reviewDateFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
+
 function pct(value: number | null) {
   if (value === null) return "—";
   return `${Math.round(value * 100)}%`;
@@ -242,12 +244,12 @@ export default async function SessionReviewPage({ params }: { params: { sessionI
       <article className="surface p-5">
         <p className="text-xs uppercase tracking-[0.14em] text-accent">Session review</p>
         <h1 className="mt-1 text-2xl font-semibold">{sessionTitle}</h1>
-        <p className="mt-1 text-sm text-muted">{new Date(`${session.date}T00:00:00.000Z`).toLocaleDateString()} · {getDisciplineMeta(session.sport).label}</p>
+        <p className="mt-1 text-sm text-muted">{reviewDateFormatter.format(new Date(`${session.date}T00:00:00.000Z`))} · {getDisciplineMeta(session.sport).label}</p>
 
         <div className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-5">
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"><p className="text-xs text-muted">Discipline</p><p className="mt-1 font-semibold">{getDisciplineMeta(session.sport).label}</p></div>
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"><p className="text-xs text-muted">Duration</p><p className="mt-1 font-semibold">{durationLabel(session.duration_minutes)}</p></div>
-          <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"><p className="text-xs text-muted">Status</p><p className="mt-1 font-semibold capitalize">{session.status ?? "completed"}</p></div>
+          <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"><p className="text-xs text-muted">Status</p><p className="mt-1 font-semibold">{session.status ? session.status[0].toUpperCase() + session.status.slice(1) : "Completed"}</p></div>
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"><p className="text-xs text-muted">Intent match</p><p className={`mt-1 font-semibold ${intent.tone}`}>{intent.label}</p></div>
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"><p className="text-xs text-muted">Execution score</p><p className="mt-1 font-semibold">{score === null ? "—" : `${Math.round(score)} / 100`}</p></div>
         </div>
@@ -299,7 +301,7 @@ export default async function SessionReviewPage({ params }: { params: { sessionI
 
       <article className="surface p-5">
         <h2 className="text-lg font-semibold">Ask coach follow-up</h2>
-        <p className="mt-1 text-sm text-muted">Continue this in coaching chat to decide whether this week should adapt.</p>
+        <p className="mt-1 text-sm text-muted">Continue this in coaching chat to decide if this week needs an adjustment.</p>
         <div className="mt-3 flex flex-wrap gap-2">
           {[
             "Why was this session flagged?",

--- a/app/(protected)/week-context.ts
+++ b/app/(protected)/week-context.ts
@@ -22,5 +22,5 @@ export function weekRangeLabel(weekStart: string) {
   const start = new Date(`${weekStart}T00:00:00.000Z`);
   const end = new Date(start);
   end.setUTCDate(start.getUTCDate() + 6);
-  return `${shortDateFormatter.format(start)}–${shortDateFormatter.format(end)}`;
+  return `${shortDateFormatter.format(start)} – ${shortDateFormatter.format(end)}`;
 }

--- a/lib/training/session.test.ts
+++ b/lib/training/session.test.ts
@@ -13,6 +13,11 @@ describe("session helpers", () => {
     expect(getSessionDisplayName({ sessionName: "Session", discipline: "run" })).toBe("Run");
   });
 
+  it("treats weak explicit fallback names as generic", () => {
+    expect(getSessionDisplayName({ sessionName: "Session Run", subtype: "Easy", discipline: "run" })).toBe("Easy Run");
+    expect(getSessionDisplayName({ sessionName: "Session Bike", discipline: "bike" })).toBe("Bike");
+  });
+
   it("normalizes enriched session fields", () => {
     expect(
       normalizeSessionModel({

--- a/lib/training/session.ts
+++ b/lib/training/session.ts
@@ -46,6 +46,18 @@ export type EnrichedSessionModel = {
 
 const GENERIC_SESSION_NAMES = new Set(["session", "workout", "training", "training session"]);
 
+function isWeakFallbackName(name: string, disciplineLabel: string) {
+  const normalized = name.trim().toLowerCase();
+  if (GENERIC_SESSION_NAMES.has(normalized)) return true;
+
+  const normalizedDiscipline = disciplineLabel.toLowerCase();
+  if (normalized === `session ${normalizedDiscipline}` || normalized === `${normalizedDiscipline} session`) {
+    return true;
+  }
+
+  return /^(session|workout|training)\s+(run|bike|swim|strength)$/.test(normalized);
+}
+
 function normalizeSessionRole(role: SessionModelInput["role"]): SessionRoleState | null {
   if (!role) return null;
   const normalized = role.toString().trim().toLowerCase();
@@ -79,8 +91,7 @@ export function getSessionDisplayName(input: SessionModelInput) {
   const disciplineLabel = getDisciplineMeta(session.discipline).label;
 
   const explicit = cleanValue(session.sessionName);
-  const explicitLower = explicit?.toLowerCase() ?? "";
-  if (explicit && !GENERIC_SESSION_NAMES.has(explicitLower)) {
+  if (explicit && !isWeakFallbackName(explicit, disciplineLabel)) {
     return explicit;
   }
 


### PR DESCRIPTION
### Motivation

- Remove low-quality visible fallback titles (e.g. "Session Run", "Session Bike") so session names feel intentional and athlete-facing across Dashboard, Plan, Calendar, Coach, and Session review.  
- Tighten system-sounding copy to be concise and more readable for athletes without changing layouts.  
- Normalize date and small label formatting for consistent presentation across screens.

### Description

- Improved session-name logic by adding `isWeakFallbackName` and updating `getSessionDisplayName` to treat weak explicit names (like `Session Run`, `Workout Swim`, etc.) as generic so fallbacks follow: explicit name → subtype + discipline → discipline-only; implemented in `lib/training/session.ts`.  
- Added a regression test for the weak-name cases in `lib/training/session.test.ts`.  
- Small copy and label cleanups without layout changes across surfaces: `app/(protected)/calendar/week-calendar.tsx`, `app/(protected)/coach/page.tsx`, `app/(protected)/sessions/[sessionId]/page.tsx`, `app/(protected)/dashboard/page.tsx`, and `app/(protected)/plan/plan-editor.tsx` (examples: `Current` → `This week`, `All states` → `All statuses`, `Adaptation strip` → `Adjustments to review`, `uploaded` → `logged`, `Suggested day` → `Suggested move`, `Review session` → `Open review`, and tighter coaching/diagnostic helper copy).  
- Normalized date presentation and range punctuation via `app/(protected)/week-context.ts` and adjusted local formatters (use `day: "numeric"` and spaced en-dash in week ranges) for consistent short date displays used across pages.

### Testing

- Ran unit tests: `npm test -- lib/training/session.test.ts`, all tests passed (6/6).  
- Ran static type check: `npm run typecheck`, typecheck passed.  
- Started dev server and captured a UI screenshot to validate copy changes visually; server started but protected routes require Supabase env keys in this environment (runtime Supabase env error observed), screenshot of the calendar view was captured prior to the runtime error.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b08eefabd88332ad10c3a1513306e6)