### PR TITLE
Include unplanned workouts in totals and views

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -3,6 +3,7 @@ import { isValidIsoDate } from "@/lib/date/iso";
 import { WeekCalendar } from "./week-calendar";
 import { computeWeekMinuteTotals, computeWeekSessionCounts } from "@/lib/training/week-metrics";
 import { buildCalendarDisplayItems } from "@/lib/calendar/day-items";
+import { loadCompletedActivities } from "@/lib/activities/completed-activities";
 import { getSessionDisplayName } from "@/lib/training/session";
 import type { SessionLifecycleState } from "@/lib/training/semantics";
 
@@ -51,64 +52,6 @@ type CalendarActivityRow = {
 
 const weekdayFormatter = new Intl.DateTimeFormat("en-US", { weekday: "short", timeZone: "UTC" });
 const dayFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", timeZone: "UTC" });
-
-function isMissingActivityColumnError(error: { code?: string; message?: string } | null) {
-  if (!error) return false;
-  return error.code === "42703" || /(schedule_status|is_unplanned|schema cache|column .* does not exist|42703)/i.test(error.message ?? "");
-}
-
-async function loadCalendarActivities(params: {
-  supabase: Awaited<ReturnType<typeof createClient>>;
-  userId: string;
-  weekStart: string;
-  weekEnd: string;
-}): Promise<CalendarActivityRow[]> {
-  const { supabase, userId, weekStart, weekEnd } = params;
-  const rangeStart = `${addDays(weekStart, -1)}T00:00:00.000Z`;
-  const rangeEnd = `${addDays(weekEnd, 1)}T00:00:00.000Z`;
-
-  const selectVariants = [
-    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned",
-    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned,notes",
-    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,is_unplanned,notes",
-    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,notes",
-    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,notes",
-    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power"
-  ] as const;
-
-  let lastError: { code?: string; message?: string } | null = null;
-
-  for (const selectClause of selectVariants) {
-    const query = await supabase
-      .from("completed_activities")
-      .select(selectClause)
-      .eq("user_id", userId)
-      .gte("start_time_utc", rangeStart)
-      .lt("start_time_utc", rangeEnd);
-
-    if (!query.error) {
-      return ((query.data ?? []) as unknown as Array<Record<string, unknown>>).map((activity) => ({
-        id: String(activity.id),
-        upload_id: typeof activity.upload_id === "string" ? activity.upload_id : null,
-        sport_type: String(activity.sport_type),
-        start_time_utc: String(activity.start_time_utc),
-        duration_sec: typeof activity.duration_sec === "number" ? activity.duration_sec : null,
-        distance_m: typeof activity.distance_m === "number" ? activity.distance_m : null,
-        avg_hr: typeof activity.avg_hr === "number" ? activity.avg_hr : null,
-        avg_power: typeof activity.avg_power === "number" ? activity.avg_power : null,
-        schedule_status: typeof activity.schedule_status === "string" ? activity.schedule_status : "unscheduled",
-        is_unplanned: typeof activity.is_unplanned === "boolean" ? activity.is_unplanned : false
-      }));
-    }
-
-    lastError = query.error;
-    if (!isMissingActivityColumnError(query.error)) {
-      break;
-    }
-  }
-
-  throw new Error(lastError?.message ?? "Failed to load uploaded activities for calendar.");
-}
 
 async function loadUploadStatuses(params: {
   supabase: Awaited<ReturnType<typeof createClient>>;
@@ -239,11 +182,11 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
     throw new Error(sessionError.message ?? "Failed to load calendar sessions.");
   }
 
-  const activitiesData = await loadCalendarActivities({
+  const activitiesData = await loadCompletedActivities({
     supabase,
     userId: user.id,
-    weekStart,
-    weekEnd
+    rangeStart: `${addDays(weekStart, -1)}T00:00:00.000Z`,
+    rangeEnd: `${addDays(weekEnd, 1)}T00:00:00.000Z`
   });
   const uploadStatusById = await loadUploadStatuses({
     supabase,
@@ -283,8 +226,10 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
   });
 
   const plannedSessions = sessions.filter((item) => item.displayType === "planned_session");
+  const completedActivityItems = sessions.filter((item) => item.displayType === "completed_activity");
   const unmatchedUploadCount = sessions.filter((item) => item.displayType === "completed_activity" && !item.isUnplanned).length;
-  const extraActivityCount = sessions.filter((item) => item.displayType === "completed_activity" && item.isUnplanned).length;
+  const extraActivities = sessions.filter((item) => item.displayType === "completed_activity" && item.isUnplanned);
+  const extraActivityCount = extraActivities.length;
   const plannedSessionCount = plannedSessions.length;
 
   const countMetrics = computeWeekSessionCounts(
@@ -295,6 +240,12 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       durationMinutes: session.duration,
       status: session.status,
       isKey: session.is_key
+    })),
+    completedActivityItems.map((activity) => ({
+      id: activity.id,
+      date: activity.date,
+      sport: activity.sport,
+      durationMinutes: activity.duration
     }))
   );
   const minuteMetrics = computeWeekMinuteTotals(
@@ -305,6 +256,12 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       durationMinutes: session.duration,
       status: session.status,
       isKey: session.is_key
+    })),
+    completedActivityItems.map((activity) => ({
+      id: activity.id,
+      date: activity.date,
+      sport: activity.sport,
+      durationMinutes: activity.duration
     }))
   );
   const todayIso = new Date().toISOString().slice(0, 10);

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -402,7 +402,7 @@ export function WeekCalendar({
             <option value="all">All statuses</option><option value="planned">Planned</option><option value="completed">Completed</option><option value="skipped">Skipped</option><option value="moved">Moved</option><option value="extra">Extra</option>
           </select>
           <button onClick={() => setQuickAddDate(weekDays[0]?.iso)} className="btn-primary px-2 py-1 text-xs">Add session</button>
-          <span className="rounded-full border border-[hsl(var(--border)/0.8)] bg-[hsl(var(--surface-subtle)/0.45)] px-2 py-0.5 text-[11px] text-muted">{completedCount} completed · {plannedRemainingCount} remaining · {skippedCount} skipped · {extraSessionCount} extra</span>
+          <span className="rounded-full border border-[hsl(var(--border)/0.8)] bg-[hsl(var(--surface-subtle)/0.45)] px-2 py-0.5 text-[11px] text-muted">{completedCount} done · {plannedRemainingCount} remaining · {skippedCount} skipped · {extraSessionCount} extra</span>
         </div>
       </header>
 

--- a/app/(protected)/dashboard/page.test.tsx
+++ b/app/(protected)/dashboard/page.test.tsx
@@ -1,0 +1,190 @@
+import { render, screen } from "@testing-library/react";
+import { createServerClient } from "@supabase/ssr";
+import DashboardPage from "./page";
+
+jest.mock("@supabase/ssr", () => ({
+  createServerClient: jest.fn()
+}));
+
+jest.mock("next/headers", () => ({
+  cookies: jest.fn(async () => ({
+    getAll: () => [],
+    set: jest.fn()
+  }))
+}));
+
+type QueryResult = {
+  data: unknown;
+  error?: { code?: string; message?: string } | null;
+};
+
+type QueryResponse = { data: unknown; error: { code?: string; message?: string } | null };
+
+type QueryBuilder = {
+  eq: (column: string, value: unknown) => QueryBuilder;
+  gte: (column: string, value: unknown) => QueryBuilder;
+  lt: (column: string, value: unknown) => QueryBuilder;
+  order: (column: string, options?: { ascending?: boolean }) => QueryBuilder;
+  maybeSingle: () => Promise<QueryResponse>;
+  then: Promise<QueryResponse>["then"];
+  catch: Promise<QueryResponse>["catch"];
+  finally: Promise<QueryResponse>["finally"];
+};
+
+function createQueryBuilder(result: QueryResult) {
+  const resolvedResult: QueryResponse = { data: result.data, error: result.error ?? null };
+  const resolvedPromise = Promise.resolve(resolvedResult);
+  let builder: QueryBuilder;
+
+  builder = {
+    eq: jest.fn(() => builder),
+    gte: jest.fn(() => builder),
+    lt: jest.fn(() => builder),
+    order: jest.fn(() => builder),
+    maybeSingle: jest.fn(async () => ({
+      data: Array.isArray(result.data) ? result.data[0] ?? null : result.data,
+      error: result.error ?? null
+    })),
+    then: resolvedPromise.then.bind(resolvedPromise),
+    catch: resolvedPromise.catch.bind(resolvedPromise),
+    finally: resolvedPromise.finally.bind(resolvedPromise)
+  };
+
+  return builder;
+}
+
+function createSupabaseMock(params: { sessions: unknown[]; links?: unknown[] }) {
+  const { sessions, links = [] } = params;
+
+  return {
+    auth: {
+      getUser: jest.fn().mockResolvedValue({
+        data: {
+          user: {
+            id: "user-1",
+            user_metadata: { timezone: "UTC" }
+          }
+        }
+      })
+    },
+    from: jest.fn((table: string) => ({
+      select: jest.fn((_selectClause: string) => {
+        const resultByTable: Record<string, QueryResult> = {
+          profiles: {
+            data: {
+              active_plan_id: "plan-1",
+              race_date: null,
+              race_name: null
+            }
+          },
+          training_plans: {
+            data: [{ id: "plan-1" }]
+          },
+          completed_sessions: {
+            data: []
+          },
+          completed_activities: {
+            data: [
+              {
+                id: "a-extra",
+                upload_id: "upload-1",
+                sport_type: "bike",
+                start_time_utc: "2026-03-13T18:26:04.000Z",
+                duration_sec: 1826,
+                distance_m: 15000,
+                avg_hr: 135,
+                avg_power: 185,
+                schedule_status: "unscheduled"
+              }
+            ]
+          },
+          session_activity_links: {
+            data: links
+          },
+          sessions: {
+            data: sessions
+          }
+        };
+
+        const result = resultByTable[table];
+        if (!result) {
+          throw new Error(`Unexpected table in dashboard test: ${table}`);
+        }
+
+        return createQueryBuilder(result);
+      })
+    }))
+  };
+}
+
+describe("DashboardPage", () => {
+  const mockedCreateServerClient = createServerClient as unknown as jest.Mock;
+
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date("2026-03-13T12:00:00.000Z"));
+    process.env.NEXT_PUBLIC_SUPABASE_URL = "https://example.supabase.co";
+    process.env.NEXT_PUBLIC_SUPABASE_PUBLISHABLE_DEFAULT_KEY = "test-key";
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+    jest.resetAllMocks();
+  });
+
+  it("shows an extra workout in the Today card while planned work remains", async () => {
+    mockedCreateServerClient.mockReturnValue(
+      createSupabaseMock({
+        sessions: [
+          {
+            id: "s-today",
+            plan_id: "plan-1",
+            date: "2026-03-13",
+            sport: "run",
+            type: "Easy",
+            duration_minutes: 45,
+            notes: null,
+            created_at: "2026-03-10T08:00:00.000Z",
+            status: "planned"
+          }
+        ],
+        links: [
+          {
+            completed_activity_id: "a-extra",
+            planned_session_id: null,
+            confirmation_status: null
+          }
+        ]
+      })
+    );
+
+    render(await DashboardPage({ searchParams: { weekStart: "2026-03-09" } }));
+
+    expect(screen.getByRole("heading", { name: "Today" })).toBeInTheDocument();
+    expect(screen.getByText("1 remaining · 1 completed")).toBeInTheDocument();
+    expect(screen.getByText("Completed today")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Bike extra workout/i })).toHaveAttribute("href", "/sessions/activity/a-extra");
+    expect(screen.getByText("30 min • Done")).toBeInTheDocument();
+  });
+
+  it("shows extra workouts in the completed-only Today card when no planned work remains", async () => {
+    mockedCreateServerClient.mockReturnValue(
+      createSupabaseMock({
+        sessions: [],
+        links: [
+          {
+            completed_activity_id: "a-extra",
+            planned_session_id: null,
+            confirmation_status: null
+          }
+        ]
+      })
+    );
+
+    render(await DashboardPage({ searchParams: { weekStart: "2026-03-09" } }));
+
+    expect(screen.getByText("0 remaining · 1 completed")).toBeInTheDocument();
+    expect(screen.getByText("0h 30m done")).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Review completed sessions/i })).toHaveAttribute("href", "/sessions/activity/a-extra");
+    expect(screen.getByRole("link", { name: /Bike extra workout/i })).toHaveAttribute("href", "/sessions/activity/a-extra");
+  });
+});

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1,5 +1,11 @@
 import Link from "next/link";
 import { createClient } from "@/lib/supabase/server";
+import {
+  buildExtraCompletedActivities,
+  hasConfirmedPlannedSessionLink,
+  loadCompletedActivities,
+  localIsoDate
+} from "@/lib/activities/completed-activities";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { getSessionDisplayName } from "@/lib/training/session";
 import { computeWeekMinuteTotals } from "@/lib/training/week-metrics";
@@ -33,11 +39,15 @@ type CompletedSession = {
 
 type CompletedActivity = {
   id: string;
+  upload_id: string | null;
   sport_type: string;
   start_time_utc: string;
-  duration_sec: number;
+  duration_sec: number | null;
+  distance_m: number | null;
+  avg_hr: number | null;
+  avg_power: number | null;
   schedule_status: "scheduled" | "unscheduled";
-  is_unplanned: boolean | null;
+  is_unplanned: boolean;
 };
 
 type Profile = {
@@ -323,18 +333,24 @@ export default async function DashboardPage({
   const currentWeekStart = getMonday().toISOString().slice(0, 10);
   const weekStart = requestedWeekStart && /^\d{4}-\d{2}-\d{2}$/.test(requestedWeekStart) ? requestedWeekStart : currentWeekStart;
   const weekEnd = addDays(weekStart, 7);
-  const todayIso = new Date().toISOString().slice(0, 10);
+  const timeZone =
+    (user.user_metadata && typeof user.user_metadata.timezone === "string" && user.user_metadata.timezone) ||
+    Intl.DateTimeFormat().resolvedOptions().timeZone ||
+    "UTC";
+  const todayIso = localIsoDate(new Date().toISOString(), timeZone);
+  const activityRangeStart = `${addDays(weekStart, -1)}T00:00:00.000Z`;
+  const activityRangeEnd = `${addDays(weekEnd, 1)}T00:00:00.000Z`;
 
-  const [{ data: profileData }, { data: plansData }, { data: completedData }, { data: completedActivities }, { data: linksData }] = await Promise.all([
+  const [{ data: profileData }, { data: plansData }, { data: completedData }, completedActivities, { data: linksData }] = await Promise.all([
     supabase.from("profiles").select("active_plan_id,race_date,race_name").eq("id", user.id).maybeSingle(),
     supabase.from("training_plans").select("id").order("start_date", { ascending: false }),
     supabase.from("completed_sessions").select("date,sport").gte("date", weekStart).lt("date", weekEnd),
-    supabase
-      .from("completed_activities")
-      .select("id,sport_type,start_time_utc,duration_sec,schedule_status,is_unplanned")
-      .eq("user_id", user.id)
-      .gte("start_time_utc", `${weekStart}T00:00:00.000Z`)
-      .lt("start_time_utc", `${weekEnd}T00:00:00.000Z`),
+    loadCompletedActivities({
+      supabase,
+      userId: user.id,
+      rangeStart: activityRangeStart,
+      rangeEnd: activityRangeEnd
+    }),
     supabase.from("session_activity_links").select("completed_activity_id,planned_session_id,confirmation_status").eq("user_id", user.id)
   ]);
 
@@ -381,9 +397,9 @@ export default async function DashboardPage({
     return acc;
   }, {});
 
-  const uploadedActivities = (completedActivities ?? []) as CompletedActivity[];
+  const uploadedActivities = completedActivities;
   const links = (linksData ?? []) as Array<{ completed_activity_id: string; planned_session_id?: string | null; confirmation_status?: "suggested" | "confirmed" | "rejected" | null }>;
-  const confirmedLinks = links.filter((item) => item.confirmation_status === "confirmed" || !item.confirmation_status);
+  const confirmedLinks = links.filter(hasConfirmedPlannedSessionLink);
   const linkedSessionIds = new Set(confirmedLinks.map((item) => item.planned_session_id).filter((value): value is string => Boolean(value)));
 
   const durationByActivityId = new Map(uploadedActivities.map((activity) => [activity.id, Math.round((activity.duration_sec ?? 0) / 60)]));
@@ -391,6 +407,21 @@ export default async function DashboardPage({
     if (!link.planned_session_id) return acc;
     const minutes = durationByActivityId.get(link.completed_activity_id) ?? 0;
     acc.set(link.planned_session_id, (acc.get(link.planned_session_id) ?? 0) + minutes);
+    return acc;
+  }, new Map());
+  const extraActivities = buildExtraCompletedActivities({
+    activities: uploadedActivities,
+    links,
+    timeZone,
+    weekStart,
+    weekEndExclusive: weekEnd
+  });
+  const extraMinutesByDay = extraActivities.reduce<Map<string, number>>((acc, activity) => {
+    acc.set(activity.date, (acc.get(activity.date) ?? 0) + activity.durationMinutes);
+    return acc;
+  }, new Map());
+  const extraMinutesBySport = extraActivities.reduce<Map<string, number>>((acc, activity) => {
+    acc.set(activity.sport, (acc.get(activity.sport) ?? 0) + activity.durationMinutes);
     return acc;
   }, new Map());
 
@@ -414,8 +445,13 @@ export default async function DashboardPage({
   const todaySessions = sessions.filter((session) => session.date === todayIso);
   const pendingTodaySessions = todaySessions.filter((session) => session.status === "planned");
   const completedTodaySessions = todaySessions.filter((session) => session.status === "completed");
+  const extraTodayActivities = extraActivities.filter((activity) => activity.date === todayIso);
   const nextPendingTodaySession = pendingTodaySessions[0] ?? null;
-  const todayCompletedMinutes = completedTodaySessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
+  const todayCompletedMinutes =
+    completedTodaySessions.reduce((sum, session) => sum + getCompletedMinutes(session), 0) +
+    extraTodayActivities.reduce((sum, activity) => sum + activity.durationMinutes, 0);
+  const plannedCompletedSessionsCount = sessions.filter((session) => session.status === "completed").length;
+  const extraCompletedCount = extraActivities.length;
 
   const weekMetricSessions = sessions.map((session) => ({
     id: session.id,
@@ -426,9 +462,17 @@ export default async function DashboardPage({
     isKey: session.is_key
   }));
 
-  const minuteMetrics = computeWeekMinuteTotals(weekMetricSessions);
+  const minuteMetrics = computeWeekMinuteTotals(
+    weekMetricSessions,
+    extraActivities.map((activity) => ({
+      id: activity.id,
+      date: activity.date,
+      sport: activity.sport,
+      durationMinutes: activity.durationMinutes
+    }))
+  );
   const totals = { planned: minuteMetrics.plannedMinutes, completed: minuteMetrics.completedMinutes };
-  const completedSessionsCount = sessions.filter((session) => session.status === "completed").length;
+  const completedSessionsCount = plannedCompletedSessionsCount + extraCompletedCount;
   const missedSessions = sessions.filter((session) => session.status === "planned" && session.date < todayIso);
   const missedSessionsCount = missedSessions.length;
   const missedMinutes = missedSessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
@@ -445,8 +489,11 @@ export default async function DashboardPage({
     const daySessions = sessions.filter((session) => session.date === iso);
     const plannedCount = daySessions.filter((session) => session.status === "planned").length;
     const plannedMinutes = daySessions.reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-    const remainingMinutesOnDay = daySessions.filter((session) => session.status === "planned").reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
-    const completedMinutesOnDay = daySessions.filter((session) => session.status === "completed").reduce((sum, session) => sum + getCompletedMinutes(session), 0);
+    const extraMinutesOnDay = extraMinutesByDay.get(iso) ?? 0;
+    const completedMinutesOnDay =
+      daySessions.filter((session) => session.status === "completed").reduce((sum, session) => sum + getCompletedMinutes(session), 0) +
+      extraMinutesOnDay;
+    const remainingMinutesOnDay = Math.max(plannedMinutes - completedMinutesOnDay, 0);
     const trainingMeaning = getDayMeaningLabel(daySessions);
 
     const label = new Intl.DateTimeFormat("en-US", { weekday: "short", timeZone: "UTC" }).format(new Date(`${iso}T00:00:00.000Z`));
@@ -456,24 +503,24 @@ export default async function DashboardPage({
     let microLabel = "Rest";
 
     if (iso === todayIso) {
-      if (plannedCount > 0) {
+      if (plannedCount > 0 && remainingMinutesOnDay > 0) {
         tone = "today-remaining";
         stateLabel = "Today";
-        microLabel = `${remainingMinutesOnDay}m left`;
-      } else if (daySessions.length > 0) {
+        microLabel = completedMinutesOnDay > 0 ? `${completedMinutesOnDay}m done · ${remainingMinutesOnDay}m left` : `${remainingMinutesOnDay}m left`;
+      } else if (completedMinutesOnDay > 0) {
         tone = "today-complete";
         stateLabel = "Completed";
         microLabel = `${completedMinutesOnDay}m done`;
       }
     } else if (iso < todayIso) {
-      if (plannedCount > 0) {
+      if (plannedCount > 0 && remainingMinutesOnDay > 0) {
         tone = "missed";
-        stateLabel = "Missed";
-        microLabel = `${remainingMinutesOnDay || plannedMinutes}m missed`;
-      } else if (daySessions.length > 0) {
+        stateLabel = completedMinutesOnDay > 0 ? "Mixed" : "Missed";
+        microLabel = completedMinutesOnDay > 0 ? `${completedMinutesOnDay}m done · ${remainingMinutesOnDay || plannedMinutes}m missed` : `${remainingMinutesOnDay || plannedMinutes}m missed`;
+      } else if (completedMinutesOnDay > 0) {
         tone = "completed";
         stateLabel = "Completed";
-        microLabel = `${completedMinutesOnDay || plannedMinutes}m done`;
+        microLabel = `${completedMinutesOnDay}m done`;
       }
     } else if (plannedCount > 0) {
       tone = "upcoming";
@@ -496,7 +543,7 @@ export default async function DashboardPage({
       const planned = sessions.filter((session) => session.sport === sport).reduce((sum, session) => sum + (session.duration_minutes ?? 0), 0);
       const completed = sessions
         .filter((session) => session.sport === sport)
-        .reduce((sum, session) => sum + getCompletedMinutes(session), 0);
+        .reduce((sum, session) => sum + getCompletedMinutes(session), 0) + (extraMinutesBySport.get(sport) ?? 0);
       return { sport, label: getDisciplineMeta(sport).label, gap: Math.max(planned - completed, 0), planned, completed };
     })
     .sort((a, b) => b.gap - a.gap)[0];
@@ -604,7 +651,10 @@ export default async function DashboardPage({
             <div>
               <p className="text-5xl font-semibold leading-none">{completionPct}%</p>
               <p className="mt-2 text-base font-medium">{toHoursAndMinutes(totals.completed)} / {toHoursAndMinutes(totals.planned)}</p>
-              <p className="mt-1 text-sm text-muted">{completedSessionsCount} / {sessions.length} sessions completed</p>
+              <p className="mt-1 text-sm text-muted">
+                {completedSessionsCount} completed this week
+                {extraCompletedCount > 0 ? ` · ${plannedCompletedSessionsCount}/${sessions.length} planned landed · ${extraCompletedCount} extra` : ` · ${plannedCompletedSessionsCount}/${sessions.length} planned landed`}
+              </p>
             </div>
             <span className={`inline-flex rounded-full border px-3 py-1 text-xs font-semibold ${resolvedStatusChip.className}`}>{resolvedStatusChip.label}</span>
           </div>
@@ -646,7 +696,7 @@ export default async function DashboardPage({
           {pendingTodaySessions.length > 0 ? (
             <>
               <h2 className="text-xl font-semibold">Today</h2>
-              <p className="mt-1 text-sm text-muted">{pendingTodaySessions.length} remaining{` · ${completedTodaySessions.length} completed`}</p>
+              <p className="mt-1 text-sm text-muted">{pendingTodaySessions.length} remaining{` · ${completedTodaySessions.length + extraTodayActivities.length} completed`}</p>
               {todayCue ? <p className="mt-2 text-xs text-muted">Cue: {todayCue}</p> : null}
 
               <div className="mt-4 space-y-3">
@@ -662,15 +712,21 @@ export default async function DashboardPage({
                   </div>
                 </div>
 
-                {completedTodaySessions.length > 0 ? (
+                {completedTodaySessions.length > 0 || extraTodayActivities.length > 0 ? (
                   <div>
                     <p className="mb-2 text-[11px] uppercase tracking-[0.12em] text-[hsl(var(--fg-muted))]">Completed today</p>
                     <div className="space-y-2">
                       {completedTodaySessions.map((session) => (
                         <div key={session.id} className="rounded-lg border border-[hsl(var(--success)/0.35)] bg-[hsl(var(--success)/0.08)] px-3 py-2">
                           <p className="text-sm font-medium">{getSessionDisplayName(session)}</p>
-                          <p className="text-xs text-muted">{session.duration_minutes} min • Done</p>
+                          <p className="text-xs text-muted">{getCompletedMinutes(session)} min • Done</p>
                         </div>
+                      ))}
+                      {extraTodayActivities.map((activity) => (
+                        <Link key={activity.id} href={`/sessions/activity/${activity.id}`} className="block rounded-lg border border-[hsl(var(--success)/0.35)] bg-[hsl(var(--success)/0.08)] px-3 py-2 transition hover:border-[hsl(var(--success)/0.5)]">
+                          <p className="text-sm font-medium">{getDisciplineMeta(activity.sport).label} extra workout</p>
+                          <p className="text-xs text-muted">{activity.durationMinutes} min • Done</p>
+                        </Link>
                       ))}
                     </div>
                   </div>
@@ -682,22 +738,39 @@ export default async function DashboardPage({
                 <Link href="/calendar" className="btn-secondary px-3 py-1.5 text-xs">View plan</Link>
               </div>
             </>
-          ) : completedTodaySessions.length > 0 ? (
+          ) : completedTodaySessions.length > 0 || extraTodayActivities.length > 0 ? (
             <>
               <h2 className="text-xl font-semibold">Today</h2>
-              <p className="mt-1 text-sm text-muted">0 remaining · {completedTodaySessions.length} completed</p>
+              <p className="mt-1 text-sm text-muted">0 remaining · {completedTodaySessions.length + extraTodayActivities.length} completed</p>
               <h3 className="mt-2 text-lg font-semibold">{toHoursAndMinutes(todayCompletedMinutes)} done</h3>
               <p className="mt-2 text-sm text-muted">All scheduled sessions for today are complete. You are {resolvedStatusChip.label === "On track" ? "on track" : "still within reach"} this week.</p>
               <div className="mt-4 space-y-2">
                 {completedTodaySessions.map((session) => (
                   <div key={session.id} className="rounded-lg border border-[hsl(var(--success)/0.35)] bg-[hsl(var(--success)/0.08)] px-3 py-2">
                     <p className="text-sm font-medium">{getSessionDisplayName(session)}</p>
-                    <p className="text-xs text-muted">{session.duration_minutes} min • Done</p>
+                    <p className="text-xs text-muted">{getCompletedMinutes(session)} min • Done</p>
                   </div>
+                ))}
+                {extraTodayActivities.map((activity) => (
+                  <Link key={activity.id} href={`/sessions/activity/${activity.id}`} className="block rounded-lg border border-[hsl(var(--success)/0.35)] bg-[hsl(var(--success)/0.08)] px-3 py-2 transition hover:border-[hsl(var(--success)/0.5)]">
+                    <p className="text-sm font-medium">{getDisciplineMeta(activity.sport).label} extra workout</p>
+                    <p className="text-xs text-muted">{activity.durationMinutes} min • Done</p>
+                  </Link>
                 ))}
               </div>
               <div className="mt-4 flex flex-wrap gap-2">
-                <Link href={completedTodaySessions[0] ? `/sessions/${completedTodaySessions[0].id}` : "/calendar"} className="btn-primary px-3 py-1.5 text-xs">Review completed sessions</Link>
+                <Link
+                  href={
+                    completedTodaySessions[0]
+                      ? `/sessions/${completedTodaySessions[0].id}`
+                      : extraTodayActivities[0]
+                        ? `/sessions/activity/${extraTodayActivities[0].id}`
+                        : "/calendar"
+                  }
+                  className="btn-primary px-3 py-1.5 text-xs"
+                >
+                  Review completed sessions
+                </Link>
                 <Link href="/plan" className="btn-secondary px-3 py-1.5 text-xs">Open plan</Link>
               </div>
             </>

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { isMissingCompletedActivityColumnError } from "@/lib/activities/completed-activities";
 import { createClient } from "@/lib/supabase/server";
 import { createReviewViewModel, durationLabel, toneToBadgeClass, toneToTextClass, type SessionReviewRow } from "@/lib/session-review";
 import { getSessionDisplayName } from "@/lib/training/session";
@@ -74,12 +75,6 @@ function toSessionRow(row: SessionRow | SessionsMinimalRow): SessionRow {
 
 const reviewDateFormatter = new Intl.DateTimeFormat("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" });
 
-function isMissingActivityColumnError(error: { code?: string; message?: string } | null) {
-  if (!error) return false;
-  if (error.code === "42703") return true;
-  return /(schema cache|column .* does not exist|42703)/i.test(error.message ?? "");
-}
-
 async function loadActivityReviewRow(params: {
   supabase: Awaited<ReturnType<typeof createClient>>;
   userId: string;
@@ -121,7 +116,7 @@ async function loadActivityReviewRow(params: {
     if (data && !error) {
       return data as ActivityReviewRow;
     }
-    if (error && !isMissingActivityColumnError(error)) {
+    if (error && !isMissingCompletedActivityColumnError(error)) {
       break;
     }
   }
@@ -156,6 +151,7 @@ export default async function SessionReviewPage({ params }: { params: { sessionI
       target: null,
       duration_minutes: activity.duration_sec ? Math.round(activity.duration_sec / 60) : null,
       status: "completed",
+      is_extra: true,
       execution_result: buildExecutionResultForSession(
         {
           id: params.sessionId,
@@ -359,6 +355,7 @@ export default async function SessionReviewPage({ params }: { params: { sessionI
   const disciplineLabel = getDisciplineMeta(session.sport).label;
   const sessionDateLabel = reviewDateFormatter.format(new Date(`${session.date}T00:00:00.000Z`));
   const hasSpecificPlannedIntent = reviewVm.plannedIntent.trim().toLowerCase() !== `${disciplineLabel.toLowerCase()} session intent`;
+  const plannedColumnLabel = session.is_extra ? "Weekly context" : "Planned";
 
   return (
     <section className="space-y-4">
@@ -432,7 +429,7 @@ export default async function SessionReviewPage({ params }: { params: { sessionI
             <div className="space-y-5">
               {hasSpecificPlannedIntent ? (
                 <div>
-                  <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Planned</p>
+                  <p className="text-xs uppercase tracking-[0.14em] text-tertiary">{plannedColumnLabel}</p>
                   <p className="mt-2 text-sm">{reviewVm.plannedIntent}</p>
                 </div>
               ) : null}

--- a/app/(protected)/sessions/activity/[activityId]/page.tsx
+++ b/app/(protected)/sessions/activity/[activityId]/page.tsx
@@ -1,5 +1,6 @@
 import Link from "next/link";
 import { notFound, redirect } from "next/navigation";
+import { isMissingCompletedActivityColumnError } from "@/lib/activities/completed-activities";
 import { createClient } from "@/lib/supabase/server";
 import { createReviewViewModel, durationLabel, toneToBadgeClass, toneToTextClass, type SessionReviewRow } from "@/lib/session-review";
 import { getSessionDisplayName } from "@/lib/training/session";
@@ -20,12 +21,6 @@ type ActivityReviewRow = {
   parse_summary?: Record<string, unknown> | null;
   metrics_v2?: Record<string, unknown> | null;
 };
-
-function isMissingActivityColumnError(error: { code?: string; message?: string } | null) {
-  if (!error) return false;
-  if (error.code === "42703") return true;
-  return /(schema cache|column .* does not exist|42703)/i.test(error.message ?? "");
-}
 
 async function loadActivityReviewRow(params: {
   supabase: Awaited<ReturnType<typeof createClient>>;
@@ -68,7 +63,7 @@ async function loadActivityReviewRow(params: {
     if (data && !error) {
       return data as ActivityReviewRow;
     }
-    if (error && !isMissingActivityColumnError(error)) {
+    if (error && !isMissingCompletedActivityColumnError(error)) {
       break;
     }
   }
@@ -140,6 +135,7 @@ export default async function ActivitySessionReviewPage({ params }: { params: { 
   const sessionDateLabel = reviewDateFormatter.format(new Date(`${session.date}T00:00:00.000Z`));
   const comparisonHeading = reviewVm.isReviewable ? "Session impact" : "Review unlock";
   const leftColumnLabel = "Weekly context";
+  const outcomeLabel = session.is_extra ? "Week effect" : reviewVm.isReviewable ? "Intent result" : "Session status";
 
   return (
     <section className="space-y-4">
@@ -178,7 +174,7 @@ export default async function ActivitySessionReviewPage({ params }: { params: { 
               <p className="mt-1 text-sm text-muted">{sessionDateLabel}</p>
             </div>
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-[11px] uppercase tracking-[0.14em] text-tertiary">{reviewVm.isReviewable ? "Intent result" : "Session status"}</p>
+              <p className="text-[11px] uppercase tracking-[0.14em] text-tertiary">{outcomeLabel}</p>
               <p className={`mt-2 text-base font-semibold ${toneToTextClass(reviewVm.intent.tone)}`}>{reviewVm.intent.label}</p>
               <p className="mt-1 text-sm text-muted">{reviewVm.intent.detail}</p>
             </div>

--- a/lib/activities/completed-activities.ts
+++ b/lib/activities/completed-activities.ts
@@ -1,0 +1,125 @@
+import { createClient } from "@/lib/supabase/server";
+
+export type SessionActivityLinkRecord = {
+  planned_session_id?: string | null;
+  completed_activity_id: string;
+  confirmation_status?: "suggested" | "confirmed" | "rejected" | null;
+};
+
+export type CompletedActivityRecord = {
+  id: string;
+  upload_id: string | null;
+  sport_type: string;
+  start_time_utc: string;
+  duration_sec: number | null;
+  distance_m: number | null;
+  avg_hr: number | null;
+  avg_power: number | null;
+  schedule_status: "scheduled" | "unscheduled";
+  is_unplanned: boolean;
+};
+
+export type ExtraCompletedActivity = {
+  id: string;
+  sport: string;
+  date: string;
+  durationMinutes: number;
+};
+
+export function localIsoDate(utcIso: string, timeZone: string) {
+  return new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit"
+  }).format(new Date(utcIso));
+}
+
+export function isMissingCompletedActivityColumnError(error: { code?: string; message?: string } | null) {
+  if (!error) return false;
+  return error.code === "42703" || /(schedule_status|is_unplanned|schema cache|column .* does not exist|42703)/i.test(error.message ?? "");
+}
+
+export function hasConfirmedPlannedSessionLink(link: {
+  planned_session_id?: string | null;
+  confirmation_status?: "suggested" | "confirmed" | "rejected" | null;
+}) {
+  return Boolean(link.planned_session_id) && (
+    link.confirmation_status === "confirmed" ||
+    link.confirmation_status === null ||
+    typeof link.confirmation_status === "undefined"
+  );
+}
+
+export function buildExtraCompletedActivities(params: {
+  activities: Array<Pick<CompletedActivityRecord, "id" | "sport_type" | "start_time_utc" | "duration_sec">>;
+  links: Array<Pick<SessionActivityLinkRecord, "completed_activity_id" | "planned_session_id" | "confirmation_status">>;
+  timeZone: string;
+  weekStart: string;
+  weekEndExclusive: string;
+}) {
+  const { activities, links, timeZone, weekStart, weekEndExclusive } = params;
+  const confirmedLinkedActivityIds = new Set(
+    links
+      .filter(hasConfirmedPlannedSessionLink)
+      .map((link) => link.completed_activity_id)
+  );
+
+  return activities
+    .map((activity) => ({
+      id: activity.id,
+      sport: activity.sport_type,
+      date: localIsoDate(activity.start_time_utc, timeZone),
+      durationMinutes: Math.round((activity.duration_sec ?? 0) / 60)
+    }))
+    .filter((activity) => activity.date >= weekStart && activity.date < weekEndExclusive)
+    .filter((activity) => !confirmedLinkedActivityIds.has(activity.id));
+}
+
+export async function loadCompletedActivities(params: {
+  supabase: Awaited<ReturnType<typeof createClient>>;
+  userId: string;
+  rangeStart: string;
+  rangeEnd: string;
+}): Promise<CompletedActivityRecord[]> {
+  const { supabase, userId, rangeStart, rangeEnd } = params;
+  const selectVariants = [
+    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned",
+    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status",
+    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,is_unplanned",
+    "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power"
+  ] as const;
+
+  let lastError: { code?: string; message?: string } | null = null;
+
+  for (const selectClause of selectVariants) {
+    const query = await supabase
+      .from("completed_activities")
+      .select(selectClause)
+      .eq("user_id", userId)
+      .gte("start_time_utc", rangeStart)
+      .lt("start_time_utc", rangeEnd);
+
+    if (!query.error) {
+      return ((query.data ?? []) as unknown as Array<Record<string, unknown>>).map((activity) => ({
+        id: String(activity.id),
+        upload_id: typeof activity.upload_id === "string" ? activity.upload_id : null,
+        sport_type: String(activity.sport_type),
+        start_time_utc: String(activity.start_time_utc),
+        duration_sec: typeof activity.duration_sec === "number" ? activity.duration_sec : null,
+        distance_m: typeof activity.distance_m === "number" ? activity.distance_m : null,
+        avg_hr: typeof activity.avg_hr === "number" ? activity.avg_hr : null,
+        avg_power: typeof activity.avg_power === "number" ? activity.avg_power : null,
+        schedule_status: activity.schedule_status === "scheduled" ? "scheduled" : "unscheduled",
+        is_unplanned: typeof activity.is_unplanned === "boolean" ? activity.is_unplanned : false
+      }));
+    }
+
+    lastError = query.error;
+    if (!isMissingCompletedActivityColumnError(query.error)) {
+      break;
+    }
+  }
+
+  throw new Error(lastError?.message ?? "Failed to load completed activities.");
+}

--- a/lib/calendar/day-items.ts
+++ b/lib/calendar/day-items.ts
@@ -1,5 +1,6 @@
 import type { ExecutionResultState, SessionLifecycleState, SessionRoleState } from "@/lib/training/semantics";
 import { normalizeSessionModel } from "@/lib/training/session";
+import { hasConfirmedPlannedSessionLink, localIsoDate } from "@/lib/activities/completed-activities";
 
 export type CalendarSessionRecord = {
   id: string;
@@ -89,18 +90,6 @@ function isSkipped(notes: string | null) {
   return /\[skipped\s\d{4}-\d{2}-\d{2}\]/i.test(notes ?? "");
 }
 
-function localIsoDate(utcIso: string, timeZone: string) {
-  const date = new Date(utcIso);
-  const formatter = new Intl.DateTimeFormat("en-CA", {
-    timeZone,
-    year: "numeric",
-    month: "2-digit",
-    day: "2-digit"
-  });
-  return formatter.format(date);
-}
-
-
 function dateInRange(date: string, start?: string, endExclusive?: string) {
   if (start && date < start) return false;
   if (endExclusive && date >= endExclusive) return false;
@@ -140,7 +129,7 @@ export function buildCalendarDisplayItems(input: {
   );
   const confirmedLinkedActivityIds = new Set(
     links
-      .filter((link) => link.planned_session_id && (link.confirmation_status === "confirmed" || link.confirmation_status === null || typeof link.confirmation_status === "undefined"))
+      .filter(hasConfirmedPlannedSessionLink)
       .map((link) => link.completed_activity_id)
   );
 
@@ -173,12 +162,12 @@ export function buildCalendarDisplayItems(input: {
 
   links.forEach((link) => {
     const activity = activityById.get(link.completed_activity_id);
-    const isConfirmedLink = link.confirmation_status === "confirmed" || link.confirmation_status === null || typeof link.confirmation_status === "undefined";
-    if (!activity || !link.planned_session_id || !isConfirmedLink) return;
+    const plannedSessionId = link.planned_session_id;
+    if (!activity || !plannedSessionId || !hasConfirmedPlannedSessionLink(link)) return;
     linkedActivityIds.add(activity.id);
-    const list = linkedBySession.get(link.planned_session_id) ?? [];
+    const list = linkedBySession.get(plannedSessionId) ?? [];
     list.push(activity);
-    linkedBySession.set(link.planned_session_id, list);
+    linkedBySession.set(plannedSessionId, list);
   });
 
   const unassignedByDate = new Map<string, number>();

--- a/lib/session-review.test.ts
+++ b/lib/session-review.test.ts
@@ -143,9 +143,11 @@ describe("createReviewViewModel", () => {
       }
     });
 
-    expect(vm.reviewModeLabel).toBe("Extra session review");
-    expect(vm.sessionStatusLabel).toBe("Extra workout");
-    expect(vm.plannedIntent).toBe("No planned intent. Review this as additional weekly load.");
+    expect(vm.reviewModeLabel).toBe("Post-execution review");
+    expect(vm.sessionStatusLabel).toBe("Completed");
+    expect(vm.intent.label).toBe("Supportive load");
+    expect(vm.intent.detail).toMatch(/useful training load|without obvious disruption/i);
+    expect(vm.plannedIntent).toBe("No planned target. Treat this as completed load added on top of the week.");
     expect(vm.mainGap).toMatch(/no planned target/i);
     expect(vm.unlockTitle).toBe("Weekly context");
     expect(vm.followUpIntro).toMatch(/extra session/i);

--- a/lib/session-review.ts
+++ b/lib/session-review.ts
@@ -176,19 +176,19 @@ function toReviewState(status: string | null | undefined, diagnosis: Record<stri
 function toExtraReviewState(hasDiagnosticSignals: boolean) {
   if (hasDiagnosticSignals) {
     return {
-      reviewModeLabel: "Extra session review",
-      reviewModeDetail: "This unplanned workout is reviewed against weekly context rather than a planned session target.",
-      sessionStatusLabel: "Extra workout",
-      sessionStatusDetail: "Completed unplanned session with enough execution evidence to review its impact.",
+      reviewModeLabel: "Post-execution review",
+      reviewModeDetail: "This completed workout was not planned, so the review focuses on its execution and weekly impact rather than planned vs actual.",
+      sessionStatusLabel: "Completed",
+      sessionStatusDetail: "Completed workout without a planned target, but with enough evidence to review what it added to the week.",
       isReviewable: true
     };
   }
 
   return {
-    reviewModeLabel: "Extra session review",
-    reviewModeDetail: "This unplanned workout has limited evidence, so the review stays directional.",
-    sessionStatusLabel: "Extra workout",
-    sessionStatusDetail: "Completed unplanned session without enough detail for a stronger execution review.",
+    reviewModeLabel: "Post-execution review",
+    reviewModeDetail: "This completed workout was not planned, so the review stays directional until richer evidence syncs.",
+    sessionStatusLabel: "Completed",
+    sessionStatusDetail: "Completed workout without enough detail for a stronger execution read.",
     isReviewable: false
   };
 }
@@ -238,6 +238,38 @@ function toIntent(status: unknown, isReviewable: boolean, hasLinkedActivity: boo
     label: "Partial match",
     tone: "warning" as const,
     detail: "Some of the intended stimulus landed, but key parts of the execution were off."
+  };
+}
+
+function toExtraIntent(status: unknown, isReviewable: boolean) {
+  if (!isReviewable) {
+    return {
+      label: "Directional read",
+      tone: "muted" as const,
+      detail: "This extra workout still counts, but richer interval and intensity detail would sharpen how it should change the week."
+    };
+  }
+
+  if (status === "matched_intent" || status === "matched") {
+    return {
+      label: "Supportive load",
+      tone: "success" as const,
+      detail: "The extra work looks controlled enough to add useful training load without obvious disruption."
+    };
+  }
+
+  if (status === "missed_intent" || status === "missed") {
+    return {
+      label: "Risky load",
+      tone: "risk" as const,
+      detail: "The extra work looks costly enough that the rest of the week may need more protection."
+    };
+  }
+
+  return {
+    label: "Manage load",
+    tone: "warning" as const,
+    detail: "The extra work added stimulus, but treat the next sessions conservatively until recovery is clearer."
   };
 }
 
@@ -338,7 +370,7 @@ export function createReviewViewModel(session: SessionReviewRow): ReviewViewMode
   const hasDiagnosticSignals = Boolean(diagnosis) && Object.keys(diagnosis ?? {}).length > 0;
   const isExtra = session.is_extra === true;
   const reviewState = isExtra ? toExtraReviewState(hasDiagnosticSignals) : toReviewState(session.status, diagnosis, hasLinkedActivity);
-  const intent = toIntent(diagnosis?.status, reviewState.isReviewable, hasLinkedActivity);
+  const intent = isExtra ? toExtraIntent(diagnosis?.status, reviewState.isReviewable) : toIntent(diagnosis?.status, reviewState.isReviewable, hasLinkedActivity);
   const bucket = toIntentBucket(session.intent_category, session.sport);
 
   const defaultWhyItMatters = isExtra
@@ -482,7 +514,7 @@ export function createReviewViewModel(session: SessionReviewRow): ReviewViewMode
       : null
   ].filter((metric): metric is { label: string; value: string } => metric !== null);
 
-  const plannedIntent = isExtra ? "No planned intent. Review this as additional weekly load." : session.intent_category?.trim() || `${getDisciplineMeta(session.sport).label} session intent`;
+  const plannedIntent = isExtra ? "No planned target. Treat this as completed load added on top of the week." : session.intent_category?.trim() || `${getDisciplineMeta(session.sport).label} session intent`;
   const weekAction = getString(
     v2Review?.verdict?.explanation
       ? { suggestedWeekAdjustment: v2Review.verdict.explanation.whatToDoThisWeek }

--- a/lib/training/week-metrics.test.ts
+++ b/lib/training/week-metrics.test.ts
@@ -25,6 +25,26 @@ describe("week metrics", () => {
     });
   });
 
+  it("adds extra completed work into weekly totals", () => {
+    const extras = [
+      { id: "extra-1", date: "2026-02-24", sport: "run", durationMinutes: 30 },
+      { id: "extra-2", date: "2026-02-25", sport: "bike", durationMinutes: 20 }
+    ];
+
+    expect(computeWeekSessionCounts(sessions, extras)).toEqual({
+      completedCount: 3,
+      skippedCount: 1,
+      plannedRemainingCount: 2,
+      plannedTotalCount: 4
+    });
+
+    expect(computeWeekMinuteTotals(sessions, extras)).toEqual({
+      plannedMinutes: 225,
+      completedMinutes: 95,
+      remainingMinutes: 130
+    });
+  });
+
   it("returns key sessions remaining in chronological order", () => {
     expect(getKeySessionsRemaining(sessions, "2026-02-24").map((s) => s.id)).toEqual(["2", "4"]);
   });

--- a/lib/training/week-metrics.ts
+++ b/lib/training/week-metrics.ts
@@ -11,11 +11,18 @@ export type WeekMetricSession = {
   isKey?: boolean;
 };
 
-export function computeWeekSessionCounts(sessions: WeekMetricSession[]) {
-  const completedCount = sessions.filter((s) => s.status === "completed").length;
+export type WeekExtraCompletion = {
+  id: string;
+  date: string;
+  sport: string;
+  durationMinutes: number;
+};
+
+export function computeWeekSessionCounts(sessions: WeekMetricSession[], extraCompletions: WeekExtraCompletion[] = []) {
+  const completedCount = sessions.filter((s) => s.status === "completed").length + extraCompletions.length;
   const skippedCount = sessions.filter((s) => s.status === "skipped").length;
   const plannedRemainingCount = sessions.filter((s) => s.status === "planned").length;
-  const plannedTotalCount = completedCount + skippedCount + plannedRemainingCount;
+  const plannedTotalCount = sessions.length;
 
   return {
     completedCount,
@@ -25,17 +32,19 @@ export function computeWeekSessionCounts(sessions: WeekMetricSession[]) {
   };
 }
 
-export function computeWeekMinuteTotals(sessions: WeekMetricSession[]) {
+export function computeWeekMinuteTotals(sessions: WeekMetricSession[], extraCompletions: WeekExtraCompletion[] = []) {
   const plannedMinutes = sessions.reduce((sum, session) => sum + Math.max(session.durationMinutes, 0), 0);
   const completedMinutes = sessions
     .filter((session) => session.status === "completed")
     .reduce((sum, session) => sum + Math.max(session.durationMinutes, 0), 0);
+  const extraCompletedMinutes = extraCompletions.reduce((sum, activity) => sum + Math.max(activity.durationMinutes, 0), 0);
 
-  const remainingMinutes = Math.max(plannedMinutes - completedMinutes, 0);
+  const totalCompletedMinutes = completedMinutes + extraCompletedMinutes;
+  const remainingMinutes = Math.max(plannedMinutes - totalCompletedMinutes, 0);
 
   return {
     plannedMinutes,
-    completedMinutes,
+    completedMinutes: totalCompletedMinutes,
     remainingMinutes
   };
 }


### PR DESCRIPTION
## Summary
- ensure calendar, dashboard, session, and activity pages surface unplanned/extra sessions alongside scheduled data
- extend day items, week metrics, and activity helpers plus their tests so totals and Today card include uploads

## Testing
- Not run (not requested)