### PR TITLE
Improve sparse-data fallback guidance across coach/dashboard/calendar/session review

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -177,7 +177,8 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
   });
 
   const plannedSessions = sessions.filter((item) => item.displayType === "planned_session");
-  const extraSessionCount = sessions.filter((item) => item.displayType === "completed_activity").length;
+  const unmatchedUploadCount = sessions.filter((item) => item.displayType === "completed_activity").length;
+  const plannedSessionCount = plannedSessions.length;
 
   const countMetrics = computeWeekSessionCounts(
     plannedSessions.map((session) => ({
@@ -208,12 +209,16 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       <WeekCalendar
         weekDays={weekDays}
         sessions={sessions}
-        executionLabel={nextTodaySession ? `Next key session: ${getSessionDisplayName(nextTodaySession)}` : "No planned session today"}
-        executionSubtext={extraSessionCount > 0 ? `${extraSessionCount} unscheduled uploads count as extra work.` : "Uploads and schedule aligned"}
+        executionLabel={nextTodaySession ? `Next key session: ${getSessionDisplayName(nextTodaySession)}` : plannedSessionCount > 0 ? "No planned session today" : "No planned sessions this week yet"}
+        executionSubtext={unmatchedUploadCount > 0
+          ? `${unmatchedUploadCount} upload${unmatchedUploadCount > 1 ? "s" : ""} not matched yet — keep them as extra work or assign them to a planned session.`
+          : plannedSessionCount === 0
+            ? "Start by adding 1–2 sessions so uploads have clear matching targets."
+            : "Uploads and schedule aligned"}
         completedCount={countMetrics.completedCount}
         plannedTotalCount={countMetrics.plannedTotalCount}
         skippedCount={countMetrics.skippedCount}
-        extraSessionCount={extraSessionCount}
+        extraSessionCount={unmatchedUploadCount}
         plannedRemainingCount={countMetrics.plannedRemainingCount}
         plannedMinutes={minuteMetrics.plannedMinutes}
         completedMinutes={minuteMetrics.completedMinutes}

--- a/app/(protected)/calendar/week-calendar.test.tsx
+++ b/app/(protected)/calendar/week-calendar.test.tsx
@@ -72,7 +72,7 @@ describe("WeekCalendar", () => {
     );
 
     expect(screen.getByText("Adaptation strip")).toBeInTheDocument();
-    expect(screen.getByText("Unmatched upload")).toBeInTheDocument();
+    expect(screen.getByText(/Unmatched upload/)).toBeInTheDocument();
 
     fireEvent.change(screen.getByLabelText("Status filter"), { target: { value: "extra" } });
     expect(screen.queryByText("Tempo")).not.toBeInTheDocument();
@@ -99,6 +99,6 @@ describe("WeekCalendar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Mark extra" }));
 
     expect(screen.getByText("Extra workout logged")).toBeInTheDocument();
-    expect(screen.queryByText("Unmatched upload")).not.toBeInTheDocument();
+    expect(screen.queryByText(/Unmatched upload/)).not.toBeInTheDocument();
   });
 });

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -360,11 +360,11 @@ export function WeekCalendar({
           <div className="flex flex-wrap gap-1.5 text-xs">
             {unmatchedUploads.map((upload) => (
               <div key={upload.id} className="rounded-lg border border-[hsl(var(--accent-performance)/0.35)] bg-[hsl(var(--accent-performance)/0.08)] p-2">
-                <p className="font-semibold">Unmatched upload</p>
+                <p className="font-semibold">Unmatched upload (provisional)</p>
                 <p className="text-muted">{getDisciplineMeta(upload.sport).label} · {upload.duration} min · logged {uploadDateFormatter.format(new Date(`${upload.created_at}`))}</p>
                 <div className="mt-1 flex gap-2">
                   {upload.source?.uploadId ? (
-                    <button onClick={() => setAssignSource(upload)} className="text-accent hover:underline">Assign to planned</button>
+                    <button onClick={() => setAssignSource(upload)} className="text-accent hover:underline">Assign to planned session</button>
                   ) : null}
                   <button
                     onClick={() => {
@@ -375,7 +375,7 @@ export function WeekCalendar({
                   >
                     Mark extra
                   </button>
-                  <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("unmatched_upload", upload.id)])} className="text-muted hover:text-foreground">Dismiss</button>
+                  <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("unmatched_upload", upload.id)])} className="text-muted hover:text-foreground">Keep unresolved for now</button>
                 </div>
               </div>
             ))}
@@ -399,7 +399,7 @@ export function WeekCalendar({
                   <p className="text-muted">{getSessionTitle(session)} moved from {weekDays.find((day) => day.iso === move.fromDate)?.weekday ?? move.fromDate}</p>
                   <div className="mt-1 flex gap-2">
                     <button onClick={() => setDetailSession(session)} className="text-accent hover:underline">Review</button>
-                    <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("moved_session", move.sessionId)])} className="text-muted hover:text-foreground">Dismiss</button>
+                    <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("moved_session", move.sessionId)])} className="text-muted hover:text-foreground">Keep unresolved for now</button>
                   </div>
                 </div>
               );
@@ -456,6 +456,7 @@ export function WeekCalendar({
                 {daySessions.length === 0 ? (
                   <button onClick={() => setQuickAddDate(day.iso)} className="w-full min-h-[92px] rounded-xl border border-dashed border-[hsl(var(--border)/0.85)] bg-[hsl(var(--surface-subtle)/0.25)] px-2 py-2.5 text-xs text-muted hover:border-[hsl(var(--accent-performance)/0.38)] hover:text-accent">
                     + Add session
+                    <span className="mt-1 block text-[10px] text-tertiary">No items yet — add planned work or log extra activity.</span>
                   </button>
                 ) : null}
                 {daySessions.map((session) => {
@@ -736,7 +737,11 @@ function DetailsModal({ session, onClose }: { session: CalendarSession; onClose:
               </div>
             ) : null}
           </div>
-        ) : null}
+        ) : (
+          <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
+            <p className="text-xs text-muted">Detailed execution scoring is still provisional. Use schedule status and session notes for now.</p>
+          </div>
+        )}
         {session.notes ? <p className="rounded-lg bg-[hsl(var(--surface-subtle))] p-2 text-xs text-muted">{session.notes}</p> : null}
         <div className="sticky bottom-0 pt-2 text-right">
           <button onClick={onClose} className="btn-secondary px-2 py-1 text-xs">Close</button>

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -3,6 +3,7 @@
 import Link from "next/link";
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import type { CoachDiagnosisSession } from "./types";
+import { getDiagnosisDataState } from "@/lib/ui/sparse-data";
 
 type Message = {
   role: "user" | "assistant";
@@ -247,6 +248,7 @@ export function CoachChat({ diagnosisSessions, initialPrompt }: { diagnosisSessi
   const flaggedSessions = useMemo(() => rankFlaggedSessions(sessionDiagnoses), [sessionDiagnoses]);
   const matchedSessions = useMemo(() => sessionDiagnoses.filter((session) => session.status === "matched"), [sessionDiagnoses]);
   const topInsight = useMemo(() => deriveTopInsight(sessionDiagnoses), [sessionDiagnoses]);
+  const dataState = useMemo(() => getDiagnosisDataState(sessionDiagnoses.length), [sessionDiagnoses.length]);
 
   const strongestTheme = flaggedSessions[0]?.themes[0] ?? null;
 
@@ -287,10 +289,10 @@ export function CoachChat({ diagnosisSessions, initialPrompt }: { diagnosisSessi
   const quickPrompts = useMemo(() => {
     if (sessionDiagnoses.length < 2) {
       return [
-        "What matters most now?",
+        "Which session should I protect this week?",
         "How should I adjust this week?",
         "Missed workout recovery",
-        "Build a conservative week"
+        "What should stay easy vs key?"
       ];
     }
 
@@ -451,10 +453,10 @@ export function CoachChat({ diagnosisSessions, initialPrompt }: { diagnosisSessi
 
         {flaggedSessions.length === 0 ? (
           <div className="mt-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-1))] px-3 py-3">
-            <p className="text-sm text-muted">No high-confidence session flags yet.</p>
+            <p className="text-sm text-muted">{dataState.unlockText}</p>
             <ul className="mt-2 list-disc space-y-1 pl-4 text-xs text-tertiary">
-              <li>Once a few completed workouts have intent-match results, this section will rank the top sessions needing attention.</li>
-              <li>Each card will explain what happened, why it matters, and exactly what to do in the next similar session.</li>
+              <li>{dataState.guidanceText}</li>
+              <li>Ask targeted questions now: what to protect this week, how to recover from a miss, and when to reduce load.</li>
             </ul>
           </div>
         ) : (

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -3,6 +3,7 @@ import { createClient } from "@/lib/supabase/server";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { getSessionDisplayName } from "@/lib/training/session";
 import { computeWeekMinuteTotals } from "@/lib/training/week-metrics";
+import { getDiagnosisDataState } from "@/lib/ui/sparse-data";
 import { addDays, getMonday, weekRangeLabel } from "../week-context";
 
 type Session = {
@@ -550,18 +551,25 @@ export default async function DashboardPage({
       }
     : null;
 
-  const diagnosisAwareSignal = getDiagnosisAwareSignal({
-    sessions,
-    todayIso,
-    nextPendingTodaySession,
-    fallbackFocusItem: focusItem
-  });
+  const diagnosedSessionCount = sessions.filter((session) => session.status === "completed" && session.execution_result?.status).length;
+  const diagnosisDataState = getDiagnosisDataState(diagnosedSessionCount);
+
+  const diagnosisAwareSignal = diagnosisDataState.isSparse
+    ? { focusOverride: focusItem ?? undefined }
+    : getDiagnosisAwareSignal({
+        sessions,
+        todayIso,
+        nextPendingTodaySession,
+        fallbackFocusItem: focusItem
+      });
 
   const resolvedStatusChip = diagnosisAwareSignal.statusChipOverride ?? statusChip;
-  const statusInterpretation = diagnosisAwareSignal.statusInterpretation
-    ?? (diagnosisAwareSignal.interpretationRisk
-      ? getDiagnosisStatusInterpretation(resolvedStatusChip.label, diagnosisAwareSignal.interpretationRisk)
-      : getDefaultStatusInterpretation(resolvedStatusChip.label));
+  const statusInterpretation = diagnosisDataState.isSparse
+    ? `${getDefaultStatusInterpretation(resolvedStatusChip.label)} ${diagnosisDataState.guidanceText}`
+    : diagnosisAwareSignal.statusInterpretation
+      ?? (diagnosisAwareSignal.interpretationRisk
+        ? getDiagnosisStatusInterpretation(resolvedStatusChip.label, diagnosisAwareSignal.interpretationRisk)
+        : getDefaultStatusInterpretation(resolvedStatusChip.label));
   const resolvedFocusItem = diagnosisAwareSignal.focusOverride ?? focusItem;
   const todayCue = diagnosisAwareSignal.todayCue;
 
@@ -601,6 +609,7 @@ export default async function DashboardPage({
             <span className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${resolvedStatusChip.className}`}>{resolvedStatusChip.label}</span>
           </div>
           <p className="mt-2 text-sm text-muted">{statusInterpretation}</p>
+          {diagnosisDataState.isSparse ? <p className="mt-1 text-xs text-tertiary">{diagnosisDataState.unlockText}</p> : null}
 
           <div className="mt-5 grid grid-cols-7 gap-2">
             {dailyStates.map((day) => {
@@ -697,7 +706,7 @@ export default async function DashboardPage({
               <h2 className="text-xl font-semibold">Today</h2>
               <p className="mt-1 text-sm text-muted">No sessions scheduled</p>
               <h3 className="mt-2 text-lg font-semibold">No sessions scheduled today</h3>
-              <p className="mt-2 text-sm text-muted">Use today for recovery and reset.</p>
+              <p className="mt-2 text-sm text-muted">Use today for recovery and reset, then protect the next planned key session.</p>
               <div className="mt-4">
                 <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">View plan</Link>
               </div>

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -45,6 +45,8 @@ type ReviewViewModel = {
   whyItMatters: string;
   nextAction: string;
   weekAction: string;
+  knownSummary: string;
+  provisionalSummary: string;
 };
 
 const STATUS_LABELS: Record<SessionStatus, string> = {
@@ -174,6 +176,21 @@ function createReviewViewModel(session: SessionRow): ReviewViewModel {
   const avgHr = getNumber(diagnosis, ["avgHr", "avg_hr"]);
   const avgPower = getNumber(diagnosis, ["avgPower", "avg_power"]);
 
+  const knownSignals = [
+    score !== null ? "execution score" : null,
+    durationCompletion !== null ? "duration completion" : null,
+    intervalCompletion !== null ? "interval completion" : null,
+    timeAbove !== null ? "time-above-target" : null,
+    (avgHr || avgPower) ? "load metrics" : null
+  ].filter((item): item is string => Boolean(item));
+
+  const knownSummary = knownSignals.length > 0
+    ? `Known so far: ${knownSignals.join(", ")}.`
+    : "Known so far: session completion and intended workout context.";
+  const provisionalSummary = provisional || score === null || knownSignals.length < 3
+    ? "Still provisional: diagnosis confidence will improve with richer interval/intensity upload data from similar sessions."
+    : "Diagnosis confidence is now less provisional; continue validating over the next similar session.";
+
   const usefulMetrics = [
     durationCompletion !== null ? { label: "Duration completion", value: pct(durationCompletion) } : null,
     intervalCompletion !== null ? { label: "Interval completion", value: pct(intervalCompletion) } : null,
@@ -207,7 +224,9 @@ function createReviewViewModel(session: SessionRow): ReviewViewModel {
     usefulMetrics,
     whyItMatters,
     nextAction,
-    weekAction
+    weekAction,
+    knownSummary,
+    provisionalSummary
   };
 }
 
@@ -381,6 +400,12 @@ export default async function SessionReviewPage({ params }: { params: { sessionI
           </p>
           <p className="mt-1 text-sm text-muted">{reviewVm.scoreInterpretation}</p>
           {reviewVm.scoreConfidenceNote ? <p className="mt-1 text-xs text-tertiary">{reviewVm.scoreConfidenceNote}</p> : null}
+        </div>
+
+        <div className="mt-3 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
+          <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Diagnosis confidence</p>
+          <p className="mt-2 text-sm text-muted">{reviewVm.knownSummary}</p>
+          <p className="mt-1 text-sm text-muted">{reviewVm.provisionalSummary}</p>
         </div>
 
         {reviewVm.usefulMetrics.length > 0 ? (

--- a/lib/ui/sparse-data.ts
+++ b/lib/ui/sparse-data.ts
@@ -1,0 +1,29 @@
+export type DiagnosisDataState = {
+  isSparse: boolean;
+  unlockText: string;
+  guidanceText: string;
+};
+
+export function getDiagnosisDataState(completedDiagnosedSessions: number): DiagnosisDataState {
+  if (completedDiagnosedSessions >= 2) {
+    return {
+      isSparse: false,
+      unlockText: "Diagnosis depth unlocked.",
+      guidanceText: "Diagnosis signals are stable enough to drive session-level adjustments."
+    };
+  }
+
+  if (completedDiagnosedSessions === 1) {
+    return {
+      isSparse: true,
+      unlockText: "One diagnosed session logged — one more will unlock stronger pattern coaching.",
+      guidanceText: "Use schedule-first guidance today: protect key sessions, keep easy/recovery truly easy, and avoid stacking missed work."
+    };
+  }
+
+  return {
+    isSparse: true,
+    unlockText: "Complete 1–2 sessions with uploaded activity data to unlock stronger diagnosis guidance.",
+    guidanceText: "Use schedule-first guidance for now: follow planned order, protect key sessions, and keep recovery load controlled."
+  };
+}


### PR DESCRIPTION
### Motivation

- Low-data diagnosis and sparse activity-matching states were producing empty or uncertain UX across multiple coaching surfaces.  
- The goal is to make low-data states useful and guided without redesigning pages or adding visual modules.  
- Provide consistent fallback rules so pages degrade confidently and offer actionable next steps until more data is available.

### Description

- Added a shared helper `getDiagnosisDataState` in `lib/ui/sparse-data.ts` to unify when diagnosis is considered sparse and what unlock/call-to-action copy to show.  
- Coach: the chat now uses `getDiagnosisDataState` to replace dead-end copy with explicit unlock messaging and schedule-first guidance, and low-data quick prompts were updated to be immediately actionable (`app/(protected)/coach/coach-chat.tsx`).  
- Dashboard: counts diagnosed sessions and, when sparse, suppresses diagnosis-risk overlays and falls back to confident schedule-based interpretation plus concise `unlockText` guidance (`app/(protected)/dashboard/page.tsx`).  
- Calendar: clarifies unmatched uploads as provisional, improves unresolved-action wording, adds a hint on empty day cards, and shows a provisional details fallback when execution scoring is unavailable (`app/(protected)/calendar/page.tsx`, `app/(protected)/calendar/week-calendar.tsx`).  
- Session Review: adds `knownSummary` and `provisionalSummary` to the review view model and renders a small "Diagnosis confidence" panel showing what is known and what remains provisional while preserving useful metric rows (`app/(protected)/sessions/[sessionId]/page.tsx`).  
- Tests and small copy updates: updated calendar test expectations to match the revised unmatched-upload wording (`app/(protected)/calendar/week-calendar.test.tsx`).

### Testing

- Ran type checking with `npm run typecheck` and it succeeded.  
- Ran unit tests with `npm test` (Jest) and the full test suite passed (all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b13bb436388332ad42c0970748454a)