### PR TITLE
Update week calendar review workflow UI

### DIFF
--- a/app/(protected)/calendar/week-calendar.test.tsx
+++ b/app/(protected)/calendar/week-calendar.test.tsx
@@ -54,7 +54,7 @@ const sessions = [
 ];
 
 describe("WeekCalendar", () => {
-  it("shows adaptation strip for unmatched uploads and filters by extra state", () => {
+  it("shows needs-attention queue for uploads needing review and filters by extra state", () => {
     render(
       <WeekCalendar
         weekDays={weekDays}
@@ -71,8 +71,8 @@ describe("WeekCalendar", () => {
       />
     );
 
-    expect(screen.getByText("Adaptation strip")).toBeInTheDocument();
-    expect(screen.getByText(/Unmatched upload/)).toBeInTheDocument();
+    expect(screen.getAllByText("Needs attention").length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/Upload needs review/).length).toBeGreaterThan(0);
 
     fireEvent.change(screen.getByLabelText("Status filter"), { target: { value: "extra" } });
     expect(screen.queryByText("Tempo")).not.toBeInTheDocument();
@@ -99,7 +99,31 @@ describe("WeekCalendar", () => {
     fireEvent.click(screen.getByRole("button", { name: "Mark extra" }));
 
     expect(screen.getByText("Extra workout logged")).toBeInTheDocument();
-    expect(screen.queryByText(/Unmatched upload/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Upload needs review/)).not.toBeInTheDocument();
+  });
+
+  it("opens the upload review drawer from the unresolved day card", () => {
+    render(
+      <WeekCalendar
+        weekDays={weekDays}
+        sessions={sessions}
+        executionLabel="Execution"
+        completedCount={1}
+        plannedTotalCount={1}
+        skippedCount={0}
+        extraSessionCount={1}
+        plannedRemainingCount={1}
+        plannedMinutes={45}
+        completedMinutes={35}
+        remainingMinutes={10}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Review upload" }));
+
+    expect(screen.getAllByText("Upload needs review").length).toBeGreaterThan(0);
+    expect(screen.getByText("Uploaded workout")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Assign to session" })).toBeInTheDocument();
   });
 
   it("uses discipline fallback for weak generic completed titles and hides inline open review text", () => {

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -162,9 +162,7 @@ function SessionActionMenu({
             </button>
           ) : null}
           {session.displayType === "completed_activity" && activityId ? (
-            <Link className="block rounded px-2 py-1 hover:bg-[hsl(var(--surface-subtle))]" href={`/activities/${activityId}`}>
-              Assign upload
-            </Link>
+            <Link className="block rounded px-2 py-1 hover:bg-[hsl(var(--surface-subtle))]" href={`/activities/${activityId}`}>Assign to session</Link>
           ) : null}
         </div>
       ) : null}
@@ -356,16 +354,23 @@ export function WeekCalendar({
       </header>
 
       {hasAdaptation ? (
-        <section className="surface-subtle space-y-2 px-3 py-2">
-          <p className="text-xs uppercase tracking-[0.14em] text-accent">Adaptation strip</p>
-          <div className="flex flex-wrap gap-1.5 text-xs">
+        <section className="rounded-xl border border-[hsl(var(--border)/0.62)] bg-[linear-gradient(180deg,hsl(var(--bg-elevated)/0.78),hsl(var(--bg-elevated)/0.58))] px-3 py-2">
+          <div className="mb-2 flex items-center justify-between gap-3">
+            <p className="text-xs font-semibold uppercase tracking-[0.14em] text-accent">Needs attention</p>
+            <p className="text-[11px] text-muted">
+              {unmatchedUploads.length + skippedToResolve.length + movedItems.length + extraItems.length} open
+            </p>
+          </div>
+          <div className="flex flex-col gap-1.5 text-xs">
             {unmatchedUploads.map((upload) => (
-              <div key={upload.id} className="rounded-lg border border-[hsl(var(--accent-performance)/0.35)] bg-[hsl(var(--accent-performance)/0.08)] p-2">
-                <p className="font-semibold">Unmatched upload (provisional)</p>
-                <p className="text-muted">{getDisciplineMeta(upload.sport).label} · {upload.duration} min · logged {uploadDateFormatter.format(new Date(`${upload.created_at}`))}</p>
-                <div className="mt-1 flex gap-2">
+              <div key={upload.id} className="flex flex-col gap-1.5 rounded-lg border border-[hsl(var(--accent-performance)/0.26)] bg-[hsl(var(--accent-performance)/0.04)] px-2.5 py-2 md:flex-row md:items-center md:justify-between">
+                <div className="min-w-0">
+                  <p className="font-semibold text-[hsl(var(--text-primary))]">Upload needs review</p>
+                  <p className="text-[11px] text-muted">{getDisciplineMeta(upload.sport).label} · {upload.duration} min · logged {uploadDateFormatter.format(new Date(`${upload.created_at}`))}</p>
+                </div>
+                <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-[12px] md:justify-end">
                   {upload.source?.uploadId ? (
-                    <button onClick={() => setAssignSource(upload)} className="text-accent hover:underline">Assign to planned session</button>
+                    <button onClick={() => setAssignSource(upload)} className="text-accent hover:underline">Assign to session</button>
                   ) : null}
                   <button
                     onClick={() => {
@@ -376,16 +381,18 @@ export function WeekCalendar({
                   >
                     Mark extra
                   </button>
-                  <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("unmatched_upload", upload.id)])} className="text-muted hover:text-foreground">Keep unresolved for now</button>
+                  <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("unmatched_upload", upload.id)])} className="text-muted hover:text-foreground">Dismiss</button>
                 </div>
               </div>
             ))}
             {skippedToResolve.map((session) => (
-              <div key={session.id} className="rounded-lg border border-[hsl(var(--signal-risk)/0.35)] bg-[hsl(var(--signal-risk)/0.08)] p-2">
+              <div key={session.id} className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--signal-risk)/0.35)] bg-[hsl(var(--signal-risk)/0.08)] px-2.5 py-2 md:flex-row md:items-center md:justify-between">
+                <div className="min-w-0">
                 <p className="font-semibold">Skipped session</p>
                 <p className="text-muted">{weekDays.find((day) => day.iso === session.date)?.weekday} {getSessionTitle(session)} · {session.duration} min</p>
                 <p className="text-muted">Suggested move: {absorbDayLabel}</p>
-                <div className="mt-1 flex gap-2">
+                </div>
+                <div className="flex flex-wrap gap-x-3 gap-y-1 md:justify-end">
                   <button onClick={() => setMoveSource(session)} className="text-accent hover:underline">Move to another day</button>
                   <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("skipped_reassign", session.id)])} className="text-muted hover:text-foreground">Confirm skip</button>
                 </div>
@@ -395,21 +402,25 @@ export function WeekCalendar({
               const session = localSessions.find((item) => item.id === move.sessionId);
               if (!session) return null;
               return (
-                <div key={`move-${move.sessionId}`} className="rounded-lg border border-[hsl(var(--signal-load)/0.35)] bg-[hsl(var(--signal-load)/0.08)] p-2">
+                <div key={`move-${move.sessionId}`} className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--signal-load)/0.35)] bg-[hsl(var(--signal-load)/0.08)] px-2.5 py-2 md:flex-row md:items-center md:justify-between">
+                  <div className="min-w-0">
                   <p className="font-semibold">Moved session</p>
                   <p className="text-muted">{getSessionTitle(session)} moved from {weekDays.find((day) => day.iso === move.fromDate)?.weekday ?? move.fromDate}</p>
-                  <div className="mt-1 flex gap-2">
+                  </div>
+                  <div className="flex flex-wrap gap-x-3 gap-y-1 md:justify-end">
                     <button onClick={() => setDetailSession(session)} className="text-accent hover:underline">Review</button>
-                    <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("moved_session", move.sessionId)])} className="text-muted hover:text-foreground">Keep unresolved for now</button>
+                    <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("moved_session", move.sessionId)])} className="text-muted hover:text-foreground">Dismiss</button>
                   </div>
                 </div>
               );
             })}
             {extraItems.map((item) => (
-              <div key={`extra-${item.id}`} className="rounded-lg border border-[hsl(var(--signal-load)/0.35)] bg-[hsl(var(--signal-load)/0.08)] p-2">
-                <p className="font-semibold">Extra workout logged</p>
-                <p className="text-muted">{getDisciplineMeta(item.sport).label} · {item.duration} min</p>
-                <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("extra_workout", item.id)])} className="mt-1 text-muted hover:text-foreground">Dismiss</button>
+              <div key={`extra-${item.id}`} className="flex flex-col gap-2 rounded-lg border border-[hsl(var(--signal-load)/0.35)] bg-[hsl(var(--signal-load)/0.08)] px-2.5 py-2 md:flex-row md:items-center md:justify-between">
+                <div className="min-w-0">
+                  <p className="font-semibold">Extra workout logged</p>
+                  <p className="text-muted">{getDisciplineMeta(item.sport).label} · {item.duration} min</p>
+                </div>
+                <button onClick={() => setDismissedIssues((prev) => [...prev, getIssueId("extra_workout", item.id)])} className="text-muted hover:text-foreground">Dismiss</button>
               </div>
             ))}
           </div>
@@ -474,6 +485,8 @@ export function WeekCalendar({
                           ? "border-[hsl(var(--signal-load)/0.45)] bg-[hsl(var(--signal-load)/0.08)]"
                         : state === "extra"
                           ? "border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.10)]"
+                          : state === "unmatched_upload"
+                            ? "border-[hsl(var(--accent-performance)/0.42)] bg-[linear-gradient(180deg,hsl(var(--accent-performance)/0.12),hsl(var(--accent-performance)/0.05))] shadow-[inset_0_1px_0_hsl(var(--accent-performance)/0.12)]"
                           : state === "assigned_from_upload"
                               ? "border-[hsl(var(--signal-ready)/0.34)] bg-[hsl(var(--signal-ready)/0.07)]"
                               : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]";
@@ -481,6 +494,8 @@ export function WeekCalendar({
                   const stateBadge =
                     state === "extra" ? (
                       <span className="rounded-full border border-[hsl(var(--signal-load)/0.4)] px-1.5 py-0.5 text-[10px] text-[hsl(var(--signal-load))]">Extra</span>
+                    ) : state === "unmatched_upload" ? (
+                      <span className="rounded-full border border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.14)] px-1.5 py-0.5 text-[10px] text-accent">Needs review</span>
                     ) : state === "moved" ? (
                       <span className="rounded-full border border-[hsl(var(--signal-load)/0.4)] px-1.5 py-0.5 text-[10px] text-[hsl(var(--signal-load))]">Moved{movedMeta ? ` · from ${weekDays.find((day) => day.iso === movedMeta.fromDate)?.weekday ?? movedMeta.fromDate}` : ""}</span>
                     ) : (
@@ -489,6 +504,7 @@ export function WeekCalendar({
 
                   const reviewableCompleted = session.displayType !== "completed_activity" && session.status === "completed";
                   const showCompletedFooter = state === "completed" || state === "assigned_from_upload";
+                  const cardTitle = state === "unmatched_upload" ? "Uploaded workout" : getSessionTitle(session);
 
                   return (
                     <article
@@ -532,14 +548,26 @@ export function WeekCalendar({
                           }}
                         />
                       </div>
-                      <p className="mt-1 min-h-[1.5rem] font-medium leading-snug">{getSessionTitle(session)}</p>
-                      <p className="mt-0 text-muted">{session.duration} min</p>
+                      <p className="mt-1 min-h-[1.5rem] font-medium leading-snug">{cardTitle}</p>
+                      <p className="mt-0 text-[11px] text-muted">{session.duration} min{state === "unmatched_upload" ? ` · logged ${uploadDateFormatter.format(new Date(`${session.created_at}`))}` : ""}</p>
                       {showCompletedFooter ? (
                         <div className="mt-1 flex items-center border-t border-[hsl(var(--signal-ready)/0.24)] pt-1 text-[10px]">
                           <span className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--signal-ready)/0.3)] bg-[hsl(var(--signal-ready)/0.12)] px-1.5 py-0.5 text-[hsl(var(--signal-ready)/0.9)]">
                             <span aria-hidden="true">✓</span>
                             Completed
                           </span>
+                        </div>
+                      ) : state === "unmatched_upload" ? (
+                        <div className="mt-2 border-t border-[hsl(var(--accent-performance)/0.18)] pt-1.5">
+                          {session.source?.uploadId ? (
+                            <button
+                              type="button"
+                              onClick={() => setAssignSource(session)}
+                              className="w-full rounded-md border border-[hsl(var(--accent-performance)/0.26)] bg-[hsl(var(--accent-performance)/0.05)] px-2 py-1 text-[11px] font-medium text-accent transition hover:bg-[hsl(var(--accent-performance)/0.1)]"
+                            >
+                              Review upload
+                            </button>
+                          ) : null}
                         </div>
                       ) : (
                         <div className="mt-1 flex items-center justify-end">{stateBadge}</div>
@@ -565,7 +593,7 @@ export function WeekCalendar({
             setDismissedIssues((prev) => [...prev, getIssueId("unmatched_upload", assignSource.id)]);
             setAssignSource(null);
             router.refresh();
-            setToast("Upload assigned to planned session");
+            setToast("Upload assigned to session");
           }}
           onError={() => setToast("Could not assign upload")}
         />
@@ -668,10 +696,17 @@ function AssignUploadModal({
   return (
     <TaskSheet
       onClose={onClose}
-      title="Assign upload to planned session"
-      description={`${getDisciplineMeta(upload.sport).label} · ${upload.duration} min`}
+      title="Upload needs review"
+      description="Choose where this workout belongs in your calendar."
     >
       <div className="space-y-3">
+        <div className="rounded-xl border border-[hsl(var(--accent-performance)/0.3)] bg-[hsl(var(--accent-performance)/0.08)] p-3">
+          <p className="text-[11px] uppercase tracking-[0.14em] text-accent">Uploaded workout</p>
+          <p className="mt-1 text-sm font-semibold text-[hsl(var(--text-primary))]">
+            {getDisciplineMeta(upload.sport).label} · {upload.duration} min
+          </p>
+          <p className="mt-1 text-xs text-muted">Logged {uploadDateFormatter.format(new Date(`${upload.created_at}`))}</p>
+        </div>
         {candidateSessions.length === 0 ? (
           <p className="text-xs text-muted">No planned sessions in this week. Add or move a planned session first.</p>
         ) : (
@@ -708,7 +743,7 @@ function AssignUploadModal({
             }}
             className="btn-primary px-2 py-1 text-xs"
           >
-            Assign
+            Assign to session
           </button>
         </div>
       </div>
@@ -774,7 +809,7 @@ function DetailsModal({ session, onClose }: { session: CalendarSession; onClose:
 
 function TaskOverlay({ children, onClose }: { children: React.ReactNode; onClose: () => void }) {
   return (
-    <div className="fixed inset-0 z-40 bg-black/60 backdrop-blur-[2px]">
+    <div className="fixed inset-x-0 bottom-0 top-14 z-40 bg-black/55 backdrop-blur-[2px]">
       <button type="button" aria-label="Close overlay" className="absolute inset-0 h-full w-full cursor-default" onClick={onClose} />
       {children}
     </div>
@@ -784,13 +819,22 @@ function TaskOverlay({ children, onClose }: { children: React.ReactNode; onClose
 function TaskSheet({ children, title, description, onClose }: { children: React.ReactNode; title: string; description?: string; onClose: () => void }) {
   return (
     <TaskOverlay onClose={onClose}>
-      <aside className="absolute right-0 top-0 h-full w-full max-w-xl border-l border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-5 py-4 shadow-2xl">
-        <header className="mb-4 border-b border-[hsl(var(--border))] pb-3 pr-10">
-          <p className="text-base font-semibold">{title}</p>
-          {description ? <p className="mt-1 text-xs text-muted">{description}</p> : null}
+      <aside className="absolute right-0 top-0 flex h-full w-full max-w-xl flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] shadow-2xl">
+        <header className="border-b border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle)/0.22)] px-5 py-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0">
+              <p className="text-[11px] uppercase tracking-[0.14em] text-accent">Calendar task</p>
+              <p className="mt-1 text-base font-semibold">{title}</p>
+              {description ? (
+                <p className="mt-2 max-w-md rounded-lg border border-[hsl(var(--border)/0.8)] bg-[hsl(var(--bg-elevated)/0.82)] px-3 py-2 text-xs text-muted">
+                  {description}
+                </p>
+              ) : null}
+            </div>
+            <button type="button" onClick={onClose} className="rounded-md border border-[hsl(var(--border))] px-2 py-1 text-xs text-muted hover:text-foreground">Close</button>
+          </div>
         </header>
-        <div className="max-h-[calc(100vh-7rem)] overflow-y-auto pr-1">{children}</div>
-        <button type="button" onClick={onClose} className="absolute right-4 top-4 rounded-md border border-[hsl(var(--border))] px-2 py-1 text-xs text-muted hover:text-foreground">Close</button>
+        <div className="flex-1 overflow-y-auto px-5 py-4">{children}</div>
       </aside>
     </TaskOverlay>
   );


### PR DESCRIPTION
Summary
- replace the adaptation strip with a Needs attention queue that surfaces uploads needing review, skipped sessions, moves, and extra workouts
- refresh WeekCalendar cards and drawer actions/texts to consistently reference review state, include upload metadata, and update copy for assigning/dismissing issues
- polish the task sheet styling, overlay bounds, and upload modal header so the review flow feels cohesive and actionable

Testing
- Not run (not requested)