### PR TITLE
Persist coach conversation continuity with Responses API chaining

### DIFF
--- a/app/api/coach/chat/route.test.ts
+++ b/app/api/coach/chat/route.test.ts
@@ -21,7 +21,6 @@ jest.mock("../../../../lib/security/rate-limit", () => ({
   rateLimitHeaders: jest.fn(() => ({}))
 }));
 
-
 jest.mock("next/server", () => ({
   NextResponse: {
     json: (body: unknown, init?: { status?: number; headers?: HeadersInit }) => ({
@@ -57,9 +56,10 @@ function createSupabaseMock(opts?: {
   createdConversationId?: string;
   history?: unknown[];
 }) {
-  const conversationsLookupBuilder = createBuilder({ maybeSingle: opts?.conversationLookup ?? { data: { id: "conv1" }, error: null } });
-  const conversationsInsertBuilder = createBuilder({ single: { data: { id: opts?.createdConversationId ?? "conv1" }, error: null } });
+  const conversationsLookupBuilder = createBuilder({ maybeSingle: opts?.conversationLookup ?? { data: { id: "conv1", last_response_id: null }, error: null } });
+  const conversationsInsertBuilder = createBuilder({ single: { data: { id: opts?.createdConversationId ?? "conv1", last_response_id: null }, error: null } });
   const messagesSelectBuilder = createBuilder({ limit: { data: opts?.history ?? [], error: null } });
+  const aiMessagesInsert = jest.fn().mockResolvedValue({ error: null });
 
   const supabase = {
     from: jest.fn((table: string) => {
@@ -74,7 +74,7 @@ function createSupabaseMock(opts?: {
       if (table === "ai_messages") {
         return {
           select: jest.fn(() => messagesSelectBuilder),
-          insert: jest.fn().mockResolvedValue({ error: null })
+          insert: aiMessagesInsert
         };
       }
 
@@ -82,9 +82,8 @@ function createSupabaseMock(opts?: {
     })
   };
 
-  return { supabase, conversationsLookupBuilder, messagesSelectBuilder };
+  return { supabase, conversationsLookupBuilder, messagesSelectBuilder, aiMessagesInsert };
 }
-
 
 function makeRequest(url: string, body: Record<string, unknown>) {
   return {
@@ -126,17 +125,16 @@ describe("POST /api/coach/chat hardening", () => {
     });
 
     const req = makeRequest("http://localhost/api/coach/chat", {
-        message: "Need help with my week",
-        conversationId: "11111111-1111-4111-8111-111111111111"
-      });
+      message: "Need help with my week",
+      conversationId: "11111111-1111-4111-8111-111111111111"
+    });
 
     const res = await POST(req);
     expect(res.status).toBe(404);
     expect((supabase.from as jest.Mock).mock.calls[0][0]).toBe("ai_conversations");
   });
 
-
-  it("accepts null conversationId payloads from the client", async () => {
+  it("creates a new conversation and returns a stable conversation id", async () => {
     const { supabase } = createSupabaseMock({ history: [] });
 
     (resolveCoachAuthContext as jest.Mock).mockResolvedValue({
@@ -178,10 +176,10 @@ describe("POST /api/coach/chat hardening", () => {
     const body = await res.json();
     expect(body).toMatchObject({
       conversationId: "conv1",
+      responseId: "resp-1",
       headline: "Stay controlled"
     });
   });
-
 
   it("returns fallback guidance instead of 502 when model call fails", async () => {
     const { supabase } = createSupabaseMock({ history: [] });
@@ -272,25 +270,55 @@ describe("POST /api/coach/chat hardening", () => {
         ctx: expect.objectContaining({ userId: "user-a", athleteId: "athlete-a" })
       })
     );
+  });
 
-    const lookupConversationReq = makeRequest("http://localhost/api/coach/chat", {
-        message: "continue",
-        conversationId: "11111111-1111-4111-8111-111111111111"
-      });
-
-    const { supabase: supabaseWithLookup, conversationsLookupBuilder } = createSupabaseMock({
-      conversationLookup: { data: { id: "11111111-1111-4111-8111-111111111111" }, error: null },
+  it("continues an existing conversation with persisted previous_response_id and re-sent instructions", async () => {
+    const { supabase, conversationsLookupBuilder, aiMessagesInsert } = createSupabaseMock({
+      conversationLookup: { data: { id: "11111111-1111-4111-8111-111111111111", last_response_id: "resp-prev" }, error: null },
       history: []
     });
 
-    (resolveCoachAuthContext as jest.Mock).mockResolvedValueOnce({
-      supabase: supabaseWithLookup,
+    (resolveCoachAuthContext as jest.Mock).mockResolvedValue({
+      supabase,
       ctx: { userId: "user-a", athleteId: "athlete-a", email: "a@example.com" },
       reason: null
     });
 
-    await POST(lookupConversationReq);
+    const create = jest.fn()
+      .mockResolvedValueOnce({
+        id: "resp-next",
+        output: [],
+        output_text: "Continue with low intensity today."
+      })
+      .mockResolvedValueOnce({
+        id: "resp-structured",
+        output: [],
+        output_text: JSON.stringify({
+          headline: "Keep control",
+          answer: "Continue with low intensity today.",
+          insights: [],
+          actions: [],
+          warnings: []
+        })
+      });
+
+    (getOpenAIClient as jest.Mock).mockReturnValue({ responses: { create } });
+
+    const req = makeRequest("http://localhost/api/coach/chat", {
+      message: "continue",
+      conversationId: "11111111-1111-4111-8111-111111111111"
+    });
+
+    const res = await POST(req);
+    expect(res.status).toBe(200);
+
+    const firstCall = create.mock.calls[0][0];
+    expect(firstCall.previous_response_id).toBe("resp-prev");
+    expect(firstCall.instructions).toBeDefined();
 
     expect(conversationsLookupBuilder.eq).toHaveBeenCalledWith("athlete_id", "athlete-a");
+    expect(aiMessagesInsert).toHaveBeenCalledWith(expect.arrayContaining([
+      expect.objectContaining({ role: "assistant", previous_response_id: "resp-prev", response_id: "resp-next" })
+    ]));
   });
 });

--- a/app/api/coach/chat/route.ts
+++ b/app/api/coach/chat/route.ts
@@ -14,6 +14,7 @@ type ConversationRow = {
   id: string;
   title: string;
   updated_at: string;
+  last_response_id: string | null;
 };
 
 type ConversationMessageRow = {
@@ -21,7 +22,6 @@ type ConversationMessageRow = {
   content: string;
   created_at: string;
 };
-
 
 function isCoachToolName(name: string): name is CoachToolName {
   return Object.prototype.hasOwnProperty.call(coachToolSchemas, name);
@@ -69,10 +69,10 @@ function buildServiceFallback() {
       actions: [],
       warnings: []
     },
-    responseId: undefined as string | undefined
+    responseId: undefined as string | undefined,
+    previousResponseId: undefined as string | undefined
   };
 }
-
 
 async function runCoachResponseFlow(params: {
   userMessage: string;
@@ -98,6 +98,8 @@ async function runCoachResponseFlow(params: {
     tool_choice: "auto",
     stream: false
   });
+
+  const seededPreviousResponseId = params.previousResponseId;
 
   for (let i = 0; i < 6; i += 1) {
     const toolCalls = response.output.filter((item): item is { type: "function_call"; call_id: string; name: string; arguments: string } => item.type === "function_call");
@@ -175,7 +177,8 @@ async function runCoachResponseFlow(params: {
   return {
     answer: draftAnswer,
     structured: parsed.success ? parsed.data : safeStructuredFallback(draftAnswer),
-    responseId: response.id
+    responseId: response.id,
+    previousResponseId: seededPreviousResponseId
   };
 }
 
@@ -210,7 +213,7 @@ export async function GET(request: Request) {
 
   const { data, error } = await supabase
     .from("ai_conversations")
-    .select("id,title,updated_at")
+    .select("id,title,updated_at,last_response_id")
     .eq("user_id", ctx.userId)
     .eq("athlete_id", ctx.athleteId)
     .order("updated_at", { ascending: false })
@@ -268,6 +271,7 @@ export async function POST(request: Request) {
   }
 
   let conversationId = payload.conversationId;
+  let conversationLastResponseId: string | undefined;
 
   if (conversationId) {
     if (!z.string().uuid().safeParse(conversationId).success) {
@@ -275,7 +279,7 @@ export async function POST(request: Request) {
     }
     const { data: existingConversation } = await supabase
       .from("ai_conversations")
-      .select("id")
+      .select("id,last_response_id")
       .eq("id", conversationId)
       .eq("user_id", ctx.userId)
       .eq("athlete_id", ctx.athleteId)
@@ -290,13 +294,15 @@ export async function POST(request: Request) {
       });
       return NextResponse.json({ error: "Conversation not found." }, { status: 404 });
     }
+
+    conversationLastResponseId = existingConversation.last_response_id ?? undefined;
   }
 
   if (!conversationId) {
     const { data: createdConversation, error: conversationError } = await supabase
       .from("ai_conversations")
       .insert({ user_id: ctx.userId, athlete_id: ctx.athleteId, title: payload.message.slice(0, 60) })
-      .select("id")
+      .select("id,last_response_id")
       .single();
 
     if (conversationError || !createdConversation) {
@@ -304,6 +310,7 @@ export async function POST(request: Request) {
     }
 
     conversationId = createdConversation.id;
+    conversationLastResponseId = createdConversation.last_response_id ?? undefined;
   }
 
   const resolvedConversationId = conversationId;
@@ -331,7 +338,7 @@ export async function POST(request: Request) {
     result = await runCoachResponseFlow({
       userMessage: payload.message,
       priorMessages: [...((recentMessages ?? []) as ConversationMessageRow[])].reverse(),
-      previousResponseId: payload.previousResponseId,
+      previousResponseId: conversationLastResponseId,
       supabaseConversationId: resolvedConversationId,
       toolDeps: { ctx, supabase }
     });
@@ -353,14 +360,19 @@ export async function POST(request: Request) {
       user_id: ctx.userId,
       athlete_id: ctx.athleteId,
       role: "user",
-      content: payload.message
+      content: payload.message,
+      previous_response_id: result.previousResponseId ?? null,
+      model: getCoachModel()
     },
     {
       conversation_id: resolvedConversationId,
       user_id: ctx.userId,
       athlete_id: ctx.athleteId,
       role: "assistant",
-      content: result.answer
+      content: result.answer,
+      response_id: result.responseId ?? null,
+      previous_response_id: result.previousResponseId ?? null,
+      model: getCoachModel()
     }
   ]);
 
@@ -368,7 +380,10 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: insertMessagesError.message }, { status: 500 });
   }
 
-  await supabase.from("ai_conversations").update({ updated_at: new Date().toISOString() }).eq("id", resolvedConversationId);
+  await supabase
+    .from("ai_conversations")
+    .update({ updated_at: new Date().toISOString(), last_response_id: result.responseId ?? null })
+    .eq("id", resolvedConversationId);
 
   logCoachAudit("info", "coach.chat.response_success", {
     ctx,

--- a/docs/coach-conversation-persistence.md
+++ b/docs/coach-conversation-persistence.md
@@ -1,0 +1,54 @@
+# Coach Conversation Persistence (Responses API)
+
+## Overview
+
+The coaching backend persists conversation continuity in Supabase and uses OpenAI Responses API `previous_response_id` chaining for multi-turn context.
+
+This is intentionally simple:
+
+- Conversation identity is our UUID (`ai_conversations.id`), owned by one athlete/user.
+- OpenAI continuity is tracked server-side with `ai_conversations.last_response_id`.
+- Each turn stores auditing metadata in `ai_messages`.
+
+## Stored identifiers
+
+### `ai_conversations`
+
+- `id`: stable conversation UUID exposed to client.
+- `last_response_id`: latest OpenAI response id returned for the conversation.
+
+### `ai_messages`
+
+Per message row (user + assistant rows per turn):
+
+- `response_id`: OpenAI response id for assistant turns (nullable on user turns).
+- `previous_response_id`: chain pointer used when creating the next model response.
+- `model`: model name used for that turn.
+
+## New conversation flow
+
+1. Client sends `POST /api/coach/chat` with `{ message }` (optionally `conversationId: null`).
+2. Backend creates `ai_conversations` row.
+3. Backend calls Responses API **without** `previous_response_id`.
+4. Backend stores turn rows in `ai_messages` and writes assistant `response_id` to `ai_conversations.last_response_id`.
+5. Backend returns `conversationId` and `responseId` to client.
+
+## Continued conversation flow
+
+1. Client sends `POST /api/coach/chat` with `{ message, conversationId }`.
+2. Backend verifies ownership (`user_id` + `athlete_id`) for the conversation.
+3. Backend reads `ai_conversations.last_response_id` and passes it as `previous_response_id`.
+4. Backend stores the new turn metadata and updates `last_response_id`.
+
+## Why instructions are re-sent each turn
+
+The backend always sends `COACH_SYSTEM_INSTRUCTIONS` on each Responses API call (including tool-loop follow-ups).
+
+Reason: continuity IDs chain model state, but production safety/behavior policy should be explicit and deterministic per call. Re-sending instructions ensures coach behavior does not drift and remains auditable.
+
+## Client contract
+
+- Start new thread: omit `conversationId` (or send `null`).
+- Continue thread: send existing `conversationId`.
+- Persist `conversationId` returned from API for future turns.
+- `responseId` is returned as a server-generated continuity/debug identifier; the client does not need to send OpenAI ids back.

--- a/docs/openai-coaching-security.md
+++ b/docs/openai-coaching-security.md
@@ -26,6 +26,15 @@ Model selection is centralized in `lib/openai.ts`:
 
 Use `getCoachModel()` for normal routes and `getCoachModel({ deep: true })` when opting into deep analysis.
 
+
+## Conversation continuity (Responses API)
+
+Coach chat continuity is persisted server-side using `ai_conversations.last_response_id` and passed to OpenAI as `previous_response_id` on follow-up turns.
+
+Important: we **re-send `COACH_SYSTEM_INSTRUCTIONS` on every call** (initial + tool follow-ups), instead of assuming prior instructions persist. This keeps behavior deterministic and auditable.
+
+See `docs/coach-conversation-persistence.md` for schema fields and request/response contract details.
+
 ## Why OpenAI never touches DB directly
 
 OpenAI receives prompts and tool outputs only. It has no DB credentials and cannot run arbitrary SQL.

--- a/lib/coach/types.ts
+++ b/lib/coach/types.ts
@@ -2,8 +2,7 @@ import { z } from "zod";
 
 export const coachChatRequestSchema = z.object({
   message: z.string().trim().min(3).max(2000),
-  conversationId: z.preprocess((value) => (value === null ? undefined : value), z.string().uuid().optional()),
-  previousResponseId: z.preprocess((value) => (value === null ? undefined : value), z.string().min(1).max(200).optional())
+  conversationId: z.preprocess((value) => (value === null ? undefined : value), z.string().uuid().optional())
 });
 
 export type CoachChatRequest = z.infer<typeof coachChatRequestSchema>;

--- a/supabase/migrations/202603110003_add_coach_response_linkage.sql
+++ b/supabase/migrations/202603110003_add_coach_response_linkage.sql
@@ -1,0 +1,15 @@
+alter table public.ai_conversations
+  add column if not exists last_response_id text;
+
+alter table public.ai_messages
+  add column if not exists response_id text,
+  add column if not exists previous_response_id text,
+  add column if not exists model text;
+
+create index if not exists ai_conversations_athlete_id_last_response_idx
+  on public.ai_conversations(athlete_id, last_response_id)
+  where last_response_id is not null;
+
+create index if not exists ai_messages_conversation_id_response_id_idx
+  on public.ai_messages(conversation_id, response_id)
+  where response_id is not null;


### PR DESCRIPTION
### Motivation

- Provide auditable, server-side conversation continuity for multi-turn coach chat by persisting OpenAI Responses API linkage instead of trusting client-supplied IDs. 
- Ensure coach behavior is deterministic by re-applying `COACH_SYSTEM_INSTRUCTIONS` on every Responses API call (initial call and tool-loop follow-ups). 
- Keep ownership and RLS constraints intact so athletes can only access their own conversation threads. 

### Description

- `app/api/coach/chat/route.ts`: read and write `ai_conversations.last_response_id`, send that value as `previous_response_id` on continued turns, persist per-turn metadata (`response_id`, `previous_response_id`, `model`) to `ai_messages`, and always include `COACH_SYSTEM_INSTRUCTIONS` on each Responses API call. 
- `supabase/migrations/202603110003_add_coach_response_linkage.sql`: add `ai_conversations.last_response_id` and `ai_messages.response_id`, `ai_messages.previous_response_id`, `ai_messages.model` plus supporting indexes. 
- `lib/coach/types.ts`: remove `previousResponseId` from the public request schema so the server controls chaining. 
- `app/api/coach/chat/route.test.ts`: updated and added tests to cover new conversation creation, continued conversations using persisted chain, cross-user access rejection, and that instructions are present on follow-up calls. 
- Docs: added `docs/coach-conversation-persistence.md` and updated `docs/openai-coaching-security.md` to describe stored identifiers, how `previous_response_id` is used, and why instructions are re-sent each turn. 

### Testing

- Ran `npm test -- app/api/coach/chat/route.test.ts` and the suite passed (`7 tests, 0 failures`). 
- Unit tests exercised: creating a new conversation, failing model calls (fallback), tool loop behavior, ownership enforcement for conversations, and continued conversation behavior asserting `previous_response_id` is used and `instructions` are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17717527c8332bc38bafd416b733d)