### PR TITLE
Include uploaded activities in coach recent-session context

### DIFF
--- a/lib/coach/tool-handlers.test.ts
+++ b/lib/coach/tool-handlers.test.ts
@@ -32,6 +32,78 @@ describe("executeCoachTool hardening", () => {
     expect(supabase.from).not.toHaveBeenCalled();
   });
 
+  it("falls back to uploaded activities when legacy completed sessions are missing", async () => {
+    const completedBuilder = createQueryBuilder({
+      limit: {
+        data: [],
+        error: null
+      }
+    });
+    completedBuilder.limit.mockResolvedValue({
+      data: [],
+      error: null
+    });
+
+    const uploadedBuilder = createQueryBuilder({
+      limit: {
+        data: [
+          {
+            id: "activity-1",
+            sport_type: "swim",
+            start_time_utc: "2026-03-10T07:10:00.000Z",
+            duration_sec: 3600
+          }
+        ],
+        error: null
+      }
+    });
+    uploadedBuilder.limit.mockResolvedValue({
+      data: [
+        {
+          id: "activity-1",
+          sport_type: "swim",
+          start_time_utc: "2026-03-10T07:10:00.000Z",
+          duration_sec: 3600
+        }
+      ],
+      error: null
+    });
+
+    const plannedBuilder = createQueryBuilder({
+      limit: {
+        data: [],
+        error: null
+      }
+    });
+    plannedBuilder.limit.mockResolvedValue({
+      data: [],
+      error: null
+    });
+
+    const supabase = {
+      from: jest.fn((table: string) => {
+        if (table === "completed_sessions") return completedBuilder;
+        if (table === "completed_activities") return uploadedBuilder;
+        if (table === "sessions") return plannedBuilder;
+        throw new Error(`Unexpected table: ${table}`);
+      })
+    } as unknown as { from: jest.Mock };
+
+    const result = await executeCoachTool("get_recent_sessions", { daysBack: 7 }, { supabase: supabase as never, ctx });
+
+    expect(uploadedBuilder.eq).toHaveBeenCalledWith("user_id", ctx.userId);
+    expect(result).toMatchObject({
+      completed: [
+        {
+          id: "activity:activity-1",
+          date: "2026-03-10",
+          sport: "swim",
+          durationMinutes: 60
+        }
+      ]
+    });
+  });
+
   it("rejects proposal creation for another athlete session", async () => {
     const sessionsBuilder = createQueryBuilder({ maybeSingle: { data: null, error: null } });
 

--- a/lib/coach/tool-handlers.ts
+++ b/lib/coach/tool-handlers.ts
@@ -57,6 +57,8 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
   const parsed = coachToolSchemas.get_recent_sessions.parse(args);
   const since = isoDate(addDays(new Date(), -parsed.daysBack));
   const today = isoDate(new Date());
+  const sinceUtc = `${since}T00:00:00.000Z`;
+  const todayUtc = `${today}T23:59:59.999Z`;
 
   const { data: completed, error: completedError } = await deps.supabase
     .from("completed_sessions")
@@ -71,6 +73,19 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
     throw new Error(`get_recent_sessions completed query failed: ${completedError.message}`);
   }
 
+  const { data: uploadedActivities, error: uploadedActivitiesError } = await deps.supabase
+    .from("completed_activities")
+    .select("id,sport_type,start_time_utc,duration_sec")
+    .eq("user_id", deps.ctx.userId)
+    .gte("start_time_utc", sinceUtc)
+    .lte("start_time_utc", todayUtc)
+    .order("start_time_utc", { ascending: false })
+    .limit(20);
+
+  if (uploadedActivitiesError) {
+    throw new Error(`get_recent_sessions uploaded activities query failed: ${uploadedActivitiesError.message}`);
+  }
+
   const { data: planned } = await deps.supabase
     .from("sessions")
     .select("id,date,sport,type,duration_minutes,status")
@@ -80,16 +95,42 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
     .order("date", { ascending: false })
     .limit(20);
 
+  const legacyCompletionCount = new Map<string, number>();
+  (completed ?? []).forEach((session) => {
+    const key = `${session.date}:${session.sport}`;
+    legacyCompletionCount.set(key, (legacyCompletionCount.get(key) ?? 0) + 1);
+  });
+
+  const uploadedFallback = (uploadedActivities ?? []).flatMap((activity) => {
+    const activityDate = activity.start_time_utc.slice(0, 10);
+    const key = `${activityDate}:${activity.sport_type}`;
+    const legacyCount = legacyCompletionCount.get(key) ?? 0;
+    if (legacyCount > 0) {
+      legacyCompletionCount.set(key, legacyCount - 1);
+      return [];
+    }
+
+    return {
+      id: `activity:${activity.id}`,
+      date: activityDate,
+      sport: activity.sport_type,
+      durationMinutes: activity.duration_sec ? Math.round(activity.duration_sec / 60) : null
+    };
+  });
+
   return {
     range: { since, until: today },
-    completed: (completed ?? []).map((session) => ({
-      id: session.id,
-      date: session.date,
-      sport: session.sport,
-      durationMinutes: typeof session.metrics === "object" && session.metrics && "duration" in session.metrics
-        ? Number((session.metrics as { duration?: number }).duration ?? 0)
-        : null
-    })),
+    completed: [
+      ...(completed ?? []).map((session) => ({
+        id: session.id,
+        date: session.date,
+        sport: session.sport,
+        durationMinutes: typeof session.metrics === "object" && session.metrics && "duration" in session.metrics
+          ? Number((session.metrics as { duration?: number }).duration ?? 0)
+          : null
+      })),
+      ...uploadedFallback
+    ],
     planned: (planned ?? []).map((session) => ({
       id: session.id,
       date: session.date,


### PR DESCRIPTION
### Motivation
- Coach tooling only looked at `completed_sessions` for recent completed workouts, so uploaded activities stored in `completed_activities` (and linked to planned sessions) could be invisible to the coach and cause missing completed swims or other workouts.
- The coach response needs to include uploaded activities while avoiding double-counting when both legacy and uploaded records exist.

### Description
- Updated `getRecentSessions` in `lib/coach/tool-handlers.ts` to query `completed_activities` (scoped by `user_id`) for the same date window and include uploaded activities as fallback items when matching `completed_sessions` are absent.
- Added deduplication by `date + sport` (legacy `completed_sessions` wins) and emit fallback rows with ids prefixed as `activity:<id>` and a computed `durationMinutes` field.
- Added a unit test in `lib/coach/tool-handlers.test.ts` that exercises the fallback path and asserts the uploaded-activity lookup uses the `user_id` ownership filter.
- Changes touch `lib/coach/tool-handlers.ts` and `lib/coach/tool-handlers.test.ts` (no changes to persisted schema or RLS policies).

### Testing
- Ran `npm test -- lib/coach/tool-handlers.test.ts` and the test suite passed with all tests green (`3 passed, 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b178f97624833281d75333f5813e2b)