### PR TITLE
Collapse multiple coach notes behind toggle on calendar

### DIFF
--- a/app/(protected)/calendar/components/coach-note-card.tsx
+++ b/app/(protected)/calendar/components/coach-note-card.tsx
@@ -153,13 +153,34 @@ function SingleCoachNote({ rationale }: { rationale: AdaptationRationale }) {
 }
 
 export function CoachNoteCards({ rationales }: Props) {
+  const [showAll, setShowAll] = useState(false);
+
   if (rationales.length === 0) return null;
+
+  const firstNote = rationales[0];
+  const restNotes = rationales.slice(1);
 
   return (
     <div className="space-y-3">
-      {rationales.map((r) => (
-        <SingleCoachNote key={r.id} rationale={r} />
-      ))}
+      <SingleCoachNote key={firstNote.id} rationale={firstNote} />
+
+      {restNotes.length > 0 && (
+        <button
+          type="button"
+          onClick={() => setShowAll((prev) => !prev)}
+          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-xs text-tertiary transition hover:border-[rgba(255,255,255,0.16)] hover:text-white"
+        >
+          {showAll
+            ? "Hide older notes"
+            : `${restNotes.length} more coach note${restNotes.length > 1 ? "s" : ""}`}
+          <span className="text-[10px]">{showAll ? "\u25B2" : "\u25BC"}</span>
+        </button>
+      )}
+
+      {showAll &&
+        restNotes.map((r) => (
+          <SingleCoachNote key={r.id} rationale={r} />
+        ))}
     </div>
   );
 }

--- a/lib/agent-preview/data.ts
+++ b/lib/agent-preview/data.ts
@@ -1471,6 +1471,54 @@ export function createPreviewDatabase(): PreviewDatabase {
         athlete_response: null,
         created_at: "2026-03-15T10:06:00.000Z",
         acknowledged_at: null
+      },
+      {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaab",
+        user_id: PREVIEW_USER_ID,
+        trigger_type: "load_rebalance",
+        trigger_data: {
+          sourceSessionId: "77777777-7777-4777-8777-777777777775",
+          sourceSessionName: "Wednesday Swim",
+          verdictStatus: "achieved",
+          verdictSummary: "Session executed well but weekly swim volume trending low."
+        },
+        rationale_text: "I've added 10 minutes to Saturday's swim to rebalance weekly volume. Your Wednesday swim was solid but total swim minutes are 20% below target for this build block. The extra time is easy aerobic pull sets — no intensity change.",
+        changes_summary: [
+          { session_id: "77777777-7777-4777-8777-777777777776", session_label: "Saturday Endurance Swim", change_type: "duration_increased", before: "45 min", after: "55 min" }
+        ],
+        preserved_elements: ["Saturday's main set unchanged", "Sunday long ride unaffected"],
+        week_number: 2,
+        training_block: "Build",
+        affected_sessions: ["77777777-7777-4777-8777-777777777776"],
+        source_verdict_id: "99999999-9999-4999-8999-999999999993",
+        status: "pending",
+        athlete_response: null,
+        created_at: "2026-03-15T09:30:00.000Z",
+        acknowledged_at: null
+      },
+      {
+        id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaac",
+        user_id: PREVIEW_USER_ID,
+        trigger_type: "feel_based",
+        trigger_data: {
+          sourceSessionId: "77777777-7777-4777-8777-777777777773",
+          sourceSessionName: "Thursday Bike Intervals",
+          verdictStatus: "partial",
+          verdictSummary: "RPE reported as 9/10 when target was 7/10."
+        },
+        rationale_text: "Thursday's bike intervals felt harder than planned (RPE 9 vs target 7). I'm swapping Friday's tempo run for an easy recovery jog to give your legs a chance to absorb the bike load before the weekend.",
+        changes_summary: [
+          { session_id: "77777777-7777-4777-8777-777777777778", session_label: "Friday Tempo Run", change_type: "intensity_reduced", before: "40 min with 20 min @ tempo", after: "30 min easy recovery jog" }
+        ],
+        preserved_elements: ["Saturday's long ride preserved — key weekend session"],
+        week_number: 2,
+        training_block: "Build",
+        affected_sessions: ["77777777-7777-4777-8777-777777777778"],
+        source_verdict_id: "99999999-9999-4999-8999-999999999994",
+        status: "pending",
+        athlete_response: null,
+        created_at: "2026-03-15T08:15:00.000Z",
+        acknowledged_at: null
       }
     ],
     morning_briefs: [


### PR DESCRIPTION
## Summary
- **Collapse coach notes:** When multiple pending coach notes exist, only the most recent is shown with a "N more coach notes" toggle to reveal older ones — reduces vertical space from ~500px to ~160px
- **Single-note unchanged:** When there's only one note, it displays exactly as before with no toggle
- **Preview seed data:** Added 2 extra adaptation rationales (load_rebalance, feel_based) to agent preview so the collapse behavior can be tested locally

## Test plan
- [ ] Visit `/calendar` with 1 pending coach note — displays normally, no toggle
- [ ] Visit `/calendar` with 3+ pending notes — only first note visible, "2 more coach notes" toggle underneath
- [ ] Click toggle — older notes expand below; click again — they collapse
- [ ] Click "Got it" on the visible note — dismisses correctly
- [ ] Click "Let's discuss" — navigates to coach chat with context
- [ ] `npm run typecheck` passes
- [ ] `npm run lint` passes

https://claude.ai/code/session_018fpGtbksup4nzYi4A5fQTn