### PR TITLE
Add reclassify affordance for extras intent override

### DIFF
--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
@@ -248,7 +248,7 @@ describe("ExtrasVerdictCard", () => {
 
     fireEvent.click(screen.getByText("Reclassify"));
 
-    // Universal options should be visible
+    // Run+bike options should be visible for a run sport
     expect(screen.getByText("Recovery")).toBeInTheDocument();
     expect(screen.getByText("Easy endurance")).toBeInTheDocument();
     expect(screen.getByText("Threshold / intervals")).toBeInTheDocument();

--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
@@ -2,6 +2,10 @@ import { render, screen, fireEvent } from "@testing-library/react";
 import { ExtrasVerdictCard } from "./extras-verdict-card";
 import type { CoachVerdict } from "@/lib/execution-review-types";
 
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}));
+
 function makeVerdict(overrides: Partial<CoachVerdict> = {}): CoachVerdict {
   return {
     sessionVerdict: {
@@ -203,5 +207,77 @@ describe("ExtrasVerdictCard", () => {
     expect(
       screen.queryByText(/maintain aerobic base/)
     ).not.toBeInTheDocument();
+  });
+
+  test("renders reclassify button when sessionId and sport are provided", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict()}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+        sessionId="activity-abc123"
+        sport="run"
+      />
+    );
+
+    expect(screen.getByText("Reclassify")).toBeInTheDocument();
+  });
+
+  test("does not render reclassify button when sessionId is missing", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict()}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+      />
+    );
+
+    expect(screen.queryByText("Reclassify")).not.toBeInTheDocument();
+  });
+
+  test("shows reclassify dropdown with sport-filtered options on click", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict()}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+        sessionId="activity-abc123"
+        sport="run"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Reclassify"));
+
+    // Universal options should be visible
+    expect(screen.getByText("Recovery")).toBeInTheDocument();
+    expect(screen.getByText("Easy endurance")).toBeInTheDocument();
+    expect(screen.getByText("Threshold / intervals")).toBeInTheDocument();
+
+    // Run-specific option should be visible
+    expect(screen.getByText("Long endurance run")).toBeInTheDocument();
+
+    // Bike/swim/strength-specific options should NOT be visible
+    expect(screen.queryByText("Long endurance ride")).not.toBeInTheDocument();
+    expect(screen.queryByText("Swim session")).not.toBeInTheDocument();
+    expect(screen.queryByText("Strength session")).not.toBeInTheDocument();
+  });
+
+  test("marks current intent as disabled in dropdown", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict()}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+        sessionId="activity-abc123"
+        sport="run"
+      />
+    );
+
+    fireEvent.click(screen.getByText("Reclassify"));
+
+    // The "Easy endurance" option should show "(current)" and be disabled
+    expect(screen.getByText("(current)")).toBeInTheDocument();
+    const easyEnduranceButton = screen.getByText("Easy endurance").closest("button");
+    expect(easyEnduranceButton).toBeDisabled();
   });
 });

--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from "react";
 import type { CoachVerdict } from "@/lib/execution-review-types";
+import { ReclassifyIntentSelector } from "./reclassify-intent-selector";
 
 /** Sanitize camelCase field names that may leak from stored verdict text. */
 function sanitizeText(text: string): string {
@@ -89,9 +90,13 @@ type Props = {
   verdict: CoachVerdict;
   intentCategory: string | null;
   narrativeSource: "ai" | "fallback" | "legacy_unknown";
+  /** Synthetic session ID (e.g. "activity-{uuid}") for the regenerate endpoint. */
+  sessionId?: string;
+  /** Sport type used to filter the reclassify intent options. */
+  sport?: string;
 };
 
-export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource }: Props) {
+export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, sessionId, sport }: Props) {
   const [showEvidence, setShowEvidence] = useState(false);
 
   const match = INTENT_MATCH_CONFIG[verdict.sessionVerdict.intentMatch];
@@ -121,10 +126,17 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource }: 
       <div className="divide-y divide-[hsl(var(--border))]">
         {/* Part 1: What this session was */}
         <div className="px-5 py-4">
-          <div className="flex items-center gap-2">
+          <div className="flex flex-wrap items-center gap-2">
             <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-0.5 text-[11px] font-medium text-muted">
               {intentLabel}
             </span>
+            {sessionId && sport ? (
+              <ReclassifyIntentSelector
+                sessionId={sessionId}
+                currentIntent={intentCategory}
+                sport={sport}
+              />
+            ) : null}
           </div>
           {verdict.explanation.sessionIntent ? (
             <p className="mt-2 text-sm text-muted">{sanitizeText(verdict.explanation.sessionIntent)}</p>

--- a/app/(protected)/sessions/[sessionId]/components/reclassify-intent-selector.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/reclassify-intent-selector.tsx
@@ -1,0 +1,105 @@
+"use client";
+
+import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { EXTRA_INTENT_OPTIONS } from "@/lib/workouts/infer-extra-intent";
+
+type Props = {
+  sessionId: string;
+  currentIntent: string | null;
+  sport: string;
+};
+
+export function ReclassifyIntentSelector({ sessionId, currentIntent, sport }: Props) {
+  const router = useRouter();
+  const [isPending, startTransition] = useTransition();
+  const [isOpen, setIsOpen] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const sportLower = sport.toLowerCase();
+  const options = EXTRA_INTENT_OPTIONS.filter(
+    (opt) => opt.sports === null || opt.sports.includes(sportLower)
+  );
+
+  function handleSelect(intentValue: string) {
+    setIsOpen(false);
+    setMessage(null);
+
+    startTransition(async () => {
+      try {
+        const response = await fetch(`/api/sessions/${sessionId}/review/regenerate`, {
+          method: "POST",
+          headers: { "content-type": "application/json" },
+          body: JSON.stringify({ intentOverride: intentValue }),
+        });
+        const payload = (await response.json()) as { ok?: boolean; error?: string; narrativeSource?: string };
+
+        if (!response.ok) {
+          throw new Error(payload.error ?? "Could not reclassify session.");
+        }
+
+        setMessage("Reclassified — verdict updated.");
+        router.refresh();
+      } catch (error) {
+        setMessage(error instanceof Error ? error.message : "Could not reclassify session.");
+      }
+    });
+  }
+
+  return (
+    <div className="relative inline-flex items-center gap-1.5">
+      <button
+        type="button"
+        onClick={() => setIsOpen(!isOpen)}
+        disabled={isPending}
+        className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--border))] px-2.5 py-1 text-[11px] text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white disabled:opacity-40"
+      >
+        {isPending ? (
+          <>
+            <span className="inline-block h-3 w-3 animate-spin rounded-full border border-[rgba(255,255,255,0.2)] border-t-white" />
+            Reclassifying...
+          </>
+        ) : (
+          <>
+            <svg width="10" height="10" viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
+              <path d="M11 4H4V11" /><path d="M4 4L14 14" />
+            </svg>
+            Reclassify
+          </>
+        )}
+      </button>
+
+      {isOpen && !isPending ? (
+        <>
+          {/* Backdrop to close on outside click */}
+          <div className="fixed inset-0 z-10" onClick={() => setIsOpen(false)} />
+          <div className="absolute left-0 top-full z-20 mt-1 min-w-[200px] rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface))] py-1 shadow-lg">
+            {options.map((opt) => {
+              const isCurrent = opt.value === currentIntent;
+              return (
+                <button
+                  key={opt.value}
+                  type="button"
+                  onClick={() => handleSelect(opt.value)}
+                  disabled={isCurrent}
+                  className={`flex w-full items-center gap-2 px-3 py-2 text-left text-xs transition ${
+                    isCurrent
+                      ? "text-tertiary opacity-50"
+                      : "text-muted hover:bg-[rgba(255,255,255,0.06)] hover:text-white"
+                  }`}
+                >
+                  {opt.label}
+                  {isCurrent ? (
+                    <span className="ml-auto text-[10px] text-tertiary">(current)</span>
+                  ) : null}
+                </button>
+              );
+            })}
+          </div>
+        </>
+      ) : null}
+
+      {message ? <span className="text-[11px] text-muted">{message}</span> : null}
+    </div>
+  );
+}

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -627,6 +627,8 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           verdict={execReview.verdict}
           intentCategory={execReview.deterministic?.planned?.intentCategory ?? session.intent_category ?? null}
           narrativeSource={execReview.narrativeSource}
+          sessionId={session.id}
+          sport={session.sport}
         />
       ) : null}
 

--- a/app/(protected)/sessions/activity/[activityId]/page.tsx
+++ b/app/(protected)/sessions/activity/[activityId]/page.tsx
@@ -247,6 +247,8 @@ export default async function ActivitySessionReviewPage({ params }: { params: { 
           verdict={execReview.verdict}
           intentCategory={execReview.deterministic?.planned?.intentCategory ?? null}
           narrativeSource={execReview.narrativeSource}
+          sessionId={session.id}
+          sport={session.sport}
         />
       ) : null}
 

--- a/app/api/sessions/[sessionId]/review/regenerate/route.ts
+++ b/app/api/sessions/[sessionId]/review/regenerate/route.ts
@@ -3,6 +3,9 @@ import { NextResponse } from "next/server";
 import { isSameOrigin } from "@/lib/security/request";
 import { createClient } from "@/lib/supabase/server";
 import { syncExtraActivityExecution, syncSessionExecutionFromActivityLink } from "@/lib/workouts/session-execution";
+import { EXTRA_INTENT_OPTIONS } from "@/lib/workouts/infer-extra-intent";
+
+const VALID_INTENT_VALUES = new Set(EXTRA_INTENT_OPTIONS.map((o) => o.value));
 
 export async function POST(request: Request, context: { params: Promise<{ sessionId: string }> }) {
   if (!isSameOrigin(request)) {
@@ -23,9 +26,25 @@ export async function POST(request: Request, context: { params: Promise<{ sessio
   const activityIdMatch = sessionId.match(/^activity-(.+)$/);
   if (activityIdMatch) {
     const activityId = activityIdMatch[1];
+
+    // Parse optional intent override from request body
+    let intentOverride: string | undefined;
     try {
-      const executionResult = await syncExtraActivityExecution({ supabase, userId: user.id, activityId });
+      const body = await request.json();
+      if (body && typeof body.intentOverride === "string" && body.intentOverride) {
+        if (!VALID_INTENT_VALUES.has(body.intentOverride)) {
+          return NextResponse.json({ error: "Invalid intent category." }, { status: 400 });
+        }
+        intentOverride = body.intentOverride;
+      }
+    } catch {
+      // No body or invalid JSON — proceed without override
+    }
+
+    try {
+      const executionResult = await syncExtraActivityExecution({ supabase, userId: user.id, activityId, intentOverride });
       revalidatePath(`/sessions/${sessionId}`);
+      revalidatePath(`/sessions/activity/${activityId}`);
       revalidatePath(`/sessions/activity-${activityId}`);
       revalidatePath("/dashboard");
       return NextResponse.json({ ok: true, narrativeSource: executionResult.narrativeSource });

--- a/lib/workouts/infer-extra-intent.test.ts
+++ b/lib/workouts/infer-extra-intent.test.ts
@@ -242,7 +242,25 @@ describe("EXTRA_INTENT_OPTIONS", () => {
     const swimOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "extra swim");
     expect(swimOpt?.sports).toEqual(["swim"]);
 
-    const universalOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "recovery");
-    expect(universalOpt?.sports).toBeNull();
+    const recoveryOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "recovery");
+    expect(recoveryOpt?.sports).toEqual(["run", "bike"]);
+
+    const easyOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "easy endurance");
+    expect(easyOpt?.sports).toEqual(["run", "bike"]);
+
+    const thresholdOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "threshold intervals");
+    expect(thresholdOpt?.sports).toEqual(["run", "bike"]);
+  });
+
+  test("swim and strength only see their own options", () => {
+    const swimOptions = EXTRA_INTENT_OPTIONS.filter(
+      (o) => o.sports === null || o.sports.includes("swim")
+    );
+    expect(swimOptions.map((o) => o.value)).toEqual(["extra swim"]);
+
+    const strengthOptions = EXTRA_INTENT_OPTIONS.filter(
+      (o) => o.sports === null || o.sports.includes("strength")
+    );
+    expect(strengthOptions.map((o) => o.value)).toEqual(["extra strength"]);
   });
 });

--- a/lib/workouts/infer-extra-intent.test.ts
+++ b/lib/workouts/infer-extra-intent.test.ts
@@ -1,4 +1,4 @@
-import { inferExtraIntent } from "./infer-extra-intent";
+import { inferExtraIntent, EXTRA_INTENT_OPTIONS } from "./infer-extra-intent";
 
 const baseZone = (zone: number, durationSec: number) => ({
   zone,
@@ -206,5 +206,43 @@ describe("inferExtraIntent", () => {
     });
 
     expect(result.intentCategory).toBe("easy endurance");
+  });
+});
+
+describe("EXTRA_INTENT_OPTIONS", () => {
+  test("covers every intent category that inferExtraIntent can return", () => {
+    const optionValues = new Set(EXTRA_INTENT_OPTIONS.map((o) => o.value));
+    const knownCategories = [
+      "recovery",
+      "easy endurance",
+      "long endurance run",
+      "long endurance ride",
+      "threshold intervals",
+      "extra swim",
+      "extra strength",
+    ];
+    for (const cat of knownCategories) {
+      expect(optionValues).toContain(cat);
+    }
+  });
+
+  test("each option has a non-empty label", () => {
+    for (const opt of EXTRA_INTENT_OPTIONS) {
+      expect(opt.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("sport-specific options have correct sport filters", () => {
+    const runOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "long endurance run");
+    expect(runOpt?.sports).toEqual(["run"]);
+
+    const bikeOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "long endurance ride");
+    expect(bikeOpt?.sports).toEqual(["bike"]);
+
+    const swimOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "extra swim");
+    expect(swimOpt?.sports).toEqual(["swim"]);
+
+    const universalOpt = EXTRA_INTENT_OPTIONS.find((o) => o.value === "recovery");
+    expect(universalOpt?.sports).toBeNull();
   });
 });

--- a/lib/workouts/infer-extra-intent.ts
+++ b/lib/workouts/infer-extra-intent.ts
@@ -36,14 +36,17 @@ export type InferredExtraIntent = {
  * Valid intent categories for extra sessions, used by the reclassify UI.
  * Each entry's `value` matches what `inferExtraIntent` returns and what
  * `toIntentBucket` in `lib/coach/session-diagnosis.ts` consumes.
- * `sports` restricts which options appear for a given sport (null = all).
+ * `sports` restricts which options appear for a given sport — swim and
+ * strength are always routed to the `swim_strength` evaluator bucket by
+ * sport, so showing recovery/easy/threshold for those sports would route
+ * them to the wrong evaluator.
  */
 export const EXTRA_INTENT_OPTIONS = [
-  { value: "recovery", label: "Recovery", sports: null },
-  { value: "easy endurance", label: "Easy endurance", sports: null },
+  { value: "recovery", label: "Recovery", sports: ["run", "bike"] as string[] },
+  { value: "easy endurance", label: "Easy endurance", sports: ["run", "bike"] as string[] },
   { value: "long endurance run", label: "Long endurance run", sports: ["run"] as string[] },
   { value: "long endurance ride", label: "Long endurance ride", sports: ["bike"] as string[] },
-  { value: "threshold intervals", label: "Threshold / intervals", sports: null },
+  { value: "threshold intervals", label: "Threshold / intervals", sports: ["run", "bike"] as string[] },
   { value: "extra swim", label: "Swim session", sports: ["swim"] as string[] },
   { value: "extra strength", label: "Strength session", sports: ["strength"] as string[] },
 ] as const;

--- a/lib/workouts/infer-extra-intent.ts
+++ b/lib/workouts/infer-extra-intent.ts
@@ -32,6 +32,24 @@ export type InferredExtraIntent = {
   rationale: string;
 };
 
+/**
+ * Valid intent categories for extra sessions, used by the reclassify UI.
+ * Each entry's `value` matches what `inferExtraIntent` returns and what
+ * `toIntentBucket` in `lib/coach/session-diagnosis.ts` consumes.
+ * `sports` restricts which options appear for a given sport (null = all).
+ */
+export const EXTRA_INTENT_OPTIONS = [
+  { value: "recovery", label: "Recovery", sports: null },
+  { value: "easy endurance", label: "Easy endurance", sports: null },
+  { value: "long endurance run", label: "Long endurance run", sports: ["run"] as string[] },
+  { value: "long endurance ride", label: "Long endurance ride", sports: ["bike"] as string[] },
+  { value: "threshold intervals", label: "Threshold / intervals", sports: null },
+  { value: "extra swim", label: "Swim session", sports: ["swim"] as string[] },
+  { value: "extra strength", label: "Strength session", sports: ["strength"] as string[] },
+] as const;
+
+export type ExtraIntentValue = (typeof EXTRA_INTENT_OPTIONS)[number]["value"];
+
 const LONG_RUN_MIN_MINUTES = 90;
 const LONG_RIDE_MIN_MINUTES = 150;
 const HARD_ZONE_THRESHOLD = 0.2;

--- a/lib/workouts/session-execution.ts
+++ b/lib/workouts/session-execution.ts
@@ -810,6 +810,9 @@ export async function syncExtraActivityExecution(args: {
   supabase: SupabaseClient;
   userId: string;
   activityId: string;
+  /** When set, overrides the auto-inferred intent category. Persisted to
+   *  `completed_activities.intent_override` so it survives regeneration. */
+  intentOverride?: string;
 }): Promise<PersistedExecutionReview> {
   const { data: activity, error: activityError } = await args.supabase
     .from("completed_activities")
@@ -821,15 +824,14 @@ export async function syncExtraActivityExecution(args: {
   if (activityError) throw new Error(activityError.message);
   if (!activity) throw new Error("Activity not found.");
 
-  // Classify the workout from its own metrics so the downstream evaluator
-  // picks a real intent bucket (easy_endurance, threshold_quality, etc.)
-  // instead of the catch-all unknown bucket. The classifier label also flows
-  // into the AI prompt as the inferred intent.
-  const inferredIntent = inferExtraIntent({
-    sport_type: activity.sport_type,
-    duration_sec: activity.duration_sec,
-    metrics_v2: activity.metrics_v2 ?? null,
-  });
+  // Use the user's override when available; otherwise classify automatically.
+  const intentResult = args.intentOverride
+    ? { intentCategory: args.intentOverride, rationale: "User override" }
+    : inferExtraIntent({
+        sport_type: activity.sport_type,
+        duration_sec: activity.duration_sec,
+        metrics_v2: activity.metrics_v2 ?? null,
+      });
 
   // Extras have no planned duration, so leave `duration_minutes` null.
   // Passing the actual activity duration here would be a self-comparison — it
@@ -842,7 +844,7 @@ export async function syncExtraActivityExecution(args: {
     type: "Extra workout",
     duration_minutes: null,
     target: null,
-    intent_category: inferredIntent.intentCategory,
+    intent_category: intentResult.intentCategory,
     session_name: "Extra workout",
     session_role: null,
     status: "completed"
@@ -857,12 +859,13 @@ export async function syncExtraActivityExecution(args: {
     athleteContext = null;
   }
 
+  const intentSource = args.intentOverride ? "User override" : "Inferred intent";
   const { evidence } = buildExecutionEvidence({
     athleteId: args.userId,
     sessionId: syntheticSession.id,
     sessionTitle: "Extra workout",
     sessionRole: null,
-    plannedStructure: `Inferred intent: ${inferredIntent.intentCategory} (${inferredIntent.rationale})`,
+    plannedStructure: `${intentSource}: ${intentResult.intentCategory} (${intentResult.rationale})`,
     diagnosisInput,
     weeklyState: athleteContext ? { fatigue: athleteContext.weeklyState.fatigue } : null
   });
@@ -875,9 +878,16 @@ export async function syncExtraActivityExecution(args: {
     narrativeSource: generated.source
   });
 
+  const updatePayload: Record<string, unknown> = { execution_result: executionResult };
+  // Persist the override so it survives future regenerations. Clear it when
+  // no override is provided (user could have removed a previous override).
+  if (args.intentOverride !== undefined) {
+    updatePayload.intent_override = args.intentOverride || null;
+  }
+
   const { error: saveError } = await args.supabase
     .from("completed_activities")
-    .update({ execution_result: executionResult })
+    .update(updatePayload)
     .eq("id", activity.id)
     .eq("user_id", args.userId);
 

--- a/lib/workouts/session-execution.ts
+++ b/lib/workouts/session-execution.ts
@@ -816,7 +816,7 @@ export async function syncExtraActivityExecution(args: {
 }): Promise<PersistedExecutionReview> {
   const { data: activity, error: activityError } = await args.supabase
     .from("completed_activities")
-    .select("id,sport_type,duration_sec,distance_m,avg_hr,avg_power,avg_pace_per_100m_sec,laps_count,parse_summary,metrics_v2")
+    .select("id,sport_type,duration_sec,distance_m,avg_hr,avg_power,avg_pace_per_100m_sec,laps_count,parse_summary,metrics_v2,intent_override")
     .eq("id", args.activityId)
     .eq("user_id", args.userId)
     .maybeSingle();
@@ -824,9 +824,12 @@ export async function syncExtraActivityExecution(args: {
   if (activityError) throw new Error(activityError.message);
   if (!activity) throw new Error("Activity not found.");
 
-  // Use the user's override when available; otherwise classify automatically.
-  const intentResult = args.intentOverride
-    ? { intentCategory: args.intentOverride, rationale: "User override" }
+  // Use the caller's explicit override first, then fall back to a previously
+  // stored override from the DB, and only auto-classify as a last resort.
+  // This ensures a user's reclassification survives plain regenerations.
+  const effectiveOverride = args.intentOverride ?? (activity as Record<string, unknown>).intent_override as string | null;
+  const intentResult = effectiveOverride
+    ? { intentCategory: effectiveOverride, rationale: "User override" }
     : inferExtraIntent({
         sport_type: activity.sport_type,
         duration_sec: activity.duration_sec,

--- a/supabase/migrations/202604130001_add_intent_override_to_completed_activities.sql
+++ b/supabase/migrations/202604130001_add_intent_override_to_completed_activities.sql
@@ -1,0 +1,9 @@
+-- Add intent_override column to completed_activities so users can correct
+-- the auto-inferred intent category for extra (unplanned) workouts.
+-- Stored as a dedicated column (not inside execution_result JSONB) because
+-- execution_result gets fully replaced on regeneration.
+ALTER TABLE public.completed_activities
+  ADD COLUMN IF NOT EXISTS intent_override text;
+
+COMMENT ON COLUMN public.completed_activities.intent_override IS
+  'User-supplied intent override for extra sessions. When set, downstream code uses this instead of calling inferExtraIntent.';


### PR DESCRIPTION
## Summary

- **Reclassify dropdown on extras verdict card** — when `inferExtraIntent` misclassifies an unplanned workout, users can now pick the correct intent category from a sport-filtered dropdown, which regenerates the execution review with the override
- **`intent_override` column on `completed_activities`** — persists the user's override so it survives future regenerations (stored as a dedicated column, not inside `execution_result` JSONB which gets replaced on regen)
- **`syncExtraActivityExecution` accepts `intentOverride` param** — skips `inferExtraIntent` when provided; the regenerate API route validates against the known set of intent categories
- **7 new tests** — 4 component tests (reclassify button rendering, sport-filtered dropdown, disabled current option) and 3 intent options coverage tests

## Context

This is M3 (Reclassify affordance) following M1 (feel→verdict, #256) and M2 (extras verdict card, #257). Completes the extras verdict loop: auto-classify → show verdict → let user correct if wrong.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npm run test` — 842/842 passing (62 suites)
- [x] Agent Preview: "Reclassify" button renders on `/sessions/activity/{extraRunId}` with sport-filtered dropdown
- [ ] Click "Reclassify" → select a different intent → verify verdict regenerates with new classification
- [ ] Verify planned session pages are unaffected (no reclassify button appears)
- [ ] Apply migration: `supabase db push` — confirm `intent_override` column exists on `completed_activities`

https://claude.ai/code/session_01Wfm6dbHRWXaU3KNQCfQyBn