### PR TITLE
Expose exact average pace metrics for coach session summaries

### DIFF
--- a/lib/coach/instructions.ts
+++ b/lib/coach/instructions.ts
@@ -5,6 +5,7 @@ Core behavior rules:
 - Never invent athlete data.
 - If athlete-specific context is needed, call tools.
 - If data is missing, explicitly say what is missing.
+- When session pace fields are available from tools, present them as recorded average pace (not estimated).
 - Never claim to directly edit a training plan.
 - You may create proposal records only via create_plan_change_proposal.
 - Never ask for or rely on userId/athleteId from the athlete.

--- a/lib/coach/tool-handlers.test.ts
+++ b/lib/coach/tool-handlers.test.ts
@@ -114,6 +114,8 @@ describe("executeCoachTool hardening", () => {
           avgPower: null,
           calories: 510,
           parseSummary: { lapCount: 24 },
+          avgPaceSecPerKm: 1500,
+          avgPaceSecPer100m: 150,
           source: "upload"
         }
       ]

--- a/lib/coach/tool-handlers.ts
+++ b/lib/coach/tool-handlers.ts
@@ -21,6 +21,17 @@ function isoDate(date: Date) {
   return date.toISOString().slice(0, 10);
 }
 
+function derivePace(durationSec: number | null | undefined, distanceM: number | null | undefined) {
+  if (!durationSec || !distanceM || durationSec <= 0 || distanceM <= 0) {
+    return { avgPaceSecPerKm: null, avgPaceSecPer100m: null };
+  }
+
+  return {
+    avgPaceSecPerKm: Number((durationSec / (distanceM / 1000)).toFixed(2)),
+    avgPaceSecPer100m: Number((durationSec / (distanceM / 100)).toFixed(2))
+  };
+}
+
 async function getAthleteSnapshot({ supabase, ctx }: ToolDeps) {
   const { data: profile } = await supabase
     .from("profiles")
@@ -110,16 +121,22 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
       return [];
     }
 
+    const durationSec = activity.duration_sec ? Number(activity.duration_sec) : null;
+    const distanceMeters = activity.distance_m ? Number(activity.distance_m) : null;
+    const pace = derivePace(durationSec, distanceMeters);
+
     return {
       id: `activity:${activity.id}`,
       date: activityDate,
       sport: activity.sport_type,
-      durationMinutes: activity.duration_sec ? Math.round(activity.duration_sec / 60) : null,
-      distanceMeters: activity.distance_m ? Number(activity.distance_m) : null,
+      durationMinutes: durationSec ? Math.round(durationSec / 60) : null,
+      distanceMeters,
       avgHr: activity.avg_hr ?? null,
       avgPower: activity.avg_power ?? null,
       calories: activity.calories ?? null,
       parseSummary: activity.parse_summary ?? null,
+      avgPaceSecPerKm: pace.avgPaceSecPerKm,
+      avgPaceSecPer100m: pace.avgPaceSecPer100m,
       source: "upload"
     };
   });
@@ -127,30 +144,38 @@ async function getRecentSessions(args: unknown, deps: ToolDeps) {
   return {
     range: { since, until: today },
     completed: [
-      ...(completed ?? []).map((session) => ({
-        id: session.id,
-        date: session.date,
-        sport: session.sport,
-        durationMinutes: typeof session.metrics === "object" && session.metrics && "duration" in session.metrics
+      ...(completed ?? []).map((session) => {
+        const durationMinutes = typeof session.metrics === "object" && session.metrics && "duration" in session.metrics
           ? Number((session.metrics as { duration?: number }).duration ?? 0)
-          : null,
-        distanceMeters: typeof session.metrics === "object" && session.metrics && "distance" in session.metrics
+          : null;
+        const distanceMeters = typeof session.metrics === "object" && session.metrics && "distance" in session.metrics
           ? Number((session.metrics as { distance?: number }).distance ?? 0)
-          : null,
-        avgHr: typeof session.metrics === "object" && session.metrics && "avg_hr" in session.metrics
-          ? Number((session.metrics as { avg_hr?: number }).avg_hr ?? 0)
-          : null,
-        avgPower: typeof session.metrics === "object" && session.metrics && "avg_power" in session.metrics
-          ? Number((session.metrics as { avg_power?: number }).avg_power ?? 0)
-          : null,
-        calories: typeof session.metrics === "object" && session.metrics && "calories" in session.metrics
-          ? Number((session.metrics as { calories?: number }).calories ?? 0)
-          : null,
-        parseSummary: typeof session.metrics === "object" && session.metrics && "parse_summary" in session.metrics
-          ? (session.metrics as { parse_summary?: unknown }).parse_summary ?? null
-          : null,
-        source: "legacy"
-      })),
+          : null;
+        const pace = derivePace(durationMinutes ? durationMinutes * 60 : null, distanceMeters);
+
+        return {
+          id: session.id,
+          date: session.date,
+          sport: session.sport,
+          durationMinutes,
+          distanceMeters,
+          avgHr: typeof session.metrics === "object" && session.metrics && "avg_hr" in session.metrics
+            ? Number((session.metrics as { avg_hr?: number }).avg_hr ?? 0)
+            : null,
+          avgPower: typeof session.metrics === "object" && session.metrics && "avg_power" in session.metrics
+            ? Number((session.metrics as { avg_power?: number }).avg_power ?? 0)
+            : null,
+          calories: typeof session.metrics === "object" && session.metrics && "calories" in session.metrics
+            ? Number((session.metrics as { calories?: number }).calories ?? 0)
+            : null,
+          parseSummary: typeof session.metrics === "object" && session.metrics && "parse_summary" in session.metrics
+            ? (session.metrics as { parse_summary?: unknown }).parse_summary ?? null
+            : null,
+          avgPaceSecPerKm: pace.avgPaceSecPerKm,
+          avgPaceSecPer100m: pace.avgPaceSecPer100m,
+          source: "legacy"
+        };
+      }),
       ...uploadedFallback
     ],
     planned: (planned ?? []).map((session) => ({

--- a/lib/workouts/activity-parser.ts
+++ b/lib/workouts/activity-parser.ts
@@ -14,6 +14,17 @@ export type ParsedActivity = {
   parseSummary?: Record<string, unknown>;
 };
 
+function buildPaceSummary(durationSec: number, distanceM: number) {
+  if (durationSec <= 0 || distanceM <= 0) {
+    return {};
+  }
+
+  return {
+    avgPaceSecPerKm: Number((durationSec / (distanceM / 1000)).toFixed(2)),
+    avgPaceSecPer100m: Number((durationSec / (distanceM / 100)).toFixed(2))
+  };
+}
+
 const tcxParser = new XMLParser({ ignoreAttributes: false, attributeNamePrefix: "", parseTagValue: true, trimValues: true });
 
 function asArray<T>(value: T | T[] | undefined): T[] {
@@ -62,7 +73,10 @@ export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
     avgHr: session.avg_heart_rate ? Number(session.avg_heart_rate) : null,
     avgPower: session.avg_power ? Number(session.avg_power) : null,
     calories: session.total_calories ? Number(session.total_calories) : null,
-    parseSummary: { records: Array.isArray(fit?.records) ? fit.records.length : 0 }
+    parseSummary: {
+      records: Array.isArray(fit?.records) ? fit.records.length : 0,
+      ...buildPaceSummary(durationSec, Number(session.total_distance ?? 0))
+    }
   };
 }
 
@@ -90,6 +104,9 @@ export function parseTcxFile(xml: string): ParsedActivity {
     avgHr,
     avgPower: null,
     calories,
-    parseSummary: { lapCount: laps.length }
+    parseSummary: {
+      lapCount: laps.length,
+      ...buildPaceSummary(durationSec, distanceM)
+    }
   };
 }

--- a/lib/workouts/tcx.test.ts
+++ b/lib/workouts/tcx.test.ts
@@ -31,6 +31,11 @@ describe('TCX parsing and normalization', () => {
     expect(activity.distanceM).toBe(10100);
     expect(activity.avgHr).toBe(152);
     expect(activity.sportType).toBe('run');
+    expect(activity.parseSummary).toMatchObject({
+      lapCount: 2,
+      avgPaceSecPerKm: 362.38,
+      avgPaceSecPer100m: 36.24
+    });
   });
 
   test('given malformed TCX, then parsing throws', () => {


### PR DESCRIPTION
### Motivation
- Coaching replies currently show an "estimated" pace when exact recorded pace is available, which can be misleading; this change surfaces precise average pace values so responses can report recorded pace directly.
- Persist average-pace metrics from uploaded FIT/TCX files so downstream tools have deterministic numeric fields to use instead of relying on text or heuristics.
- Expose the recorded pace values in the recent-sessions tool so the coach model can call tools and report the exact average pace when present.
- No external skills were required for this change.

### Description
- Added `buildPaceSummary` in `lib/workouts/activity-parser.ts` and include `avgPaceSecPerKm` and `avgPaceSecPer100m` in `parseSummary` for both FIT and TCX parsing. 
- Added `derivePace` helper and extended `get_recent_sessions` in `lib/coach/tool-handlers.ts` to return top-level `avgPaceSecPerKm` and `avgPaceSecPer100m` for uploaded activities and legacy completed sessions. 
- Updated coach system instructions in `lib/coach/instructions.ts` to prefer presenting recorded pace fields as recorded averages rather than labeling them as estimated. 
- Updated unit tests in `lib/workouts/tcx.test.ts` and `lib/coach/tool-handlers.test.ts` to validate the new pace fields.

### Testing
- Ran the targeted test suites with `npm test -- lib/workouts/tcx.test.ts lib/coach/tool-handlers.test.ts`, and both test suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b196088fd08332807d8eeea202ae1a)