### PR TITLE
Expose richer uploaded-activity metrics in coach recent sessions context

### DIFF
--- a/lib/coach/tool-handlers.test.ts
+++ b/lib/coach/tool-handlers.test.ts
@@ -51,7 +51,12 @@ describe("executeCoachTool hardening", () => {
             id: "activity-1",
             sport_type: "swim",
             start_time_utc: "2026-03-10T07:10:00.000Z",
-            duration_sec: 3600
+            duration_sec: 3600,
+            distance_m: 2400,
+            avg_hr: 141,
+            avg_power: null,
+            calories: 510,
+            parse_summary: { lapCount: 24 }
           }
         ],
         error: null
@@ -63,7 +68,12 @@ describe("executeCoachTool hardening", () => {
           id: "activity-1",
           sport_type: "swim",
           start_time_utc: "2026-03-10T07:10:00.000Z",
-          duration_sec: 3600
+          duration_sec: 3600,
+          distance_m: 2400,
+          avg_hr: 141,
+          avg_power: null,
+          calories: 510,
+          parse_summary: { lapCount: 24 }
         }
       ],
       error: null
@@ -98,7 +108,13 @@ describe("executeCoachTool hardening", () => {
           id: "activity:activity-1",
           date: "2026-03-10",
           sport: "swim",
-          durationMinutes: 60
+          durationMinutes: 60,
+          distanceMeters: 2400,
+          avgHr: 141,
+          avgPower: null,
+          calories: 510,
+          parseSummary: { lapCount: 24 },
+          source: "upload"
         }
       ]
     });

--- a/lib/coach/tool-handlers.ts
+++ b/lib/coach/tool-handlers.ts
@@ -75,7 +75,7 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
 
   const { data: uploadedActivities, error: uploadedActivitiesError } = await deps.supabase
     .from("completed_activities")
-    .select("id,sport_type,start_time_utc,duration_sec")
+    .select("id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,calories,parse_summary")
     .eq("user_id", deps.ctx.userId)
     .gte("start_time_utc", sinceUtc)
     .lte("start_time_utc", todayUtc)
@@ -114,7 +114,13 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
       id: `activity:${activity.id}`,
       date: activityDate,
       sport: activity.sport_type,
-      durationMinutes: activity.duration_sec ? Math.round(activity.duration_sec / 60) : null
+      durationMinutes: activity.duration_sec ? Math.round(activity.duration_sec / 60) : null,
+      distanceMeters: activity.distance_m ? Number(activity.distance_m) : null,
+      avgHr: activity.avg_hr ?? null,
+      avgPower: activity.avg_power ?? null,
+      calories: activity.calories ?? null,
+      parseSummary: activity.parse_summary ?? null,
+      source: "upload"
     };
   });
 
@@ -127,7 +133,23 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
         sport: session.sport,
         durationMinutes: typeof session.metrics === "object" && session.metrics && "duration" in session.metrics
           ? Number((session.metrics as { duration?: number }).duration ?? 0)
-          : null
+          : null,
+        distanceMeters: typeof session.metrics === "object" && session.metrics && "distance" in session.metrics
+          ? Number((session.metrics as { distance?: number }).distance ?? 0)
+          : null,
+        avgHr: typeof session.metrics === "object" && session.metrics && "avg_hr" in session.metrics
+          ? Number((session.metrics as { avg_hr?: number }).avg_hr ?? 0)
+          : null,
+        avgPower: typeof session.metrics === "object" && session.metrics && "avg_power" in session.metrics
+          ? Number((session.metrics as { avg_power?: number }).avg_power ?? 0)
+          : null,
+        calories: typeof session.metrics === "object" && session.metrics && "calories" in session.metrics
+          ? Number((session.metrics as { calories?: number }).calories ?? 0)
+          : null,
+        parseSummary: typeof session.metrics === "object" && session.metrics && "parse_summary" in session.metrics
+          ? (session.metrics as { parse_summary?: unknown }).parse_summary ?? null
+          : null,
+        source: "legacy"
       })),
       ...uploadedFallback
     ],


### PR DESCRIPTION
### Motivation
- Coaching responses lacked distance, heart-rate, power, calories, and parse-summary data for uploaded activities because the recent-sessions tool only returned minimal fields (`id`, `sport`, `date`, `duration`).
- The deeper metrics were already parsed and stored at ingest, so the gap was in the tool output rather than parsing/storage.

### Description
- Expanded the `completed_activities` query in `getRecentSessions` to select `distance_m`, `avg_hr`, `avg_power`, `calories`, and `parse_summary` so uploads surface richer metrics to the coach tool. 
- Included normalized fields in the returned payload for uploads (`distanceMeters`, `avgHr`, `avgPower`, `calories`, `parseSummary`) and added a `source: "upload"` tag. 
- Normalized legacy `completed_sessions.metrics` into the same shape (`distanceMeters`, `avgHr`, `avgPower`, `calories`, `parseSummary`) and added `source: "legacy"` to maintain consistent downstream handling. 
- Updated unit test expectations in `lib/coach/tool-handlers.test.ts` to assert the enriched fallback payload structure.

### Testing
- Ran the targeted unit tests with `npm test -- lib/coach/tool-handlers.test.ts` and the suite passed (`PASS lib/coach/tool-handlers.test.ts`, all tests green).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b17c05efe08332b7f15ee79972f140)