### PR TITLE
Keep matched planned session visible after sidebar upload assignment

### DIFF
--- a/app/(protected)/calendar/week-calendar.test.tsx
+++ b/app/(protected)/calendar/week-calendar.test.tsx
@@ -47,6 +47,7 @@ const sessions = [
     created_at: "2026-03-02T08:00:00.000Z",
     status: "completed" as const,
     displayType: "completed_activity" as const,
+    source: { uploadId: "upload-1", assignedBy: "upload" as const },
     linkedActivityCount: 1,
     linkedStats: { durationMin: 35, distanceKm: 7, avgHr: 150, avgPower: null },
     is_key: false
@@ -54,6 +55,14 @@ const sessions = [
 ];
 
 describe("WeekCalendar", () => {
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
   it("shows needs-attention queue for uploads needing review and filters by extra state", () => {
     render(
       <WeekCalendar
@@ -119,11 +128,109 @@ describe("WeekCalendar", () => {
       />
     );
 
-    fireEvent.click(screen.getByRole("button", { name: "Review upload" }));
+    fireEvent.click(screen.getByRole("button", { name: "Assign to session" }));
 
     expect(screen.getAllByText("Upload needs review").length).toBeGreaterThan(0);
-    expect(screen.getByText("Uploaded workout")).toBeInTheDocument();
-    expect(screen.getByRole("button", { name: "Assign to session" })).toBeInTheDocument();
+    expect(screen.getAllByText("Uploaded workout").length).toBeGreaterThan(0);
+    expect(screen.getAllByRole("button", { name: "Assign to session" }).length).toBeGreaterThan(0);
+  });
+
+  it("prefers a same-day same-sport session when opening upload assignment from the sidebar", () => {
+    render(
+      <WeekCalendar
+        weekDays={weekDays}
+        sessions={[
+          {
+            id: "s-early",
+            date: "2026-03-02",
+            sport: "bike",
+            type: "Bike endurance",
+            duration: 60,
+            notes: null,
+            created_at: "2026-03-01T00:00:00.000Z",
+            status: "planned" as const,
+            displayType: "planned_session" as const,
+            is_key: false
+          },
+          {
+            id: "s-target",
+            date: "2026-03-02",
+            sport: "run",
+            type: "Tempo",
+            duration: 40,
+            notes: null,
+            created_at: "2026-03-01T01:00:00.000Z",
+            status: "planned" as const,
+            displayType: "planned_session" as const,
+            is_key: false
+          },
+          sessions[1]
+        ]}
+        executionLabel="Execution"
+        completedCount={1}
+        plannedTotalCount={2}
+        skippedCount={0}
+        extraSessionCount={1}
+        plannedRemainingCount={2}
+        plannedMinutes={100}
+        completedMinutes={35}
+        remainingMinutes={65}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign to session" }));
+
+    const selects = screen.getAllByRole("combobox");
+    const assignmentSelect = selects[selects.length - 1] as HTMLSelectElement;
+    expect(assignmentSelect.value).toBe("s-target");
+  });
+
+  it("keeps the matched planned session visible after assigning an upload from the sidebar", async () => {
+    (global.fetch as jest.Mock).mockResolvedValue({ ok: true });
+
+    render(
+      <WeekCalendar
+        weekDays={weekDays}
+        sessions={[
+          {
+            id: "s1",
+            date: "2026-03-02",
+            sport: "run",
+            type: "Tempo",
+            duration: 45,
+            notes: null,
+            created_at: "2026-03-01T00:00:00.000Z",
+            status: "planned" as const,
+            displayType: "planned_session" as const,
+            is_key: false
+          },
+          {
+            ...sessions[1],
+            source: { uploadId: "upload-1", assignedBy: "upload" as const }
+          }
+        ]}
+        executionLabel="Execution"
+        completedCount={1}
+        plannedTotalCount={1}
+        skippedCount={0}
+        extraSessionCount={1}
+        plannedRemainingCount={1}
+        plannedMinutes={45}
+        completedMinutes={35}
+        remainingMinutes={10}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Assign to session" }));
+
+    const assignButtons = screen.getAllByRole("button", { name: "Assign to session" });
+    fireEvent.click(assignButtons[assignButtons.length - 1]);
+
+    expect(await screen.findByText("Upload assigned to session")).toBeInTheDocument();
+    expect(screen.queryAllByRole("button", { name: "Assign to session" })).toHaveLength(0);
+    const tempoCard = screen.getByRole("link", { name: /Tempo/i }).closest("article");
+    expect(tempoCard).not.toBeNull();
+    expect(within(tempoCard as HTMLElement).getByText("Completed")).toBeInTheDocument();
   });
 
   it("uses discipline fallback for weak generic completed titles and hides inline open review text", () => {

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -94,6 +94,31 @@ function getSessionTitle(session: CalendarSession) {
   });
 }
 
+function getSuggestedSessionId(upload: CalendarSession, candidateSessions: CalendarSession[]) {
+  if (candidateSessions.length === 0) return "";
+
+  const scoredCandidates = candidateSessions.map((session, index) => {
+    let score = 0;
+
+    if (session.date === upload.date) score += 5;
+    if (session.sport === upload.sport) score += 4;
+    if (session.status === "planned") score += 2;
+    if (session.status === "skipped") score -= 1;
+
+    const durationDelta = Math.abs(session.duration - upload.duration);
+    score -= durationDelta / 30;
+
+    return { sessionId: session.id, score, index };
+  });
+
+  scoredCandidates.sort((left, right) => {
+    if (right.score !== left.score) return right.score - left.score;
+    return left.index - right.index;
+  });
+
+  return scoredCandidates[0]?.sessionId ?? candidateSessions[0]?.id ?? "";
+}
+
 function getSessionState(session: CalendarSession, recentMoves: RecentMove[], extraActivityIds: string[]) {
   if (session.displayType === "completed_activity") {
     if (extraActivityIds.includes(session.id)) {
@@ -589,8 +614,21 @@ export function WeekCalendar({
           weekDays={weekDays}
           candidateSessions={localSessions.filter((session) => session.displayType !== "completed_activity")}
           onClose={() => setAssignSource(null)}
-          onAssigned={() => {
-            setDismissedIssues((prev) => [...prev, getIssueId("unmatched_upload", assignSource.id)]);
+          onAssigned={(selectedSessionId) => {
+            setLocalSessions((prev) =>
+              prev
+                .filter((session) => session.id !== assignSource.id)
+                .map((session) =>
+                  session.id === selectedSessionId
+                    ? {
+                        ...session,
+                        status: "completed",
+                        linkedActivityCount: Math.max(session.linkedActivityCount ?? 0, 0) + 1
+                      }
+                    : session
+                )
+            );
+            setDismissedIssues((prev) => prev.filter((issueId) => issueId !== getIssueId("unmatched_upload", assignSource.id)));
             setAssignSource(null);
             router.refresh();
             setToast("Upload assigned to session");
@@ -687,11 +725,15 @@ function AssignUploadModal({
   weekDays: WeekDay[];
   candidateSessions: CalendarSession[];
   onClose: () => void;
-  onAssigned: () => void;
+  onAssigned: (selectedSessionId: string) => void;
   onError: () => void;
 }) {
-  const [selectedSessionId, setSelectedSessionId] = useState(candidateSessions[0]?.id ?? "");
+  const [selectedSessionId, setSelectedSessionId] = useState(() => getSuggestedSessionId(upload, candidateSessions));
   const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setSelectedSessionId(getSuggestedSessionId(upload, candidateSessions));
+  }, [candidateSessions, upload]);
 
   return (
     <TaskSheet
@@ -734,7 +776,7 @@ function AssignUploadModal({
                 });
 
                 if (!response.ok) throw new Error("failed");
-                onAssigned();
+                onAssigned(selectedSessionId);
               } catch {
                 onError();
               } finally {

--- a/app/api/uploads/activities/[uploadId]/attach/route.ts
+++ b/app/api/uploads/activities/[uploadId]/attach/route.ts
@@ -1,3 +1,4 @@
+import { revalidatePath } from "next/cache";
 import { NextResponse } from "next/server";
 import { z } from "zod";
 import { createClient } from "@/lib/supabase/server";
@@ -59,11 +60,14 @@ export async function POST(request: Request, { params }: { params: { uploadId: s
 
   await supabase
     .from("completed_activities")
-    .update({ schedule_status: "scheduled" })
+    .update({ schedule_status: "scheduled", is_unplanned: false })
     .eq("id", activity.id)
     .eq("user_id", user.id);
 
   await supabase.from("activity_uploads").update({ status: "matched", error_message: null }).eq("id", params.uploadId).eq("user_id", user.id);
+
+  revalidatePath("/calendar");
+  revalidatePath("/dashboard");
 
   return NextResponse.json({ ok: true });
 }


### PR DESCRIPTION
Summary
- prefer same-day/sport planned sessions when opening the sidebar assignment dialog and keep selected session visible after assignment
- update assignment modal to score candidates, refresh local state on success, and stop dismissing the upload issue prematurely
- revalidate calendar/dashboard after matching an upload and mark the completed activity as planned
Testing
- Not run (not requested)