### PR TITLE
claude/delete-strava-activities-CY2RD

### DIFF
--- a/app/(protected)/activities/[activityId]/actions.ts
+++ b/app/(protected)/activities/[activityId]/actions.ts
@@ -2,7 +2,7 @@
 
 import { revalidatePath } from "next/cache";
 import { createClient } from "@/lib/supabase/server";
-import { syncSessionLoad } from "@/lib/training/load-sync";
+import { syncSessionLoad, rebuildDailyLoad, updateFitnessFromDate } from "@/lib/training/load-sync";
 import { syncSessionExecutionAfterUnlink, syncSessionExecutionFromActivityLink } from "@/lib/workouts/session-execution";
 import { postSessionSyncSideEffects } from "@/lib/workouts/post-sync-effects";
 import { updateUploadStatusForActivity } from "@/lib/workouts/upload-status";
@@ -169,5 +169,75 @@ export async function toggleRaceAction(activityId: string, isRace: boolean) {
   if (error) return { error: error.message };
 
   revalidatePath(`/activities/${activityId}`);
+  return { ok: true };
+}
+
+export async function deleteActivityAction(activityId: string) {
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return { error: "Unauthorized" };
+
+  // 1. Fetch the activity
+  const { data: activity } = await supabase
+    .from("completed_activities")
+    .select("id, upload_id, source, external_provider, start_time_utc")
+    .eq("id", activityId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!activity) return { error: "Activity not found" };
+
+  const activityDate = activity.start_time_utc
+    ? activity.start_time_utc.slice(0, 10)
+    : new Date().toISOString().slice(0, 10);
+
+  // 2. Gather affected session IDs before cascade deletes them
+  const { data: existingLinks } = await supabase
+    .from("session_activity_links")
+    .select("planned_session_id,confirmation_status")
+    .eq("user_id", user.id)
+    .eq("completed_activity_id", activityId)
+    .limit(5);
+
+  const affectedSessionIds = (existingLinks ?? [])
+    .filter((link: any) => link.planned_session_id && (link.confirmation_status === "confirmed" || link.confirmation_status === null))
+    .map((link: any) => link.planned_session_id as string);
+
+  // 3. Delete the activity (cascades to session_activity_links, session_load, session_verdicts)
+  if (activity.upload_id) {
+    // File-uploaded: delete the upload row, which cascades to completed_activities
+    const { error } = await supabase
+      .from("activity_uploads")
+      .delete()
+      .eq("id", activity.upload_id)
+      .eq("user_id", user.id);
+    if (error) return { error: error.message };
+  } else {
+    // Strava or other source: delete directly from completed_activities
+    const { error } = await supabase
+      .from("completed_activities")
+      .delete()
+      .eq("id", activityId)
+      .eq("user_id", user.id);
+    if (error) return { error: error.message };
+  }
+
+  // 4. Reset execution state on any sessions that were linked
+  for (const sessionId of affectedSessionIds) {
+    await syncSessionExecutionAfterUnlink({ supabase, userId: user.id, sessionId });
+    revalidatePath(`/sessions/${sessionId}`);
+  }
+
+  // 5. Rebuild stale aggregation tables (daily_load, athlete_fitness)
+  try {
+    await rebuildDailyLoad(supabase, user.id, activityDate);
+    await updateFitnessFromDate(supabase, user.id, activityDate);
+  } catch (syncError) {
+    console.error("[training-load] Failed to rebuild load after activity deletion:", syncError);
+  }
+
+  revalidatePath("/dashboard");
+  revalidatePath("/calendar");
+  revalidatePath("/debrief");
   return { ok: true };
 }

--- a/app/(protected)/activities/[activityId]/activity-linking-card.tsx
+++ b/app/(protected)/activities/[activityId]/activity-linking-card.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import { useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
 import type { SessionCandidate } from "@/lib/workouts/activity-details";
-import { linkActivityAction, markUnplannedAction, toggleRaceAction, unlinkActivityAction, updateActivityNotesAction } from "./actions";
+import { deleteActivityAction, linkActivityAction, markUnplannedAction, toggleRaceAction, unlinkActivityAction, updateActivityNotesAction } from "./actions";
 
 export function ActivityLinkingCard({
   activityId,
@@ -10,7 +11,9 @@ export function ActivityLinkingCard({
   candidates,
   isRace,
   initialNotes,
-  isUnplanned
+  isUnplanned,
+  source,
+  externalProvider
 }: {
   activityId: string;
   linkedSession: SessionCandidate | null;
@@ -18,7 +21,10 @@ export function ActivityLinkingCard({
   isRace: boolean;
   initialNotes: string | null;
   isUnplanned: boolean;
+  source: string;
+  externalProvider: string | null;
 }) {
+  const router = useRouter();
   const [selectedSessionId, setSelectedSessionId] = useState(candidates[0]?.id ?? "");
   const [notes, setNotes] = useState(initialNotes ?? "");
   const [message, setMessage] = useState("");
@@ -106,6 +112,28 @@ export function ActivityLinkingCard({
           {isRace ? "Unmark race" : "Mark as race"}
         </button>
         {message ? <p className="mt-2 text-xs text-muted">{message}</p> : null}
+        <div className="mt-4 border-t border-white/10 pt-3">
+          <button
+            className="btn-secondary text-xs text-rose-400"
+            disabled={pending}
+            onClick={() => {
+              const msg = externalProvider === "strava"
+                ? "Delete this activity? It may be re-imported on the next Strava sync."
+                : "Delete this activity? This cannot be undone.";
+              if (!window.confirm(msg)) return;
+              startTransition(async () => {
+                const result = await deleteActivityAction(activityId);
+                if (result?.error) {
+                  setMessage(result.error);
+                } else {
+                  router.push("/dashboard");
+                }
+              });
+            }}
+          >
+            Delete activity
+          </button>
+        </div>
       </article>
     </div>
   );

--- a/app/(protected)/activities/[activityId]/page.tsx
+++ b/app/(protected)/activities/[activityId]/page.tsx
@@ -263,6 +263,8 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
           isRace={activity.is_race}
           initialNotes={activity.notes}
           isUnplanned={activity.is_unplanned}
+          source={activity.source}
+          externalProvider={activity.external_provider}
         />
       </div>
     </section>

--- a/lib/training/load-sync.ts
+++ b/lib/training/load-sync.ts
@@ -112,7 +112,7 @@ export async function syncSessionLoad(
 /**
  * Rebuild daily_load rows for a specific date by summing session_load.
  */
-async function rebuildDailyLoad(
+export async function rebuildDailyLoad(
   supabase: SupabaseClient,
   userId: string,
   date: string
@@ -179,7 +179,7 @@ async function rebuildDailyLoad(
  * Update athlete_fitness from a specific date forward.
  * Only recomputes from the affected date — not the full history.
  */
-async function updateFitnessFromDate(
+export async function updateFitnessFromDate(
   supabase: SupabaseClient,
   userId: string,
   fromDate: string


### PR DESCRIPTION
Adds a "Delete activity" button to the ActivityLinkingCard sidebar,
allowing users to delete both file-uploaded and Strava-synced activities.
Handles cascade cleanup of session links, training load, and fitness
aggregation tables. Strava activities warn about potential re-import.

https://claude.ai/code/session_01RbLjWLCZr5AhPPJFCQiaYv