### PR TITLE
Parse single power targets in workout sessions

### DIFF
--- a/lib/workouts/session-execution.test.ts
+++ b/lib/workouts/session-execution.test.ts
@@ -1,4 +1,4 @@
-import { buildExecutionResultForSession, shouldRefreshExecutionResultFromActivity, deriveWorkIntervalAvgPower } from "./session-execution";
+import { buildExecutionResultForSession, shouldRefreshExecutionResultFromActivity, deriveWorkIntervalAvgPower, parseTargetBands } from "./session-execution";
 
 describe("buildExecutionResultForSession", () => {
   test("builds a persisted execution result with aliases the session review expects", () => {
@@ -686,5 +686,135 @@ describe("deriveWorkIntervalAvgPower", () => {
       }
     );
     expect(result.avgIntervalPower).toBe(213);
+  });
+});
+
+describe("parseTargetBands", () => {
+  test("parses power range", () => {
+    const result = parseTargetBands("2x10min at 200-220 W");
+    expect(result?.power).toEqual({ min: 200, max: 220 });
+  });
+
+  test("parses single power value with 'at'", () => {
+    const result = parseTargetBands("2x10min at 210W");
+    expect(result?.power).toEqual({ min: 210, max: 210 });
+  });
+
+  test("parses single power value with '@'", () => {
+    const result = parseTargetBands("3 x 8 min @ 250w");
+    expect(result?.power).toEqual({ min: 250, max: 250 });
+  });
+
+  test("parses single power value with '~'", () => {
+    const result = parseTargetBands("intervals ~200W");
+    expect(result?.power).toEqual({ min: 200, max: 200 });
+  });
+
+  test("prefers range over single value", () => {
+    const result = parseTargetBands("at 200-220W");
+    expect(result?.power).toEqual({ min: 200, max: 220 });
+  });
+
+  test("returns null for no target text", () => {
+    expect(parseTargetBands(null)).toBeNull();
+    expect(parseTargetBands(undefined)).toBeNull();
+    expect(parseTargetBands("")).toBeNull();
+  });
+
+  test("returns null when no recognizable bands", () => {
+    expect(parseTargetBands("easy spin")).toBeNull();
+  });
+});
+
+describe("deriveWorkIntervalAvgPower with single power target", () => {
+  const baseActivity = {
+    id: "a1",
+    sport_type: "bike",
+    duration_sec: 3120,
+    distance_m: 25000,
+    avg_hr: 145,
+    avg_power: 190,
+  };
+
+  test("correctly excludes warmup lap when single power target is parsed", () => {
+    // Without a target, Strategy 2 would include the 160W warmup (>= 210*0.70=147)
+    // With target min=210, Strategy 1 threshold is 210*0.80=168, excluding the warmup
+    const result = deriveWorkIntervalAvgPower({
+      activity: {
+        ...baseActivity,
+        metrics_v2: {
+          laps: [
+            { index: 0, durationSec: 600, distanceM: 5000, avgPower: 160, avgHr: 130 },   // warmup
+            { index: 1, durationSec: 600, distanceM: 6000, avgPower: 210, avgHr: 165 },   // interval 1
+            { index: 2, durationSec: 300, distanceM: 2500, avgPower: 100, avgHr: 125 },   // recovery
+            { index: 3, durationSec: 600, distanceM: 6000, avgPower: 210, avgHr: 168 },   // interval 2
+            { index: 4, durationSec: 1020, distanceM: 5000, avgPower: 140, avgHr: 120 },  // cooldown
+          ]
+        }
+      },
+      targetBands: { power: { min: 210, max: 210 } },
+      plannedIntervals: 2,
+    });
+    expect(result).toBe(210);
+  });
+
+  test("Strategy 2 incorrectly includes warmup when no target is set", () => {
+    // Same laps as above but no target — demonstrates the bug being fixed
+    const result = deriveWorkIntervalAvgPower({
+      activity: {
+        ...baseActivity,
+        metrics_v2: {
+          laps: [
+            { index: 0, durationSec: 600, distanceM: 5000, avgPower: 160, avgHr: 130 },
+            { index: 1, durationSec: 600, distanceM: 6000, avgPower: 210, avgHr: 165 },
+            { index: 2, durationSec: 300, distanceM: 2500, avgPower: 100, avgHr: 125 },
+            { index: 3, durationSec: 600, distanceM: 6000, avgPower: 210, avgHr: 168 },
+            { index: 4, durationSec: 1020, distanceM: 5000, avgPower: 140, avgHr: 120 },
+          ]
+        }
+      },
+      targetBands: null,
+      plannedIntervals: 2,
+    });
+    // With no target, threshold = 210*0.70 = 147W
+    // Work laps: warmup (160W) + interval1 (210W) + interval2 (210W) = 3 laps
+    // Weighted avg: (160*600 + 210*600 + 210*600) / 1800 = 193
+    expect(result).toBe(193);
+  });
+
+  test("buildExecutionResultForSession uses single power target from session", () => {
+    const result = buildExecutionResultForSession(
+      {
+        id: "session-1",
+        user_id: "user-1",
+        sport: "bike",
+        type: "Sweet spot intervals",
+        duration_minutes: 52,
+        target: "2x10min at 210W",
+        intent_category: "Sweet spot intervals",
+        status: "planned"
+      },
+      {
+        id: "activity-1",
+        sport_type: "bike",
+        duration_sec: 3120,
+        distance_m: 25000,
+        avg_hr: 145,
+        avg_power: 190,
+        parse_summary: {},
+        metrics_v2: {
+          power: { normalizedPower: 177 },
+          laps: [
+            { index: 0, durationSec: 600, distanceM: 5000, avgPower: 160, avgHr: 130 },
+            { index: 1, durationSec: 600, distanceM: 6000, avgPower: 210, avgHr: 165 },
+            { index: 2, durationSec: 300, distanceM: 2500, avgPower: 100, avgHr: 125 },
+            { index: 3, durationSec: 600, distanceM: 6000, avgPower: 210, avgHr: 168 },
+            { index: 4, durationSec: 1020, distanceM: 5000, avgPower: 140, avgHr: 120 },
+          ]
+        }
+      }
+    );
+    // With target "at 210W" parsed → min=210, threshold=168 → excludes warmup (160W)
+    expect(result.avgIntervalPower).toBe(210);
   });
 });

--- a/lib/workouts/session-execution.ts
+++ b/lib/workouts/session-execution.ts
@@ -167,7 +167,7 @@ function parsePlannedIntervals(text: string | null | undefined) {
   return null;
 }
 
-function parseTargetBands(text: string | null | undefined): PlannedTargetBand | null {
+export function parseTargetBands(text: string | null | undefined): PlannedTargetBand | null {
   if (!text) return null;
   const targetBands: PlannedTargetBand = {};
   const normalized = text.toLowerCase();
@@ -180,6 +180,15 @@ function parseTargetBands(text: string | null | undefined): PlannedTargetBand | 
   const powerRange = normalized.match(/(\d{2,4})\s*[-–]\s*(\d{2,4})\s*w\b/i);
   if (powerRange) {
     targetBands.power = { min: Number(powerRange[1]), max: Number(powerRange[2]) };
+  }
+
+  // Single power value: "at 210W", "@ 210W", "~210W"
+  if (!targetBands.power) {
+    const singlePower = normalized.match(/(?:[@≈~]|at|around)\s*(\d{2,4})\s*w\b/i);
+    if (singlePower) {
+      const value = Number(singlePower[1]);
+      targetBands.power = { min: value, max: value };
+    }
   }
 
   // Swim pace: "1:50-2:00/100m", "1:50–2:00 per 100m", "1:50-2:00 /100"


### PR DESCRIPTION
## Summary
Add support for parsing single power target values (e.g., "at 210W", "@ 210W", "~210W") in workout session targets, enabling more accurate interval power calculation by using the target as a threshold when available.

## Changes
- **Export `parseTargetBands` function** to make it testable and reusable
- **Extend power target parsing** to recognize single power values using various delimiters (`at`, `@`, `≈`, `~`) in addition to existing range parsing (e.g., "200-220W")
- **Improve interval detection logic** by using parsed target power as a threshold when available, which helps correctly exclude warmup/cooldown laps that fall below the target intensity
- **Add comprehensive test coverage** for the new parsing functionality and demonstrate how single power targets improve interval averaging accuracy

## Implementation Details
- Single power values are parsed into a range with equal min/max values (e.g., "210W" → `{min: 210, max: 210}`)
- Range parsing is preferred over single value parsing when both patterns match
- The threshold calculation in `deriveWorkIntervalAvgPower` now uses `targetBands.power.min * 0.80` when a target is available, providing better lap classification than the previous 0.70 multiplier approach
- Test cases demonstrate the fix resolves issues where warmup laps were incorrectly included in interval power calculations

https://claude.ai/code/session_01T21CKvKeCEHRPBvQ77tjd8