### PR TITLE
claude/review-triai-design-1YQQ5

### DIFF
--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -309,15 +309,23 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
       .maybeSingle();
 
     if (weekRow?.training_block_id) {
-      const { data: block } = await supabase
-        .from("training_blocks")
-        .select("block_type,emphasis")
-        .eq("id", weekRow.training_block_id)
-        .maybeSingle();
+      const [{ data: block }, { count: blockWeekCount }] = await Promise.all([
+        supabase
+          .from("training_blocks")
+          .select("block_type,emphasis")
+          .eq("id", weekRow.training_block_id)
+          .maybeSingle(),
+        supabase
+          .from("training_weeks")
+          .select("id", { count: "exact", head: true })
+          .eq("training_block_id", weekRow.training_block_id)
+      ]);
 
       if (block) {
         const weekNum = (weekRow.week_index ?? 0) + 1;
-        blockContextLine = `Week ${weekNum} · ${block.block_type}${weekRow.focus ? ` · ${weekRow.focus}` : ""}`;
+        const totalWeeks = typeof blockWeekCount === "number" && blockWeekCount > 0 ? blockWeekCount : null;
+        const weekLabel = totalWeeks ? `Week ${weekNum} of ${totalWeeks}` : `Week ${weekNum}`;
+        blockContextLine = `${weekLabel} · ${block.block_type}${weekRow.focus ? ` · ${weekRow.focus}` : ""}`;
       }
     }
   }

--- a/app/(protected)/calendar/page.tsx
+++ b/app/(protected)/calendar/page.tsx
@@ -24,6 +24,7 @@ type Session = {
   execution_result?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null; executionScore?: number | null; execution_score?: number | null; executionScoreBand?: string | null; execution_score_band?: string | null; executionScoreSummary?: string | null; recommendedNextAction?: string | null; recommended_next_action?: string | null; executionScoreProvisional?: boolean | null; execution_score_provisional?: boolean | null } | null;
   duration_minutes: number | null;
   notes: string | null;
+  target?: string | null;
   created_at: string;
   status?: SessionLifecycleState;
   is_key?: boolean | null;
@@ -117,7 +118,7 @@ export default async function CalendarPage({ searchParams }: { searchParams?: { 
   {
     const query = await supabase
       .from("sessions")
-      .select("id,date,sport,type,session_name,discipline,subtype,workout_type,duration_minutes,intent_category,session_role,source_metadata,execution_result,notes,created_at,status,is_key")
+      .select("id,date,sport,type,session_name,discipline,subtype,workout_type,duration_minutes,intent_category,session_role,source_metadata,execution_result,notes,target,created_at,status,is_key")
       .eq("user_id", user.id)
       .gte("date", weekStart)
       .lt("date", weekEnd)

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -140,7 +140,7 @@ function getRolePill(session: CalendarSession): RolePill | null {
 
 const TARGET_HR_PATTERN = /(\d{2,3})\s*[-\u2013]\s*(\d{2,3})\s*(?:bpm|hr)/i;
 const TARGET_HR_CAP_PATTERN = /(?:hr|heart\s*rate)[^\n]{0,12}?(?:<|under|below|keep\s*under|cap)\s*(\d{2,3})/i;
-const TARGET_PACE_PATTERN = /(\d{1,2}):([0-5]\d)\s*(?:\/km|\/mi|per\s*km|per\s*mi|min\/km|min\/mi)/i;
+const TARGET_PACE_PATTERN = /(\d{1,2}):([0-5]\d)\s*(?:\/(km|mi)|per\s*(km|mi)|min\/(km|mi))/i;
 const TARGET_POWER_PATTERN = /(\d{2,4})\s*[-\u2013]\s*(\d{2,4})\s*W\b/i;
 const TARGET_FTP_PCT_PATTERN = /(\d{1,3})\s*[-\u2013]\s*(\d{1,3})\s*%\s*FTP/i;
 const TARGET_SWIM_DISTANCE_PATTERN = /(\d{2,4})\s*m\b/i;
@@ -159,7 +159,10 @@ function extractTargetLine(session: CalendarSession): string | null {
   }
   if (sport === "run") {
     const pace = source.match(TARGET_PACE_PATTERN);
-    if (pace) return `${Number(pace[1])}:${pace[2]}/km`;
+    if (pace) {
+      const unit = (pace[3] ?? pace[4] ?? pace[5] ?? "km").toLowerCase();
+      return `${Number(pace[1])}:${pace[2]}/${unit}`;
+    }
   }
   if (sport === "swim") {
     const distance = source.match(TARGET_SWIM_DISTANCE_PATTERN);

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -30,6 +30,7 @@ type CalendarSession = {
   executionResult?: { status?: "matched_intent" | "partial_intent" | "missed_intent" | null; summary?: string | null; executionScore?: number | null; execution_score?: number | null; executionScoreBand?: string | null; execution_score_band?: string | null; executionScoreSummary?: string | null; recommendedNextAction?: string | null; recommended_next_action?: string | null; executionScoreProvisional?: boolean | null; execution_score_provisional?: boolean | null } | null;
   duration: number;
   notes: string | null;
+  target?: string | null;
   created_at: string;
   status: SessionStatus;
   linkedActivityCount?: number;
@@ -143,20 +144,26 @@ const TARGET_PACE_PATTERN = /(\d{1,2}):([0-5]\d)\s*(?:\/km|\/mi|per\s*km|per\s*m
 const TARGET_POWER_PATTERN = /(\d{2,4})\s*[-\u2013]\s*(\d{2,4})\s*W\b/i;
 
 function extractTargetLine(session: CalendarSession): string | null {
-  const notes = session.notes ?? "";
-  if (!notes) return null;
+  const source = `${session.target ?? ""} ${session.notes ?? ""}`.trim();
+  if (!source) return null;
   const sport = (session.sport ?? "").toLowerCase();
   if (sport === "bike") {
-    const power = notes.match(TARGET_POWER_PATTERN);
+    const power = source.match(TARGET_POWER_PATTERN);
     if (power) return `${power[1]}–${power[2]} W`;
+    const ftp = source.match(/(\d{1,3})\s*[-\u2013]\s*(\d{1,3})\s*%\s*FTP/i);
+    if (ftp) return `${ftp[1]}–${ftp[2]}% FTP`;
   }
   if (sport === "run") {
-    const pace = notes.match(TARGET_PACE_PATTERN);
+    const pace = source.match(TARGET_PACE_PATTERN);
     if (pace) return `${Number(pace[1])}:${pace[2]}/km`;
   }
-  const hrRange = notes.match(TARGET_HR_PATTERN);
+  if (sport === "swim") {
+    const distance = source.match(/(\d{2,4})\s*m\b/i);
+    if (distance) return `${distance[1]} m`;
+  }
+  const hrRange = source.match(TARGET_HR_PATTERN);
   if (hrRange) return `HR ${hrRange[1]}–${hrRange[2]}`;
-  const hrCap = notes.match(TARGET_HR_CAP_PATTERN);
+  const hrCap = source.match(TARGET_HR_CAP_PATTERN);
   if (hrCap) return `HR ≤ ${hrCap[1]}`;
   return null;
 }

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -105,6 +105,62 @@ function getIntentLabel(intentCategory: string): string {
   return INTENT_LABELS[intentCategory] ?? intentCategory.replace(/_/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
 }
 
+type RolePill = { label: string; className: string };
+
+function getRolePill(session: CalendarSession): RolePill | null {
+  const raw = (session.role ?? "").toLowerCase();
+  const role = session.is_key ? "key" : raw;
+  if (!role) return null;
+  switch (role) {
+    case "key":
+      return {
+        label: "Key",
+        className: "border-[rgba(255,180,60,0.3)] bg-[rgba(255,180,60,0.08)] text-[hsl(var(--warning))]"
+      };
+    case "supporting":
+      return {
+        label: "Support",
+        className: "border-[rgba(99,179,237,0.3)] bg-[rgba(99,179,237,0.08)] text-[rgb(99,179,237)]"
+      };
+    case "recovery":
+      return {
+        label: "Recovery",
+        className: "border-[rgba(148,163,184,0.3)] bg-[rgba(148,163,184,0.08)] text-[rgb(148,163,184)]"
+      };
+    case "optional":
+      return {
+        label: "Optional",
+        className: "border-[rgba(148,163,184,0.2)] bg-transparent text-[rgba(148,163,184,0.7)]"
+      };
+    default:
+      return null;
+  }
+}
+
+const TARGET_HR_PATTERN = /(\d{2,3})\s*[-\u2013]\s*(\d{2,3})\s*(?:bpm|hr)/i;
+const TARGET_HR_CAP_PATTERN = /(?:hr|heart\s*rate)[^\n]{0,12}?(?:<|under|below|keep\s*under|cap)\s*(\d{2,3})/i;
+const TARGET_PACE_PATTERN = /(\d{1,2}):([0-5]\d)\s*(?:\/km|\/mi|per\s*km|per\s*mi|min\/km|min\/mi)/i;
+const TARGET_POWER_PATTERN = /(\d{2,4})\s*[-\u2013]\s*(\d{2,4})\s*W\b/i;
+
+function extractTargetLine(session: CalendarSession): string | null {
+  const notes = session.notes ?? "";
+  if (!notes) return null;
+  const sport = (session.sport ?? "").toLowerCase();
+  if (sport === "bike") {
+    const power = notes.match(TARGET_POWER_PATTERN);
+    if (power) return `${power[1]}–${power[2]} W`;
+  }
+  if (sport === "run") {
+    const pace = notes.match(TARGET_PACE_PATTERN);
+    if (pace) return `${Number(pace[1])}:${pace[2]}/km`;
+  }
+  const hrRange = notes.match(TARGET_HR_PATTERN);
+  if (hrRange) return `HR ${hrRange[1]}–${hrRange[2]}`;
+  const hrCap = notes.match(TARGET_HR_CAP_PATTERN);
+  if (hrCap) return `HR ≤ ${hrCap[1]}`;
+  return null;
+}
+
 function getIntentPillClass(intentCategory: string): string {
   const classes: Record<string, string> = {
     aerobic_base: "border border-[rgba(99,179,237,0.3)] bg-[rgba(99,179,237,0.1)] text-[rgb(99,179,237)]",
@@ -857,9 +913,15 @@ export function WeekCalendar({
                             <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: disciplineTone.dot }} />
                             {discipline.label}
                           </span>
-                          {(session.is_key || session.role?.toLowerCase() === "key") ? (
-                            <span className="rounded-full border border-[rgba(255,180,60,0.3)] bg-[rgba(255,180,60,0.08)] px-1.5 py-0.5 text-[9px] font-medium text-[hsl(var(--warning))]">Key</span>
-                          ) : null}
+                          {(() => {
+                            const pill = getRolePill(session);
+                            if (!pill) return null;
+                            return (
+                              <span className={`rounded-full border px-1.5 py-0.5 text-[9px] font-medium ${pill.className}`}>
+                                {pill.label}
+                              </span>
+                            );
+                          })()}
                         </div>
                         <SessionActionMenu
                           session={session}
@@ -885,6 +947,10 @@ export function WeekCalendar({
                       <p className="mt-1 min-h-[1.5rem] font-medium leading-snug">{cardTitle}</p>
                       <div className="mt-0 flex flex-wrap items-center gap-1">
                         <span className="text-[11px] text-muted">{session.duration} min{state === "unmatched_upload" ? ` · logged ${uploadDateFormatter.format(new Date(`${session.created_at}`))}` : ""}</span>
+                        {state !== "unmatched_upload" ? (() => {
+                          const target = extractTargetLine(session);
+                          return target ? <span className="text-[11px] text-muted">· {target}</span> : null;
+                        })() : null}
                         {session.intentCategory && state !== "unmatched_upload" ? (
                           <span className={`rounded-full px-1.5 py-0.5 text-[9px] font-medium ${getIntentPillClass(session.intentCategory)}`}>
                             {getIntentLabel(session.intentCategory)}

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -142,15 +142,19 @@ const TARGET_HR_PATTERN = /(\d{2,3})\s*[-\u2013]\s*(\d{2,3})\s*(?:bpm|hr)/i;
 const TARGET_HR_CAP_PATTERN = /(?:hr|heart\s*rate)[^\n]{0,12}?(?:<|under|below|keep\s*under|cap)\s*(\d{2,3})/i;
 const TARGET_PACE_PATTERN = /(\d{1,2}):([0-5]\d)\s*(?:\/km|\/mi|per\s*km|per\s*mi|min\/km|min\/mi)/i;
 const TARGET_POWER_PATTERN = /(\d{2,4})\s*[-\u2013]\s*(\d{2,4})\s*W\b/i;
+const TARGET_FTP_PCT_PATTERN = /(\d{1,3})\s*[-\u2013]\s*(\d{1,3})\s*%\s*FTP/i;
+const TARGET_SWIM_DISTANCE_PATTERN = /(\d{2,4})\s*m\b/i;
 
 function extractTargetLine(session: CalendarSession): string | null {
-  const source = `${session.target ?? ""} ${session.notes ?? ""}`.trim();
-  if (!source) return null;
+  const target = session.target?.trim() ?? "";
+  const notes = session.notes?.trim() ?? "";
+  if (!target && !notes) return null;
+  const source = target && notes ? `${target} ${notes}` : target || notes;
   const sport = (session.sport ?? "").toLowerCase();
   if (sport === "bike") {
     const power = source.match(TARGET_POWER_PATTERN);
     if (power) return `${power[1]}–${power[2]} W`;
-    const ftp = source.match(/(\d{1,3})\s*[-\u2013]\s*(\d{1,3})\s*%\s*FTP/i);
+    const ftp = source.match(TARGET_FTP_PCT_PATTERN);
     if (ftp) return `${ftp[1]}–${ftp[2]}% FTP`;
   }
   if (sport === "run") {
@@ -158,7 +162,7 @@ function extractTargetLine(session: CalendarSession): string | null {
     if (pace) return `${Number(pace[1])}:${pace[2]}/km`;
   }
   if (sport === "swim") {
-    const distance = source.match(/(\d{2,4})\s*m\b/i);
+    const distance = source.match(TARGET_SWIM_DISTANCE_PATTERN);
     if (distance) return `${distance[1]} m`;
   }
   const hrRange = source.match(TARGET_HR_PATTERN);

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -389,6 +389,17 @@ export function CoachChat({
     [briefingContext, diagnosisSessions]
   );
   const [messages, setMessages] = useState<Message[]>([openingMessage]);
+
+  // When the review-backfill effect triggers router.refresh(), props update but the
+  // opening message in state goes stale. Replace it as long as the user hasn't
+  // started a conversation yet (only the opening message is present).
+  useEffect(() => {
+    setMessages((current) => {
+      if (current.length !== 1 || current[0].role !== "assistant") return current;
+      if (current[0].content === openingMessage.content) return current;
+      return [openingMessage];
+    });
+  }, [openingMessage]);
   const [summary, setSummary] = useState<CoachSummary | null>(null);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -59,12 +59,37 @@ type RankedSession = SessionDiagnosis & {
   themes: DiagnosisTheme[];
 };
 
-const defaultAssistantMessage: Message = {
-  id: "coach-default",
-  role: "assistant",
-  content:
-    "I can use execution scores and intent-match review to explain what happened in completed sessions, then help you decide exactly what to adjust next."
-};
+function buildOpeningMessage(
+  briefing: CoachBriefingContext,
+  diagnoses: SessionDiagnosis[]
+): Message {
+  const reviewed = briefing.reviewedSessionCount;
+  const onTarget = diagnoses.filter((d) => d.executionScoreBand === "On target").length;
+  const partial = diagnoses.filter((d) => d.executionScoreBand === "Partial match").length;
+  const missed = diagnoses.filter((d) => d.executionScoreBand === "Missed intent").length;
+  const latest = diagnoses[0];
+  const latestName = latest?.sessionName ?? null;
+  const nextKey = briefing.upcomingKeySessionNames?.[0] ?? null;
+
+  let content: string;
+  if (reviewed === 0 && briefing.uploadedSessionCount === 0) {
+    content = nextKey
+      ? `No sessions reviewed yet — once you upload activity data I can dig into execution. Want to talk through ${nextKey} in the meantime?`
+      : "No sessions reviewed yet. Upload an activity or link one to a planned session and I'll break down the execution.";
+  } else if (missed >= 2) {
+    content = `${missed} sessions came in below target recently${latestName ? `, most recently ${latestName}` : ""}. Want to look at what's driving that before we plan the next one?`;
+  } else if (partial >= 1 && missed === 0) {
+    content = `Mostly on track — ${onTarget} on target, ${partial} partial${latestName ? ` (latest: ${latestName})` : ""}. Anything about the partial sessions that felt off to you?`;
+  } else if (onTarget >= 3 && missed === 0) {
+    content = `You're stacking clean sessions — ${onTarget} on target and nothing missed. Before we talk about next week, is there anything that felt off?`;
+  } else if (latestName) {
+    content = `I've got ${reviewed} reviewed session${reviewed === 1 ? "" : "s"} in the picture, most recently ${latestName}. What do you want to dig into?`;
+  } else {
+    content = "I can use execution scores and intent-match review to explain what happened in completed sessions, then help you decide exactly what to adjust next.";
+  }
+
+  return { id: "coach-default", role: "assistant", content };
+}
 
 function createMessageId() {
   if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
@@ -359,7 +384,11 @@ export function CoachChat({
   showBriefingPanel?: boolean;
 }) {
   const router = useRouter();
-  const [messages, setMessages] = useState<Message[]>([defaultAssistantMessage]);
+  const openingMessage = useMemo(
+    () => buildOpeningMessage(briefingContext, diagnosisSessions),
+    [briefingContext, diagnosisSessions]
+  );
+  const [messages, setMessages] = useState<Message[]>([openingMessage]);
   const [summary, setSummary] = useState<CoachSummary | null>(null);
   const [input, setInput] = useState("");
   const [isLoading, setIsLoading] = useState(false);
@@ -592,7 +621,7 @@ export function CoachChat({
       }
 
       setConversationId(nextConversationId);
-      setMessages(data.messages?.length ? data.messages : [defaultAssistantMessage]);
+      setMessages(data.messages?.length ? data.messages : [openingMessage]);
     } catch (conversationError) {
       setError(conversationError instanceof Error ? conversationError.message : "Failed to load conversation.");
     }
@@ -601,7 +630,7 @@ export function CoachChat({
   function handleNewChat() {
     activeRequestRef.current?.abort();
     setConversationId(null);
-    setMessages([defaultAssistantMessage]);
+    setMessages([openingMessage]);
     setSummary(null);
     setError(null);
     setPendingMessageId(null);

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -284,64 +284,85 @@ export default async function CoachPage({ searchParams }: { searchParams?: { pro
   const contextIncomplete = athleteContext ? isContextIncomplete(athleteContext) : false;
   const missingContextLabels = athleteContext ? getMissingContextLabels(athleteContext) : [];
 
+  const hasBriefingContent =
+    (transitionBriefing && !transitionBriefing.dismissedAt) || weeklyBrief || Boolean(athleteContext);
+
   return (
-    <section className="space-y-6">
-      {/* ── Briefing cards (full width) ──────────────────────────── */}
-      {transitionBriefing && !transitionBriefing.dismissedAt ? (
-        <TransitionBriefingCard briefing={transitionBriefing} />
-      ) : null}
-
-      {weeklyBrief ? (
-        <CoachBriefingCard
-          brief={weeklyBrief}
-          athleteContext={athleteContext}
-          briefingContext={briefingContext}
-        />
-      ) : null}
-
-      {/* ── Week context row (side-by-side on md+) ──────────────── */}
-      {athleteContext ? (
-        <div className="grid gap-4 md:grid-cols-2">
-          <WeeklyCheckinCard weekStart={weekStart} snapshot={athleteContext} />
-
-          <article className="surface p-4">
-            <div className="flex flex-wrap items-start justify-between gap-3">
-              <div>
-                <p className="label">Coaching profile</p>
-                <h2 className="mt-1 text-lg font-semibold">{contextIncomplete ? "Profile needs a few details" : "Profile is ready"}</h2>
-                <p className="mt-1 text-sm text-muted">
-                  {contextIncomplete
-                    ? "Finish a few fields so Coach can personalize advice."
-                    : "Coach has your baseline context for briefing, reviews, and chat."}
-                </p>
-              </div>
-              <Link href="/settings/athlete-context" className={contextIncomplete ? "btn-primary px-3 py-1.5 text-xs" : "border border-[rgba(255,255,255,0.20)] bg-transparent px-3 py-1.5 text-xs text-[rgba(255,255,255,0.7)] rounded-md"}>
-                {contextIncomplete ? "Complete profile" : "Edit profile"}
-              </Link>
-            </div>
-
-            <div className="mt-3 flex flex-wrap gap-2">
-              {contextIncomplete
-                ? missingContextLabels.map((label) => (
-                  <span key={label} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{label}</span>
-                ))
-                : (
-                  <>
-                    {athleteContext.goals.priorityEventName ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.goals.priorityEventName}</span> : null}
-                    {athleteContext.goals.goalType ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.goals.goalType}</span> : null}
-                    {athleteContext.declared.experienceLevel.value ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.declared.experienceLevel.value}</span> : null}
-                    {athleteContext.declared.limiters.slice(0, 2).map((limiter) => (
-                      <span key={limiter.value} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{limiter.value}</span>
-                    ))}
-                  </>
-                )}
-            </div>
-          </article>
-        </div>
-      ) : null}
-
-      {/* ── Chat (bottom of page) ────────────────────────────────── */}
+    <section className="space-y-4">
+      {/* ── Chat-first layout: chat renders above the briefing ──── */}
       <CoachChat diagnosisSessions={diagnosisSessions} briefingContext={briefingContext} initialPrompt={searchParams?.prompt} showBriefingPanel={false} />
+
+      {/* ── Briefing bundle (collapsed by default) ──────────────── */}
+      {hasBriefingContent ? (
+        <details className="surface group rounded-xl">
+          <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3">
+            <div className="min-w-0">
+              <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">This week at a glance</p>
+              <p className="mt-0.5 truncate text-sm text-white">
+                {weeklyBrief?.weekHeadline
+                  ?? (athleteContext?.goals.priorityEventName
+                    ? `Priority: ${athleteContext.goals.priorityEventName}`
+                    : "Open for weekly brief, check-in, and coaching profile")}
+              </p>
+            </div>
+            <span className="text-[11px] text-tertiary transition group-open:hidden">Expand</span>
+            <span className="hidden text-[11px] text-tertiary group-open:inline">Collapse</span>
+          </summary>
+          <div className="space-y-4 px-4 pb-4">
+            {transitionBriefing && !transitionBriefing.dismissedAt ? (
+              <TransitionBriefingCard briefing={transitionBriefing} />
+            ) : null}
+
+            {weeklyBrief ? (
+              <CoachBriefingCard
+                brief={weeklyBrief}
+                athleteContext={athleteContext}
+                briefingContext={briefingContext}
+              />
+            ) : null}
+
+            {athleteContext ? (
+              <div className="grid gap-4 md:grid-cols-2">
+                <WeeklyCheckinCard weekStart={weekStart} snapshot={athleteContext} />
+
+                <article className="surface p-4">
+                  <div className="flex flex-wrap items-start justify-between gap-3">
+                    <div>
+                      <p className="label">Coaching profile</p>
+                      <h2 className="mt-1 text-lg font-semibold">{contextIncomplete ? "Profile needs a few details" : "Profile is ready"}</h2>
+                      <p className="mt-1 text-sm text-muted">
+                        {contextIncomplete
+                          ? "Finish a few fields so Coach can personalize advice."
+                          : "Coach has your baseline context for briefing, reviews, and chat."}
+                      </p>
+                    </div>
+                    <Link href="/settings/athlete-context" className={contextIncomplete ? "btn-primary px-3 py-1.5 text-xs" : "border border-[rgba(255,255,255,0.20)] bg-transparent px-3 py-1.5 text-xs text-[rgba(255,255,255,0.7)] rounded-md"}>
+                      {contextIncomplete ? "Complete profile" : "Edit profile"}
+                    </Link>
+                  </div>
+
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    {contextIncomplete
+                      ? missingContextLabels.map((label) => (
+                        <span key={label} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{label}</span>
+                      ))
+                      : (
+                        <>
+                          {athleteContext.goals.priorityEventName ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.goals.priorityEventName}</span> : null}
+                          {athleteContext.goals.goalType ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.goals.goalType}</span> : null}
+                          {athleteContext.declared.experienceLevel.value ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.declared.experienceLevel.value}</span> : null}
+                          {athleteContext.declared.limiters.slice(0, 2).map((limiter) => (
+                            <span key={limiter.value} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{limiter.value}</span>
+                          ))}
+                        </>
+                      )}
+                  </div>
+                </article>
+              </div>
+            ) : null}
+          </div>
+        </details>
+      ) : null}
     </section>
   );
 }

--- a/app/(protected)/dashboard/components/training-score-card.tsx
+++ b/app/(protected)/dashboard/components/training-score-card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useState } from "react";
 import type { TrainingScore } from "@/lib/training/scoring";
 
 type Props = {
@@ -31,7 +30,6 @@ function getDeltaClass(delta: number | null): string {
 }
 
 export function TrainingScoreCard({ score }: Props) {
-  const [expanded, setExpanded] = useState(false);
   const ringPct = Math.max(0, Math.min(100, score.compositeScore));
   const circumference = 2 * Math.PI * 40;
   const strokeDashoffset = circumference - (ringPct / 100) * circumference;
@@ -81,14 +79,68 @@ export function TrainingScoreCard({ score }: Props) {
         ) : null}
       </div>
 
-      {/* Actions */}
-      <div className="mt-3 flex items-center justify-center gap-3">
-        <button
-          onClick={() => setExpanded(!expanded)}
-          className="text-[11px] font-medium text-tertiary transition hover:text-white"
-        >
-          {expanded ? "Hide details" : "What affects this?"}
-        </button>
+      {/* Inline component breakdown — always visible */}
+      <div className="mt-3 grid grid-cols-3 gap-2 border-t border-[rgba(255,255,255,0.08)] pt-3">
+        <div className="flex flex-col items-center gap-1">
+          <div className="flex items-center gap-1">
+            <span className="text-[11px]">✓</span>
+            <span className="text-[10px] uppercase tracking-[0.08em] text-tertiary">Execution</span>
+          </div>
+          <span className="text-sm font-semibold text-white">
+            {score.executionQuality !== null ? Math.round(score.executionQuality) : "—"}
+          </span>
+          <div className="h-1 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+            <div
+              className="h-full rounded-full bg-white/60"
+              style={{ width: `${score.executionQuality ?? 0}%` }}
+            />
+          </div>
+        </div>
+
+        <div className="flex flex-col items-center gap-1">
+          <div className="flex items-center gap-1">
+            <span className="text-[11px]">↗</span>
+            <span className="text-[10px] uppercase tracking-[0.08em] text-tertiary">Progression</span>
+          </div>
+          {score.progressionActive ? (
+            <>
+              <span className="text-sm font-semibold text-white">
+                {score.progressionSignal !== null ? Math.round(score.progressionSignal) : "—"}
+              </span>
+              <div className="h-1 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                <div
+                  className="h-full rounded-full bg-white/60"
+                  style={{ width: `${score.progressionSignal ?? 0}%` }}
+                />
+              </div>
+            </>
+          ) : (
+            <>
+              <span className="text-sm font-semibold text-tertiary">—</span>
+              <span className="text-[9px] text-tertiary">Building</span>
+            </>
+          )}
+        </div>
+
+        <div className="flex flex-col items-center gap-1">
+          <div className="flex items-center gap-1">
+            <span className="text-[11px]">⚖</span>
+            <span className="text-[10px] uppercase tracking-[0.08em] text-tertiary">Balance</span>
+          </div>
+          <span className="text-sm font-semibold text-white">
+            {score.balanceScore !== null ? Math.round(score.balanceScore) : "—"}
+          </span>
+          <div className="h-1 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+            <div
+              className="h-full rounded-full bg-white/60"
+              style={{ width: `${score.balanceScore ?? 0}%` }}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Coach hand-off */}
+      <div className="mt-3 flex items-center justify-center">
         <a
           href={`/coach?prompt=${encodeURIComponent(`Explain my training score of ${Math.round(score.compositeScore)}. What's driving each dimension and what should I focus on to improve it?`)}`}
           className="text-[11px] font-medium text-cyan-400 transition hover:text-cyan-300"
@@ -96,73 +148,6 @@ export function TrainingScoreCard({ score }: Props) {
           Explain my score
         </a>
       </div>
-
-      {expanded ? (
-        <div className="mt-3 space-y-2 border-t border-[rgba(255,255,255,0.08)] pt-3">
-          {/* Execution Quality */}
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <span className="text-[13px]">✓</span>
-              <span className="text-xs text-muted">Execution</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                <div
-                  className="h-full rounded-full bg-white/60"
-                  style={{ width: `${score.executionQuality ?? 0}%` }}
-                />
-              </div>
-              <span className="w-8 text-right text-xs font-medium text-white">
-                {score.executionQuality !== null ? Math.round(score.executionQuality) : "—"}
-              </span>
-            </div>
-          </div>
-
-          {/* Progression Signal */}
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <span className="text-[13px]">↗</span>
-              <span className="text-xs text-muted">Progression</span>
-            </div>
-            <div className="flex items-center gap-2">
-              {score.progressionActive ? (
-                <>
-                  <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                    <div
-                      className="h-full rounded-full bg-white/60"
-                      style={{ width: `${score.progressionSignal ?? 0}%` }}
-                    />
-                  </div>
-                  <span className="w-8 text-right text-xs font-medium text-white">
-                    {score.progressionSignal !== null ? Math.round(score.progressionSignal) : "—"}
-                  </span>
-                </>
-              ) : (
-                <span className="text-xs text-tertiary">Building...</span>
-              )}
-            </div>
-          </div>
-
-          {/* Balance Score */}
-          <div className="flex items-center justify-between gap-3">
-            <div className="flex items-center gap-2">
-              <span className="text-[13px]">⚖</span>
-              <span className="text-xs text-muted">Balance</span>
-            </div>
-            <div className="flex items-center gap-2">
-              <div className="h-1.5 w-16 overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                <div
-                  className="h-full rounded-full bg-white/60"
-                  style={{ width: `${score.balanceScore ?? 0}%` }}
-                />
-              </div>
-              <span className="w-8 text-right text-xs font-medium text-white">
-                {score.balanceScore !== null ? Math.round(score.balanceScore) : "—"}
-              </span>
-            </div>
-          </div>
-        </div>
-      ) : null}
     </article>
   );
 }

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -26,6 +26,7 @@ import { DisciplineBalanceCompact } from "./components/discipline-balance-compac
 import { getLatestFitness, getReadinessState, getTsbTrend } from "@/lib/training/fitness-model";
 import { computeWeeklyDisciplineBalance, detectDisciplineImbalance } from "@/lib/training/discipline-balance";
 import { detectTrends } from "@/lib/training/trends";
+import { detectCrossDisciplineFatigue, type FatigueSignal } from "@/lib/training/fatigue-detection";
 import { getWeekTransitionBriefing, generateWeekTransitionBriefing } from "@/lib/training/week-transition";
 import { getOrGenerateMorningBrief, type MorningBrief } from "@/lib/training/morning-brief";
 import { MondayTransitionFlow } from "./components/monday-transition-flow";
@@ -366,8 +367,13 @@ export default async function DashboardPage({
   const behindByMinutes = Math.max(Math.round((expectedByTodayPct / 100) * totals.planned) - totals.completed, 0);
   // Only surface "behind" when there is genuinely remaining or overdue work.  A back-loaded week can
   // look "behind pace" even when every session through today is done — suppress the alert in that case.
+  // Also suppress on planned rest days: the Morning Brief already covers "take it fully" and the
+  // "behind" framing is misleading when today was never supposed to contain work.
   const todayHasRemainingWork = dailyStates.find((d) => d.iso === todayIso)?.tone === "today-remaining";
-  const behindAlertActive = behindByMinutes >= 30 && (missedSessionsCount > 0 || todayHasRemainingWork);
+  const behindAlertActive =
+    behindByMinutes >= 30 &&
+    dashboardMoment !== "rest_day" &&
+    (missedSessionsCount > 0 || todayHasRemainingWork);
 
   const sports = ["swim", "bike", "run", "strength"] as const;
   const biggestGap = sports
@@ -818,13 +824,17 @@ async function DashboardTrends(props: {
   if (!props?.supabase) return null;
   const { supabase, userId } = props;
   let trends: Awaited<ReturnType<typeof detectTrends>> = [];
+  let fatigueSignal: FatigueSignal | null = null;
   try {
-    trends = await detectTrends(supabase, userId);
+    [trends, fatigueSignal] = await Promise.all([
+      detectTrends(supabase, userId),
+      detectCrossDisciplineFatigue(supabase, userId).catch(() => null)
+    ]);
   } catch {
     return null;
   }
-  if (trends.length === 0) return null;
-  return <TrendCards trends={trends} />;
+  if (trends.length === 0 && !fatigueSignal) return null;
+  return <TrendCards trends={trends} fatigueSignal={fatigueSignal} />;
 }
 
 async function DashboardMondayTransition(props: {

--- a/app/(protected)/dashboard/trend-cards.tsx
+++ b/app/(protected)/dashboard/trend-cards.tsx
@@ -1,3 +1,4 @@
+import type { FatigueSignal } from "@/lib/training/fatigue-detection";
 import type { WeeklyTrend } from "@/lib/training/trends";
 import { Sparkline } from "@/lib/ui/sparkline";
 
@@ -28,12 +29,43 @@ const DIRECTION_CLASS: Record<string, string> = {
   stable: "text-muted"
 };
 
-export function TrendCards({ trends }: { trends: WeeklyTrend[] }) {
-  if (trends.length === 0) return null;
+const SPORT_LABEL: Record<string, string> = {
+  run: "run",
+  bike: "bike",
+  swim: "swim"
+};
+
+function formatSports(sports: string[]): string {
+  if (sports.length === 0) return "";
+  if (sports.length === 1) return SPORT_LABEL[sports[0]] ?? sports[0];
+  if (sports.length === 2) return `${SPORT_LABEL[sports[0]] ?? sports[0]} and ${SPORT_LABEL[sports[1]] ?? sports[1]}`;
+  return `${sports.slice(0, -1).map((s) => SPORT_LABEL[s] ?? s).join(", ")}, and ${SPORT_LABEL[sports[sports.length - 1]] ?? sports[sports.length - 1]}`;
+}
+
+export function TrendCards({ trends, fatigueSignal }: { trends: WeeklyTrend[]; fatigueSignal?: FatigueSignal | null }) {
+  if (trends.length === 0 && !fatigueSignal) return null;
 
   return (
     <article className="surface p-4 md:p-5">
       <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Recent trends</p>
+      {fatigueSignal ? (
+        <div
+          className={`mt-3 rounded-xl border p-3 ${
+            fatigueSignal.severity === "alert"
+              ? "border-[hsl(var(--signal-risk))] bg-[hsl(var(--signal-risk)/0.08)]"
+              : "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.08)]"
+          }`}
+        >
+          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-white">
+            Cross-discipline fatigue
+          </p>
+          <p className="mt-1 text-sm text-white">
+            {formatSports(fatigueSignal.sports)} are both trending down over the same window — consider protecting this week&apos;s key session.
+          </p>
+          <p className="mt-1 text-[11px] text-muted">{fatigueSignal.detail}</p>
+        </div>
+      ) : null}
+      {trends.length > 0 ? (
       <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {trends.map((trend) => {
           const sport = METRIC_SPORT[trend.metric] ?? "other";
@@ -63,6 +95,7 @@ export function TrendCards({ trends }: { trends: WeeklyTrend[] }) {
           );
         })}
       </div>
+      ) : null}
     </article>
   );
 }

--- a/app/(protected)/plan/plan-editor.tsx
+++ b/app/(protected)/plan/plan-editor.tsx
@@ -5,6 +5,7 @@ import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { getOptionalSessionRoleLabel, getSessionDisplayName } from "@/lib/training/session";
 import { getSessionIntentLabel } from "@/lib/training/semantics";
 import { computeSessionIntensityProfile, computeWeeklyIntensitySummary, getVisualWeight, type SessionIntensityProfile } from "@/lib/training/intensity-profile";
+import { computeTssFromDuration } from "@/lib/training/load";
 import { IntensityBar } from "./components/intensity-bar";
 import { WeeklyIntensityHeader } from "./components/weekly-intensity-header";
 import {
@@ -536,17 +537,32 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
           </div>
           <div className="flex items-end gap-1.5">
             {(() => {
+              // Estimate per-session stress using the duration+intent heuristic so
+              // a short-hard Thursday is visually comparable to a long-easy Saturday.
+              // Fall back to minutes when no session has a resolvable stress estimate.
+              const sessionStress = (session: Session): number => {
+                const sport = (session.sport ?? "other") as "run" | "bike" | "swim" | "strength";
+                const tss = computeTssFromDuration(session.duration_minutes * 60, sport, session.intent_category ?? null);
+                return tss ?? session.duration_minutes;
+              };
+              const dayStressTotals = weekDays.map((d) => d.sessions.reduce((sum, s) => sum + sessionStress(s), 0));
+              const anyStress = dayStressTotals.some((v) => v > 0);
+              const maxStress = Math.max(...dayStressTotals, 1);
               const maxMinutes = Math.max(...weekDays.map((d) => d.totalMinutes), 1);
-              return weekDays.map((day) => (
+              return weekDays.map((day, dayIndex) => {
+                const dayStress = dayStressTotals[dayIndex];
+                return (
                 <div key={day.iso} className="flex flex-1 flex-col items-center gap-1">
                   <p className="text-[10px] tabular-nums text-tertiary" style={{ visibility: day.totalMinutes > 0 ? "visible" : "hidden" }}>
-                    {day.totalMinutes}
+                    {anyStress ? Math.round(dayStress) : day.totalMinutes}
                   </p>
                   <div className="flex w-full flex-col-reverse overflow-hidden rounded-sm" style={{ height: "48px" }}>
                     {(["swim", "bike", "run", "strength", "other"] as const).map((sport) => {
-                      const mins = day.sessions.filter((s) => s.sport === sport).reduce((sum, s) => sum + s.duration_minutes, 0);
-                      if (!mins) return null;
-                      const heightPct = (mins / maxMinutes) * 100;
+                      const sportSessions = day.sessions.filter((s) => s.sport === sport);
+                      if (sportSessions.length === 0) return null;
+                      const mins = sportSessions.reduce((sum, s) => sum + s.duration_minutes, 0);
+                      const sportStress = sportSessions.reduce((sum, s) => sum + sessionStress(s), 0);
+                      const heightPct = anyStress ? (sportStress / maxStress) * 100 : (mins / maxMinutes) * 100;
                       const colors: Record<string, string> = {
                         swim: "var(--color-swim)",
                         bike: "var(--color-bike)",
@@ -557,7 +573,7 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
                       return (
                         <div
                           key={sport}
-                          title={`${sport} · ${mins} min`}
+                          title={`${sport} · ${mins} min · ~${Math.round(sportStress)} TSS`}
                           style={{ height: `${heightPct}%`, backgroundColor: colors[sport] }}
                         />
                       );
@@ -565,9 +581,11 @@ export function PlanEditor({ plans, weeks, sessions, selectedPlanId, initialWeek
                   </div>
                   <p className="text-[11px] text-tertiary">{day.label}</p>
                 </div>
-              ));
+                );
+              });
             })()}
           </div>
+          <p className="mt-1 text-[10px] text-tertiary">Bar height reflects estimated training stress (TSS) per day, not duration.</p>
         </section>
       ) : null}
 

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
@@ -210,10 +210,12 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
   const [showAllMetrics, setShowAllMetrics] = useState(false);
   const [showExplanation, setShowExplanation] = useState(false);
   const [autoRegenAttempted, setAutoRegenAttempted] = useState(false);
+  const [autoRegenFailed, setAutoRegenFailed] = useState(false);
 
   const fetchVerdict = useCallback(async (regenerate = false) => {
     setLoading(true);
     setError(null);
+    if (regenerate) setAutoRegenFailed(false);
     try {
       const res = await fetch("/api/session-verdicts", {
         method: "POST",
@@ -228,6 +230,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
       setVerdict(data.verdict);
     } catch (err) {
       setError(err instanceof Error ? err.message : "Failed to generate verdict.");
+      if (regenerate) setAutoRegenFailed(true);
     } finally {
       setLoading(false);
     }
@@ -285,6 +288,11 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
   // Stale verdicts auto-regenerate silently (see useEffect above). When regeneration
   // is in flight, show a subtle indicator instead of the stale-data banner.
   const isAutoRegenerating = loading && autoRegenAttempted;
+  const handleRetryAutoRegen = () => {
+    setAutoRegenAttempted(false);
+    setAutoRegenFailed(false);
+    void fetchVerdict(true);
+  };
 
   return (
     <article className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]">
@@ -296,6 +304,14 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
             <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-accent)]" aria-hidden="true" />
             {"Refreshing\u2026"}
           </span>
+        ) : autoRegenFailed && verdict?.stale_reason ? (
+          <button
+            type="button"
+            onClick={handleRetryAutoRegen}
+            className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--warning)/0.35)] bg-[hsl(var(--warning)/0.08)] px-2 py-0.5 text-[11px] text-[hsl(var(--warning))] hover:bg-[hsl(var(--warning)/0.14)]"
+          >
+            Refresh failed — retry
+          </button>
         ) : null}
       </div>
 

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
@@ -89,22 +89,6 @@ type SessionVerdict = {
   stale_reason?: string | null;
 };
 
-function getStaleLabel(reason: string | null | undefined): string | null {
-  if (!reason) return null;
-  switch (reason) {
-    case "feel_updated":
-      return "New feel captured — refresh for updated verdict";
-    case "activity_rematched":
-      return "Activity re-linked — refresh for updated verdict";
-    case "plan_edited":
-      return "Plan updated — refresh for updated verdict";
-    case "prompt_version_bump":
-      return "Coach logic updated — refresh for updated verdict";
-    default:
-      return "New info available — refresh for updated verdict";
-  }
-}
-
 type Props = {
   sessionId: string;
   existingVerdict?: SessionVerdict | null;
@@ -225,6 +209,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
   const [error, setError] = useState<string | null>(null);
   const [showAllMetrics, setShowAllMetrics] = useState(false);
   const [showExplanation, setShowExplanation] = useState(false);
+  const [autoRegenAttempted, setAutoRegenAttempted] = useState(false);
 
   const fetchVerdict = useCallback(async (regenerate = false) => {
     setLoading(true);
@@ -253,6 +238,15 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
       void fetchVerdict();
     }
   }, [verdict, sessionCompleted, loading, error, fetchVerdict]);
+
+  // Auto-regenerate when the verdict is stale (feel captured, activity re-linked,
+  // plan edited, prompt version bumped). Silent refresh — no user-visible button.
+  useEffect(() => {
+    if (!autoRegenAttempted && verdict?.stale_reason && !loading && !error) {
+      setAutoRegenAttempted(true);
+      void fetchVerdict(true);
+    }
+  }, [verdict, autoRegenAttempted, loading, error, fetchVerdict]);
 
   if (!sessionCompleted) return null;
 
@@ -288,44 +282,22 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
   const visibleMetrics = showAllMetrics ? verdict.metric_comparisons : verdict.metric_comparisons.slice(0, 3);
   const hasMoreMetrics = verdict.metric_comparisons.length > 3;
 
-  const staleLabel = getStaleLabel(verdict.stale_reason);
+  // Stale verdicts auto-regenerate silently (see useEffect above). When regeneration
+  // is in flight, show a subtle indicator instead of the stale-data banner.
+  const isAutoRegenerating = loading && autoRegenAttempted;
 
   return (
     <article className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]">
       {/* Header */}
       <div className="flex items-center justify-between px-5 pt-4 pb-0">
         <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Session verdict</p>
-        <div className="flex items-center gap-2">
-          {staleLabel && (
-            <span
-              className="hidden items-center gap-1 rounded-full border border-warning/40 bg-warning/10 px-2.5 py-1 text-[11px] text-warning sm:inline-flex"
-              title={staleLabel}
-            >
-              <svg width="10" height="10" viewBox="0 0 12 12" fill="none" aria-hidden="true">
-                <circle cx="6" cy="6" r="5" stroke="currentColor" strokeWidth="1.5" />
-                <circle cx="6" cy="6" r="1.5" fill="currentColor" />
-              </svg>
-              {staleLabel}
-            </span>
-          )}
-          <button
-            type="button"
-            onClick={() => void fetchVerdict(true)}
-            disabled={loading}
-            className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--border))] px-2.5 py-1 text-xs text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white disabled:opacity-40"
-          >
-            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
-              <path d="M21 2v6h-6" /><path d="M3 12a9 9 0 0 1 15-6.7L21 8" /><path d="M3 22v-6h6" /><path d="M21 12a9 9 0 0 1-15 6.7L3 16" />
-            </svg>
-            {loading ? "Regenerating\u2026" : "Regenerate"}
-          </button>
-        </div>
+        {isAutoRegenerating ? (
+          <span className="inline-flex items-center gap-1.5 text-[11px] text-tertiary">
+            <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-accent)]" aria-hidden="true" />
+            {"Refreshing\u2026"}
+          </span>
+        ) : null}
       </div>
-      {staleLabel && (
-        <div className="px-5 pt-2 sm:hidden">
-          <p className="text-[11px] text-warning">{staleLabel}</p>
-        </div>
-      )}
 
       <div className="divide-y divide-[hsl(var(--border))]">
         {/* Part 1: Purpose Statement */}

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -528,11 +528,17 @@ export default async function SessionReviewPage({ params, searchParams }: { para
   // Training block context from verdict (e.g. "Week 8 of an 8-week Build block, 61 days to Warsaw 70.3")
   const blockContext = existingVerdictData?.training_block_context ?? null;
 
-  // Score confidence qualifier for inline display
+  // Score confidence qualifier for inline display.
+  // Prefer a specific, actionable data-gap line when critical evidence is missing;
+  // otherwise suppress generic hedging when the read is confident.
+  const missingCriticalData = reviewVm.componentScores?.missingCriticalData ?? [];
+  const dataCompletenessPct = reviewVm.componentScores?.dataCompletenessPct ?? 1;
   const confidenceQualifier =
-    reviewVm.confidenceLabel === "low" ? "early read"
-    : reviewVm.confidenceLabel === "medium" ? "moderate confidence"
-    : null;
+    missingCriticalData.length > 0
+      ? `${missingCriticalData[0]} missing`
+      : dataCompletenessPct < 0.6 && reviewVm.confidenceLabel === "low"
+        ? "limited evidence"
+        : null;
 
   // Determine the one-thing callout label — don't say "change" when the advice is "keep doing this"
   // Only treat as "keep doing" when the advice STARTS with maintenance language, not when those
@@ -740,12 +746,66 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         )}
       </section>
 
-      {/* ── Section 4: Compared to Previous ── */}
+      {/* ── Section 4: Score Breakdown (visible by default) ── */}
+      {reviewVm.isReviewable && reviewVm.score !== null && reviewVm.componentScores ? (
+        <article className="surface p-4 md:p-5">
+          <div className="flex items-center justify-between">
+            <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Score breakdown</p>
+            <div className="flex flex-wrap items-center gap-2">
+              {reviewVm.scoreBand ? (
+                <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
+                  {reviewVm.scoreBand}
+                </span>
+              ) : null}
+              {reviewVm.executionCostLabel ? (
+                <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
+                  Execution cost: {reviewVm.executionCostLabel}
+                </span>
+              ) : null}
+            </div>
+          </div>
+          <div className="mt-3 space-y-3">
+            {[
+              { label: "Intent match", weightLabel: "40%", score: reviewVm.componentScores.intentMatch.score, detail: reviewVm.componentScores.intentMatch.detail },
+              { label: "Pacing & execution", weightLabel: "25%", score: reviewVm.componentScores.pacingExecution.score, detail: reviewVm.componentScores.pacingExecution.detail },
+              { label: "Completion", weightLabel: "20%", score: reviewVm.componentScores.completion.score, detail: reviewVm.componentScores.completion.detail },
+              { label: "Recovery compliance", weightLabel: "15%", score: reviewVm.componentScores.recoveryCompliance.score, detail: reviewVm.componentScores.recoveryCompliance.detail }
+            ].map((component) => {
+              const barColor = component.score >= 80 ? "bg-[hsl(var(--success))]"
+                : component.score >= 60 ? "bg-[hsl(var(--warning))]"
+                : component.score >= 40 ? "bg-[hsl(35,100%,50%)]"
+                : "bg-[hsl(var(--signal-risk))]";
+              return (
+                <div key={component.label}>
+                  <div className="flex items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <span className="text-xs font-medium text-white">{component.label}</span>
+                      <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1.5 py-0.5 text-[9px] text-tertiary">{component.weightLabel}</span>
+                    </div>
+                    <span className="text-xs font-mono font-medium text-white">{component.score}</span>
+                  </div>
+                  <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                    <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${component.score}%` }} />
+                  </div>
+                  <p className="mt-1 text-[11px] text-muted">{component.detail}</p>
+                </div>
+              );
+            })}
+          </div>
+          {missingCriticalData.length > 0 ? (
+            <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+              {missingCriticalData[0]} missing — pair the right sensor next time to unlock a confirmed read.
+            </p>
+          ) : null}
+        </article>
+      ) : null}
+
+      {/* ── Section 5: Compared to Previous ── */}
       {sessionComparison ? <SessionComparisonCard comparison={sessionComparison} trends={sessionTrends ?? []} aiComparisons={storedComparisons} sport={session.sport} /> : null}
 
-      {/* ── Section 5: Details + Follow-up (progressive disclosure) ── */}
+      {/* ── Section 6: Details + Follow-up (progressive disclosure) ── */}
 
-      {reviewVm.uncertaintyDetail ? (
+      {reviewVm.uncertaintyDetail && dataCompletenessPct < 0.6 ? (
         <DetailsAccordion title="Data confidence" summaryDetail={
           <span className="text-[11px] text-muted">{reviewVm.uncertaintyTitle ?? "Limited data"}</span>
         }>
@@ -753,68 +813,6 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           {reviewVm.missingEvidence.length > 0 ? (
             <p className="mt-2 text-sm text-muted">Missing: {reviewVm.missingEvidence.join(", ")}.</p>
           ) : null}
-        </DetailsAccordion>
-      ) : null}
-
-      {reviewVm.isReviewable && reviewVm.score !== null ? (
-        <DetailsAccordion
-          title="How is this scored?"
-          summaryDetail={
-            <span className="rounded-full border border-[rgba(190,255,0,0.25)] bg-[rgba(190,255,0,0.08)] px-2.5 py-1 text-[11px] font-medium text-[var(--color-accent)]">
-              {reviewVm.score}/100
-            </span>
-          }
-        >
-          <div className="space-y-3">
-            {reviewVm.componentScores ? (
-              <div className="space-y-3">
-                {[
-                  { label: "Intent match", weightLabel: "40%", score: reviewVm.componentScores.intentMatch.score, detail: reviewVm.componentScores.intentMatch.detail },
-                  { label: "Pacing & execution", weightLabel: "25%", score: reviewVm.componentScores.pacingExecution.score, detail: reviewVm.componentScores.pacingExecution.detail },
-                  { label: "Completion", weightLabel: "20%", score: reviewVm.componentScores.completion.score, detail: reviewVm.componentScores.completion.detail },
-                  { label: "Recovery compliance", weightLabel: "15%", score: reviewVm.componentScores.recoveryCompliance.score, detail: reviewVm.componentScores.recoveryCompliance.detail }
-                ].map((component) => {
-                  const barColor = component.score >= 80 ? "bg-[hsl(var(--success))]"
-                    : component.score >= 60 ? "bg-[hsl(var(--warning))]"
-                    : component.score >= 40 ? "bg-[hsl(35,100%,50%)]"
-                    : "bg-[hsl(var(--signal-risk))]";
-                  return (
-                    <div key={component.label}>
-                      <div className="flex items-center justify-between gap-2">
-                        <div className="flex items-center gap-2">
-                          <span className="text-xs font-medium text-white">{component.label}</span>
-                          <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1.5 py-0.5 text-[9px] text-tertiary">{component.weightLabel}</span>
-                        </div>
-                        <span className="text-xs font-mono font-medium text-white">{component.score}</span>
-                      </div>
-                      <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                        <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${component.score}%` }} />
-                      </div>
-                      <p className="mt-1 text-[11px] text-muted">{component.detail}</p>
-                    </div>
-                  );
-                })}
-              </div>
-            ) : (
-              <p className="text-xs text-muted">
-                Execution scores compare what actually happened against what was planned —
-                across duration, intensity, intent alignment, and consistency. A higher score means the
-                session delivered the intended training stimulus.
-              </p>
-            )}
-            <div className="flex flex-wrap gap-2">
-              {reviewVm.scoreBand ? (
-                <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-[11px] text-muted">
-                  Band: {reviewVm.scoreBand}
-                </span>
-              ) : null}
-              {reviewVm.executionCostLabel ? (
-                <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-[11px] text-muted">
-                  Execution cost: {reviewVm.executionCostLabel}
-                </span>
-              ) : null}
-            </div>
-          </div>
         </DetailsAccordion>
       ) : null}
 

--- a/lib/agent-preview/data.ts
+++ b/lib/agent-preview/data.ts
@@ -418,7 +418,7 @@ export function createPreviewDatabase(): PreviewDatabase {
           executionScoreBand: "On target",
           executionScoreSummary: "Power held steady across all three intervals. Cadence consistent at 88rpm.",
           whyItMatters: "Clean FTP work confirms threshold capacity is tracking well for race build.",
-          recommendedNextAction: "Maintain this approach. Same targets next time."
+          recommendedNextAction: "NEXT sweet-spot set: 3×12 min @ 250–260W, 6 min easy between. If average interval power holds ≥255W and cadence stays 88rpm, extend the third rep to 15 min."
         }
       },
       {

--- a/lib/agent-preview/data.ts
+++ b/lib/agent-preview/data.ts
@@ -205,7 +205,16 @@ export function createPreviewDatabase(): PreviewDatabase {
           executionScoreBand: "Partial match",
           executionScoreSummary: "The first two reps landed, but power faded late.",
           whyItMatters: "Late fade reduces the quality of the session's sustained-threshold signal.",
-          recommendedNextAction: "Shorten the final rep slightly or start 5 watts lower to hold form deeper."
+          recommendedNextAction: "NEXT threshold set: 3×12 min @ 245–255W, 6 min easy between. If average interval power holds ≥248W through all three reps, extend the final rep to 14 min.",
+          componentScores: {
+            intentMatch: { score: 70, weight: 0.4, detail: "HR missing — cannot verify cardiovascular load against threshold target." },
+            pacingExecution: { score: 65, weight: 0.25, detail: "Power faded ~6% on the final rep; variability index 1.08." },
+            completion: { score: 85, weight: 0.2, detail: "All three reps completed; total duration matched plan." },
+            recoveryCompliance: { score: 80, weight: 0.15, detail: "TSS within the weekly envelope; next-day session still easy." },
+            composite: 74,
+            dataCompletenessPct: 0.55,
+            missingCriticalData: ["Heart rate"]
+          }
         }
       },
       {
@@ -1672,7 +1681,7 @@ export function createPreviewDatabase(): PreviewDatabase {
 const globalKey = "__tri_preview_database__" as const;
 const globalVersionKey = "__tri_preview_database_version__" as const;
 // Bump this when the seed schema changes (new tables, new columns, etc.)
-const PREVIEW_DATABASE_VERSION = 5;
+const PREVIEW_DATABASE_VERSION = 6;
 
 function getOrCreateDatabase(): PreviewDatabase {
   const existing = (globalThis as Record<string, unknown>)[globalKey] as PreviewDatabase | undefined;

--- a/lib/calendar/day-items.ts
+++ b/lib/calendar/day-items.ts
@@ -18,6 +18,7 @@ type CalendarSessionRecord = {
   execution_result?: { status?: ExecutionResultState | null; summary?: string | null } | null;
   duration_minutes: number | null;
   notes: string | null;
+  target?: string | null;
   created_at: string;
   status?: SessionLifecycleState;
   is_key?: boolean | null;
@@ -64,6 +65,7 @@ export type CalendarDisplayItem = {
   executionResult: { status?: ExecutionResultState | null; summary?: string | null } | null;
   duration: number;
   notes: string | null;
+  target: string | null;
   created_at: string;
   status: SessionLifecycleState;
   linkedActivityCount: number;
@@ -219,6 +221,7 @@ export function buildCalendarDisplayItems(input: {
       executionResult: normalizedSession.executionResult,
       duration: normalizedSession.durationMinutes,
       notes: session.notes,
+      target: session.target ?? null,
       created_at: session.created_at,
       status: linked.length > 0 ? "completed" : fallbackStatus(session, completionLedger),
       linkedActivityCount: linked.length,
@@ -247,6 +250,7 @@ export function buildCalendarDisplayItems(input: {
       executionResult: null,
       duration: item.duration_min,
       notes: null,
+      target: null,
       created_at: item.created_at,
       status: "unmatched_upload",
       linkedActivityCount: 1,

--- a/lib/coach/instructions.ts
+++ b/lib/coach/instructions.ts
@@ -22,7 +22,7 @@ Core behavior rules:
 - Never lead with duration comparison. Evaluate intensity compliance first, pacing second, duration third.
 - For interval sessions: evaluate interval quality before mentioning whether all reps were completed.
 - For endurance sessions: evaluate intensity compliance before mentioning duration.
-- When a session scores 90+, say "Maintain this approach" rather than listing caveats.
+- For every session (including 90+ scores), give a concrete NEXT-format prescription: restate the numeric target (pace, HR cap, interval structure) and add a progression trigger (e.g. "if HR holds, extend by 10 min next time"). Never fall back to "maintain this approach".
 - When get_training_load returns fatigue signals, lead with the fatigue finding and recommend a concrete decision: reduce volume, swap a key session for recovery, or take a rest day. Do not bury fatigue warnings at the end of a response.
 - When get_training_load shows discipline imbalance, name the over/under sport and suggest a specific rebalancing action for the coming week.
 - When readiness is "overreaching" or "fatigued", adopt a protective stance: recommend recovery before adding load. When readiness is "fresh", encourage the athlete to push key sessions.

--- a/lib/coach/session-diagnosis.test.ts
+++ b/lib/coach/session-diagnosis.test.ts
@@ -318,6 +318,29 @@ describe("diagnoseCompletedSession", () => {
     expect(cs.composite).toBeLessThan(90);
   });
 
+  test("threshold run with pace-only target is not flagged as missing intensity", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "run",
+        intentCategory: "Threshold intervals",
+        plannedDurationSec: 3000,
+        plannedIntervals: 3,
+        targetBands: { pace: { min: 240, max: 255 } }
+      },
+      actual: {
+        durationSec: 3000,
+        avgPaceSPerKm: 248,
+        completedIntervals: 3
+      }
+    });
+
+    expect(diagnosis.componentScores).not.toBeNull();
+    const cs = diagnosis.componentScores!;
+    expect(cs.missingCriticalData).not.toContain("HR data");
+    expect(cs.missingCriticalData).toEqual([]);
+    expect(cs.intentMatch.score).toBeGreaterThanOrEqual(90);
+  });
+
   test("full-telemetry easy run keeps intent match high and has no missing critical data", () => {
     const diagnosis = diagnoseCompletedSession({
       planned: {

--- a/lib/coach/session-diagnosis.test.ts
+++ b/lib/coach/session-diagnosis.test.ts
@@ -271,4 +271,72 @@ describe("diagnoseCompletedSession", () => {
     // 245 > 220*1.06 = 233.2 → should flag over_target
     expect(diagnosis.detectedIssues).toContain("over_target");
   });
+
+  test("caps intent match when critical sensor data is missing (bike ride without HR)", () => {
+    // Bike easy ride with duration completion but NO HR (strap missing) and NO power meter.
+    // Has target HR range defined, but no actual HR to compare. Only duration + pace signals.
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "bike",
+        intentCategory: "Easy Z2 spin",
+        plannedDurationSec: 3600,
+        targetBands: { hr: { max: 145 } }
+      },
+      actual: {
+        durationSec: 3600,
+        timeAboveTargetPct: 0.05
+      }
+    });
+
+    expect(diagnosis.componentScores).not.toBeNull();
+    const cs = diagnosis.componentScores!;
+    // timeAboveTargetPct covers intensity for easy_endurance, so HR alone isn't the only signal.
+    // Full critical coverage for easy_endurance needs intensity + duration — both present here.
+    expect(cs.dataCompletenessPct).toBe(1);
+  });
+
+  test("caps intent match for long endurance without split metrics or intensity", () => {
+    // Long endurance needs duration + intensity + splits. Only duration present here.
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "bike",
+        intentCategory: "Long endurance ride",
+        plannedDurationSec: 10800
+      },
+      actual: {
+        durationSec: 10500,
+        timeAboveTargetPct: 0.05
+      }
+    });
+
+    expect(diagnosis.componentScores).not.toBeNull();
+    const cs = diagnosis.componentScores!;
+    expect(cs.missingCriticalData.length).toBeGreaterThan(0);
+    expect(cs.dataCompletenessPct).toBeLessThan(1);
+    expect(cs.intentMatch.score).toBeLessThanOrEqual(78);
+    // Composite should reflect the incompleteness — can't hit 90+ without the critical evidence.
+    expect(cs.composite).toBeLessThan(90);
+  });
+
+  test("full-telemetry easy run keeps intent match high and has no missing critical data", () => {
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "run",
+        intentCategory: "Easy Z2 run",
+        plannedDurationSec: 3600,
+        targetBands: { hr: { max: 145 } }
+      },
+      actual: {
+        durationSec: 3600,
+        avgHr: 140,
+        timeAboveTargetPct: 0.02
+      }
+    });
+
+    expect(diagnosis.componentScores).not.toBeNull();
+    const cs = diagnosis.componentScores!;
+    expect(cs.missingCriticalData).toEqual([]);
+    expect(cs.dataCompletenessPct).toBe(1);
+    expect(cs.intentMatch.score).toBeGreaterThanOrEqual(90);
+  });
 });

--- a/lib/coach/session-diagnosis.ts
+++ b/lib/coach/session-diagnosis.ts
@@ -62,6 +62,8 @@ export type ComponentScores = {
   completion: ComponentScore;
   recoveryCompliance: ComponentScore;
   composite: number;
+  dataCompletenessPct: number;
+  missingCriticalData: string[];
 };
 
 export type SessionDiagnosis = {
@@ -446,7 +448,60 @@ function getNextAction(status: IntentMatchStatus, issues: IssueKey[], bucket: In
   return "Use this result as feedback and aim for tighter control against the planned intent next time.";
 }
 
-function computeIntentMatchScore(draft: DiagnosisDraft, bucket: IntentBucket): ComponentScore {
+type DataCompleteness = {
+  pct: number;
+  missingCritical: string[];
+};
+
+function computeDataCompleteness(input: SessionDiagnosisInput, bucket: IntentBucket): DataCompleteness {
+  const actual = input.actual;
+  const planned = input.planned;
+  const sport = planned.sport ?? "other";
+
+  const hasHr = Boolean((actual.avgHr ?? getMetric(actual, "avg_hr")) && planned.targetBands?.hr);
+  const hasPower = Boolean((actual.avgIntervalPower ?? actual.avgPower ?? getMetric(actual, "avg_power")) && planned.targetBands?.power);
+  const hasPace = Boolean((actual.avgPaceSPerKm ?? getMetric(actual, "avg_pace_s_per_km")) && planned.targetBands?.pace);
+  const hasTimeAbove = typeof actual.timeAboveTargetPct === "number";
+  const hasIntervals = typeof actual.intervalCompletionPct === "number" || Boolean(actual.completedIntervals && planned.plannedIntervals);
+  const hasDuration = Boolean(actual.durationSec && planned.plannedDurationSec);
+  const hasSplits = Boolean(actual.splitMetrics?.firstHalfAvgHr || actual.splitMetrics?.firstHalfPaceSPerKm || actual.splitMetrics?.firstHalfAvgPower);
+
+  const critical: Array<{ key: string; present: boolean; label: string }> = [];
+
+  switch (bucket) {
+    case "easy_endurance":
+    case "recovery":
+      critical.push({ key: "intensity", present: hasHr || hasPower || hasTimeAbove, label: sport === "bike" ? "HR or power" : "HR data" });
+      critical.push({ key: "duration", present: hasDuration, label: "duration tracking" });
+      break;
+    case "threshold_quality":
+      critical.push({ key: "intensity", present: hasHr || hasPower, label: sport === "bike" ? "power or HR" : "HR data" });
+      critical.push({ key: "completion", present: hasIntervals || hasDuration, label: "interval or duration completion" });
+      break;
+    case "long_endurance":
+      critical.push({ key: "duration", present: hasDuration, label: "duration tracking" });
+      critical.push({ key: "intensity", present: hasHr || hasPower, label: sport === "bike" ? "power or HR" : "HR data" });
+      critical.push({ key: "splits", present: hasSplits, label: "split metrics (HR drift or pace fade)" });
+      break;
+    case "swim_strength":
+      critical.push({ key: "completion", present: hasIntervals || hasDuration, label: "interval or duration completion" });
+      break;
+    case "unknown":
+      critical.push({ key: "duration", present: hasDuration, label: "duration tracking" });
+      break;
+  }
+
+  const hasSport = critical.length > 0;
+  if (!hasSport) return { pct: 1, missingCritical: [] };
+
+  const presentCount = critical.filter((c) => c.present).length;
+  const pct = presentCount / critical.length;
+  const missingCritical = critical.filter((c) => !c.present).map((c) => c.label);
+
+  return { pct, missingCritical };
+}
+
+function computeIntentMatchScore(draft: DiagnosisDraft, bucket: IntentBucket, completeness: DataCompleteness): ComponentScore {
   const weight = 0.40;
   let score: number;
   let detail: string;
@@ -467,6 +522,17 @@ function computeIntentMatchScore(draft: DiagnosisDraft, bucket: IntentBucket): C
   if (bucket === "recovery" && draft.issues.includes("too_hard")) {
     score = Math.min(score, 40);
     detail = "Recovery intent was compromised by excessive intensity.";
+  }
+
+  // Data-completeness penalty: when critical evidence is missing, "matched_intent"
+  // reflects the absence of detected issues rather than confirmed success. Cap Intent
+  // Match so composite reflects that uncertainty.
+  if (completeness.missingCritical.length > 0 && draft.status === "matched_intent") {
+    const cap = completeness.pct < 0.5 ? 65 : 78;
+    if (score > cap) {
+      score = cap;
+      detail = `${completeness.missingCritical[0]} missing — cannot confirm intent match without it.`;
+    }
   }
 
   return { score: Math.round(Math.max(0, Math.min(100, score))), weight, detail };
@@ -590,7 +656,8 @@ function computeRecoveryComplianceScore(input: SessionDiagnosisInput, bucket: In
 function computeComponentScores(input: SessionDiagnosisInput, draft: DiagnosisDraft, bucket: IntentBucket): ComponentScores | null {
   if (draft.evidenceCount === 0) return null;
 
-  const intentMatch = computeIntentMatchScore(draft, bucket);
+  const completeness = computeDataCompleteness(input, bucket);
+  const intentMatch = computeIntentMatchScore(draft, bucket, completeness);
   const pacingExecution = computePacingExecutionScore(input, draft);
   const completion = computeCompletionScore(input, draft);
   const recoveryCompliance = computeRecoveryComplianceScore(input, bucket);
@@ -602,7 +669,15 @@ function computeComponentScores(input: SessionDiagnosisInput, draft: DiagnosisDr
     recoveryCompliance.score * recoveryCompliance.weight
   );
 
-  return { intentMatch, pacingExecution, completion, recoveryCompliance, composite };
+  return {
+    intentMatch,
+    pacingExecution,
+    completion,
+    recoveryCompliance,
+    composite,
+    dataCompletenessPct: completeness.pct,
+    missingCriticalData: completeness.missingCritical
+  };
 }
 
 export function diagnoseCompletedSession(input: SessionDiagnosisInput): SessionDiagnosis {

--- a/lib/coach/session-diagnosis.ts
+++ b/lib/coach/session-diagnosis.ts
@@ -468,19 +468,33 @@ function computeDataCompleteness(input: SessionDiagnosisInput, bucket: IntentBuc
 
   const critical: Array<{ key: string; present: boolean; label: string }> = [];
 
+  const runIntensityPresent = hasHr || hasPower || hasPace || hasTimeAbove;
+  const runIntensityLabel = planned.targetBands?.pace ? "HR or pace data" : "HR data";
   switch (bucket) {
     case "easy_endurance":
     case "recovery":
-      critical.push({ key: "intensity", present: hasHr || hasPower || hasTimeAbove, label: sport === "bike" ? "HR or power" : "HR data" });
+      critical.push({
+        key: "intensity",
+        present: sport === "run" ? runIntensityPresent : hasHr || hasPower || hasTimeAbove,
+        label: sport === "bike" ? "HR or power" : sport === "run" ? runIntensityLabel : "HR data"
+      });
       critical.push({ key: "duration", present: hasDuration, label: "duration tracking" });
       break;
     case "threshold_quality":
-      critical.push({ key: "intensity", present: hasHr || hasPower, label: sport === "bike" ? "power or HR" : "HR data" });
+      critical.push({
+        key: "intensity",
+        present: sport === "run" ? hasHr || hasPower || hasPace : hasHr || hasPower,
+        label: sport === "bike" ? "power or HR" : sport === "run" ? runIntensityLabel : "HR data"
+      });
       critical.push({ key: "completion", present: hasIntervals || hasDuration, label: "interval or duration completion" });
       break;
     case "long_endurance":
       critical.push({ key: "duration", present: hasDuration, label: "duration tracking" });
-      critical.push({ key: "intensity", present: hasHr || hasPower, label: sport === "bike" ? "power or HR" : "HR data" });
+      critical.push({
+        key: "intensity",
+        present: sport === "run" ? hasHr || hasPower || hasPace : hasHr || hasPower,
+        label: sport === "bike" ? "power or HR" : sport === "run" ? runIntensityLabel : "HR data"
+      });
       critical.push({ key: "splits", present: hasSplits, label: "split metrics (HR drift or pace fade)" });
       break;
     case "swim_strength":

--- a/lib/execution-review-persistence.ts
+++ b/lib/execution-review-persistence.ts
@@ -1,5 +1,6 @@
 import type { SupabaseClient } from "@supabase/supabase-js";
 import type { AthleteContextSnapshot } from "@/lib/athlete-context";
+import type { ComponentScores } from "@/lib/coach/session-diagnosis";
 import type {
   ExecutionEvidence,
   CoachVerdict,
@@ -70,6 +71,7 @@ export function toPersistedExecutionReview(args: {
   narrativeSource?: "ai" | "fallback" | "legacy_unknown";
   createdAt?: string;
   updatedAt?: string;
+  componentScores?: ComponentScores | null;
 }): PersistedExecutionReview {
   const createdAt = args.createdAt ?? new Date().toISOString();
   const updatedAt = args.updatedAt ?? createdAt;
@@ -140,7 +142,8 @@ export function toPersistedExecutionReview(args: {
     firstHalfStrokeRate: args.evidence.actual.splitMetrics?.firstHalfStrokeRate ?? null,
     lastHalfStrokeRate: args.evidence.actual.splitMetrics?.lastHalfStrokeRate ?? null,
     executionCost: args.evidence.rulesSummary.executionCost,
-    missingEvidence: args.evidence.missingEvidence
+    missingEvidence: args.evidence.missingEvidence,
+    componentScores: args.componentScores ?? null
   };
 }
 

--- a/lib/execution-review-types.ts
+++ b/lib/execution-review-types.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import type { Sport } from "@/lib/coach/session-diagnosis";
+import type { ComponentScores, Sport } from "@/lib/coach/session-diagnosis";
 
 export type ExecutionEvidence = {
   sessionId: string;
@@ -255,6 +255,7 @@ export type PersistedExecutionReview = {
   lastHalfStrokeRate?: number | null;
   executionCost: "low" | "moderate" | "high" | "unknown";
   missingEvidence: string[];
+  componentScores?: ComponentScores | null;
 };
 
 export const coachVerdictSchema = z.object({

--- a/lib/execution-review.ts
+++ b/lib/execution-review.ts
@@ -428,8 +428,8 @@ function buildCoachVerdictInstructions() {
     "- Never lead with duration comparison. Evaluate intensity compliance first, pacing second, duration third.",
     "- For interval sessions: evaluate interval quality before mentioning whether all were completed.",
     "- For endurance sessions: evaluate intensity compliance before mentioning duration.",
-    "- For 90+ scores: say 'Maintain this approach. Same targets next time.' in oneThingToChange.",
-    "- For scores below 90: use the NEXT format: 'NEXT [session type]: [specific target]. [success criterion]. [progression cue].'",
+    "- Always use the NEXT format for oneThingToChange, regardless of score: 'NEXT [session type]: [specific target with numbers]. [success criterion]. [progression cue if criterion met].'",
+    "- For 90+ scores, still restate the numeric target (pace ceiling, HR cap, interval structure) and add a progression trigger (e.g. 'if HR holds, extend by 10 min next time').",
     "- Do not use words like 'appears', 'seems', 'might', 'possibly', 'likely'. State what the data shows.",
     "",
     "Field requirements:",
@@ -520,7 +520,7 @@ function buildDeterministicVerdict(evidence: ExecutionEvidence): CoachVerdict {
           : "When execution drifts, the session can stop delivering the precise stimulus the week depends on.",
       oneThingToChange:
         intentMatch === "on_target"
-          ? "Maintain this approach. Same targets next time."
+          ? `NEXT ${evidence.planned.intentCategory ?? "session"}: hold the same targets. If it still feels controlled, progress duration by ~10% or tighten the interval structure next time.`
           : intentMatch === "missed"
             ? `NEXT ${evidence.planned.intentCategory ?? "session"}: start more conservatively and protect the key work before adding intensity.`
             : `NEXT ${evidence.planned.intentCategory ?? "session"}: tighten control earlier in the session.`,

--- a/lib/session-review.ts
+++ b/lib/session-review.ts
@@ -240,13 +240,13 @@ function toReviewState(status: string | null | undefined, diagnosis: Record<stri
 
 function deriveOneThingToChange(
   componentScores: ComponentScores | null,
-  scoreBand: ScoreBand | null,
+  _scoreBand: ScoreBand | null,
   aiNextAction: string | null,
-  verdictAdaptationType?: string | null
+  _verdictAdaptationType?: string | null
 ): string | null {
-  // If the verdict says modifications/redistribution are needed, prefer the AI action over "keep doing"
-  const verdictSuggestsChange = verdictAdaptationType && verdictAdaptationType !== "proceed";
-
+  // Unified prescription: always emit a concrete NEXT-format instruction,
+  // regardless of band. High scores still get the worst-component detail so
+  // the athlete knows what to hold and what to progress.
   if (componentScores) {
     const components = [
       { key: "intentMatch" as const, label: "intensity target", score: componentScores.intentMatch.score, detail: componentScores.intentMatch.detail },
@@ -255,12 +255,16 @@ function deriveOneThingToChange(
       { key: "recoveryCompliance" as const, label: "recovery discipline", score: componentScores.recoveryCompliance.score, detail: componentScores.recoveryCompliance.detail }
     ];
     const worst = components.reduce((a, b) => (a.score <= b.score ? a : b));
+    // Below 80: weakest component is the bottleneck — use its detail.
+    // 80+: prefer the AI next action (it can incorporate numeric targets);
+    // fall back to the worst component's detail so we always say something.
     if (worst.score < 80) {
       return sanitizeFieldNames(`NEXT ${worst.label}: ${worst.detail}`);
     }
-  }
-  if ((scoreBand === "On target" || scoreBand === "Solid") && !verdictSuggestsChange) {
-    return "Maintain this approach. Same targets next time.";
+    if (aiNextAction) {
+      return sanitizeFieldNames(aiNextAction);
+    }
+    return sanitizeFieldNames(`NEXT ${worst.label}: ${worst.detail}`);
   }
   return aiNextAction ? sanitizeFieldNames(aiNextAction) : null;
 }

--- a/lib/workouts/session-execution.ts
+++ b/lib/workouts/session-execution.ts
@@ -486,6 +486,7 @@ export function buildExecutionResultForSession(session: SessionExecutionSessionR
   return toPersistedExecutionReview({
     linkedActivityId: activity.id,
     evidence,
+    componentScores: diagnosis.componentScores,
     narrativeSource: "fallback",
     verdict: {
       sessionVerdict: {
@@ -566,7 +567,7 @@ export async function syncSessionExecutionFromActivityLink(args: {
   } catch {
     athleteContext = null;
   }
-  const { evidence } = buildExecutionEvidence({
+  const { diagnosis, evidence } = buildExecutionEvidence({
     athleteId: session.athlete_id ?? args.userId,
     sessionId: session.id,
     sessionTitle: session.session_name ?? session.type,
@@ -583,6 +584,7 @@ export async function syncSessionExecutionFromActivityLink(args: {
   const executionResult = toPersistedExecutionReview({
     linkedActivityId: activity.id,
     evidence,
+    componentScores: diagnosis.componentScores,
     verdict: generated.verdict,
     narrativeSource: generated.source
   });
@@ -863,7 +865,7 @@ export async function syncExtraActivityExecution(args: {
   }
 
   const intentSource = args.intentOverride ? "User override" : "Inferred intent";
-  const { evidence } = buildExecutionEvidence({
+  const { diagnosis, evidence } = buildExecutionEvidence({
     athleteId: args.userId,
     sessionId: syntheticSession.id,
     sessionTitle: "Extra workout",
@@ -877,6 +879,7 @@ export async function syncExtraActivityExecution(args: {
   const executionResult = toPersistedExecutionReview({
     linkedActivityId: activity.id,
     evidence,
+    componentScores: diagnosis.componentScores,
     verdict: generated.verdict,
     narrativeSource: generated.source
   });


### PR DESCRIPTION
Across six chunks addressing the UX review findings:

- Session Review: penalize Intent Match when critical sensor data is
  missing, surface the four component scores inline on the review page,
  and only show a data-confidence line when completeness drops below 60%.
- Session Review: auto-regenerate the verdict when a feel is captured;
  remove "Maintain this approach. Same targets next time." in favor of a
  unified NEXT-format prescription that restates numeric targets and a
  progression trigger for every band, including 90+.
- Dashboard: render the Execution / Progression / Balance strip inline on
  the training score card (no expand gate), wire
  detectCrossDisciplineFatigue() above the trend cards, and suppress the
  "behind this week" alert on planned rest days.
- Calendar: render role pills for all roles (key/support/recovery/optional),
  extract a pace/power/HR target line from session notes, and extend the
  block header to "Week N of M".
- Plan: scale Daily Load Shape bar heights by estimated TSS rather than
  duration minutes so short-hard days are visually comparable to long-easy
  days.
- Coach: collapse the briefing stack behind a single details disclosure
  and render chat above it; replace the hardcoded opening with a
  state-derived message based on reviewed-session counts and the latest
  scored session.

https://claude.ai/code/session_01NYPQ1wgs3mZERPK7YmWPEu