### PR TITLE
Address PR #263 review: scoring, dashboard, and calendar follow-ups

### DIFF
--- a/app/(protected)/calendar/components/coach-note-card.tsx
+++ b/app/(protected)/calendar/components/coach-note-card.tsx
@@ -47,8 +47,27 @@ const TRIGGER_COLORS: Record<string, { bg: string; border: string; text: string 
   default: { bg: "rgba(255,255,255,0.04)", border: "rgba(255,255,255,0.15)", text: "rgba(255,255,255,0.7)" }
 };
 
-function SingleCoachNote({ rationale }: { rationale: AdaptationRationale }) {
-  const [expanded, setExpanded] = useState(false);
+/**
+ * Summarize a multi-sentence rationale into a single coach-note headline:
+ * - First sentence, capped at 140 characters
+ * - If no sentence break, first 140 chars with ellipsis
+ */
+function summarizeRationale(text: string): { summary: string; hasMore: boolean } {
+  const cleaned = text.trim();
+  if (cleaned.length === 0) return { summary: "", hasMore: false };
+  const sentenceMatch = cleaned.match(/^[^.!?\n]+[.!?]/);
+  if (sentenceMatch) {
+    const first = sentenceMatch[0].trim();
+    if (first.length <= 140) {
+      return { summary: first, hasMore: cleaned.length > first.length };
+    }
+  }
+  if (cleaned.length <= 140) return { summary: cleaned, hasMore: false };
+  return { summary: `${cleaned.slice(0, 137).trimEnd()}…`, hasMore: true };
+}
+
+function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: AdaptationRationale; defaultCollapsed?: boolean }) {
+  const [expanded, setExpanded] = useState(!defaultCollapsed);
   const [acknowledging, setAcknowledging] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
@@ -58,6 +77,8 @@ function SingleCoachNote({ rationale }: { rationale: AdaptationRationale }) {
   const colors = TRIGGER_COLORS[rationale.trigger_type] ?? TRIGGER_COLORS.default;
   const changes = Array.isArray(rationale.changes_summary) ? rationale.changes_summary : [];
   const preserved = rationale.preserved_elements ?? [];
+  const { summary: summaryLine, hasMore } = summarizeRationale(rationale.rationale_text);
+  const canCollapse = hasMore || changes.length > 0 || preserved.length > 0;
 
   async function handleAcknowledge() {
     setAcknowledging(true);
@@ -89,18 +110,21 @@ function SingleCoachNote({ rationale }: { rationale: AdaptationRationale }) {
         </div>
       </div>
 
-      <p className="mt-2 text-sm text-white">{rationale.rationale_text}</p>
+      <p className="mt-2 text-sm text-white">
+        {expanded ? rationale.rationale_text : summaryLine}
+      </p>
 
-      {/* Expandable details */}
-      <button
-        type="button"
-        onClick={() => setExpanded(!expanded)}
-        className="mt-2 text-xs text-tertiary hover:text-white"
-      >
-        {expanded ? "Hide details" : "Why?"}
-      </button>
+      {canCollapse ? (
+        <button
+          type="button"
+          onClick={() => setExpanded(!expanded)}
+          className="mt-2 text-xs text-tertiary hover:text-white"
+        >
+          {expanded ? "Show less" : "Show full reasoning"}
+        </button>
+      ) : null}
 
-      {expanded && (
+      {expanded && (changes.length > 0 || preserved.length > 0) && (
         <div className="mt-3 space-y-3 rounded-lg bg-[rgba(0,0,0,0.2)] p-3">
           {changes.length > 0 && (
             <div>

--- a/app/(protected)/calendar/components/coach-note-card.tsx
+++ b/app/(protected)/calendar/components/coach-note-card.tsx
@@ -27,7 +27,17 @@ type Props = {
   rationales: AdaptationRationale[];
 };
 
-const TRIGGER_LABELS: Record<string, string> = {
+type TriggerType =
+  | "recovery_signal"
+  | "missed_session"
+  | "load_rebalance"
+  | "cross_discipline"
+  | "feel_based"
+  | "block_transition"
+  | "athlete_request"
+  | "schedule_change";
+
+const TRIGGER_LABELS: Record<TriggerType, string> = {
   recovery_signal: "Recovery adjustment",
   missed_session: "Missed session",
   load_rebalance: "Load rebalance",
@@ -38,13 +48,18 @@ const TRIGGER_LABELS: Record<string, string> = {
   schedule_change: "Schedule change"
 };
 
-const TRIGGER_COLORS: Record<string, { bg: string; border: string; text: string }> = {
+type TriggerColors = { bg: string; border: string; text: string };
+const DEFAULT_TRIGGER_COLORS: TriggerColors = {
+  bg: "rgba(255,255,255,0.04)",
+  border: "rgba(255,255,255,0.15)",
+  text: "rgba(255,255,255,0.7)"
+};
+const TRIGGER_COLORS: Partial<Record<TriggerType, TriggerColors>> = {
   recovery_signal: { bg: "rgba(251,191,36,0.08)", border: "rgba(251,191,36,0.3)", text: "rgb(251,191,36)" },
   missed_session: { bg: "rgba(248,113,113,0.08)", border: "rgba(248,113,113,0.3)", text: "rgb(248,113,113)" },
   load_rebalance: { bg: "rgba(99,179,237,0.08)", border: "rgba(99,179,237,0.3)", text: "rgb(99,179,237)" },
   feel_based: { bg: "rgba(167,139,250,0.08)", border: "rgba(167,139,250,0.3)", text: "rgb(167,139,250)" },
-  block_transition: { bg: "rgba(52,211,153,0.08)", border: "rgba(52,211,153,0.3)", text: "rgb(52,211,153)" },
-  default: { bg: "rgba(255,255,255,0.04)", border: "rgba(255,255,255,0.15)", text: "rgba(255,255,255,0.7)" }
+  block_transition: { bg: "rgba(52,211,153,0.08)", border: "rgba(52,211,153,0.3)", text: "rgb(52,211,153)" }
 };
 
 /**
@@ -73,8 +88,9 @@ function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: Ad
 
   if (dismissed) return null;
 
-  const triggerLabel = TRIGGER_LABELS[rationale.trigger_type] ?? "Plan adjustment";
-  const colors = TRIGGER_COLORS[rationale.trigger_type] ?? TRIGGER_COLORS.default;
+  const triggerType = rationale.trigger_type as TriggerType;
+  const triggerLabel = TRIGGER_LABELS[triggerType] ?? "Plan adjustment";
+  const colors = TRIGGER_COLORS[triggerType] ?? DEFAULT_TRIGGER_COLORS;
   const changes = Array.isArray(rationale.changes_summary) ? rationale.changes_summary : [];
   const preserved = rationale.preserved_elements ?? [];
   const { summary: summaryLine, hasMore } = summarizeRationale(rationale.rationale_text);

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -144,6 +144,8 @@ const TARGET_PACE_PATTERN = /(\d{1,2}):([0-5]\d)\s*(?:\/(km|mi)|per\s*(km|mi)|mi
 const TARGET_POWER_PATTERN = /(\d{2,4})\s*[-\u2013]\s*(\d{2,4})\s*W\b/i;
 const TARGET_FTP_PCT_PATTERN = /(\d{1,3})\s*[-\u2013]\s*(\d{1,3})\s*%\s*FTP/i;
 const TARGET_SWIM_DISTANCE_PATTERN = /(\d{2,4})\s*m\b/i;
+const TARGET_SWIM_INTERVALS_PATTERN = /(\d+)\s*[x\u00d7]\s*(\d{2,4})\s*m/i;
+const TARGET_INTERVALS_PATTERN = /(\d+)\s*[x\u00d7]\s*(\d{1,2})\s*(?:min|'|\s*minutes?)/i;
 
 function extractTargetLine(session: CalendarSession): string | null {
   const target = session.target?.trim() ?? "";
@@ -156,6 +158,8 @@ function extractTargetLine(session: CalendarSession): string | null {
     if (power) return `${power[1]}–${power[2]} W`;
     const ftp = source.match(TARGET_FTP_PCT_PATTERN);
     if (ftp) return `${ftp[1]}–${ftp[2]}% FTP`;
+    const intervals = source.match(TARGET_INTERVALS_PATTERN);
+    if (intervals) return `${intervals[1]}×${intervals[2]} min`;
   }
   if (sport === "run") {
     const pace = source.match(TARGET_PACE_PATTERN);
@@ -163,8 +167,12 @@ function extractTargetLine(session: CalendarSession): string | null {
       const unit = (pace[3] ?? pace[4] ?? pace[5] ?? "km").toLowerCase();
       return `${Number(pace[1])}:${pace[2]}/${unit}`;
     }
+    const intervals = source.match(TARGET_INTERVALS_PATTERN);
+    if (intervals) return `${intervals[1]}×${intervals[2]} min`;
   }
   if (sport === "swim") {
+    const swimSet = source.match(TARGET_SWIM_INTERVALS_PATTERN);
+    if (swimSet) return `${swimSet[1]}×${swimSet[2]} m`;
     const distance = source.match(TARGET_SWIM_DISTANCE_PATTERN);
     if (distance) return `${distance[1]} m`;
   }
@@ -172,6 +180,14 @@ function extractTargetLine(session: CalendarSession): string | null {
   if (hrRange) return `HR ${hrRange[1]}–${hrRange[2]}`;
   const hrCap = source.match(TARGET_HR_CAP_PATTERN);
   if (hrCap) return `HR ≤ ${hrCap[1]}`;
+  // Fallback: when no structured target can be parsed, show the raw target string
+  // (trimmed to a one-line excerpt) so the calendar card still conveys "what + why"
+  // instead of just "45 min".
+  if (target) {
+    const firstLine = target.split(/\n|\u2022|\|/)[0].trim();
+    if (firstLine && firstLine.length <= 48) return firstLine;
+    if (firstLine) return `${firstLine.slice(0, 44).trimEnd()}…`;
+  }
   return null;
 }
 

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -867,7 +867,7 @@ export function CoachChat({
   }
 
   return (
-    <div className="space-y-5">
+    <div className="space-y-4">
       {showBriefingPanel ? (
         <section className="surface p-5">
           <div className="border-b border-[hsl(var(--border))] pb-4">
@@ -1018,7 +1018,7 @@ export function CoachChat({
           </aside>
 
           <div className="flex min-h-0 flex-col">
-            <div className="border-b border-[hsl(var(--border))] bg-gradient-to-r from-[hsl(var(--surface-1))] to-[hsl(var(--surface-2))] px-3.5 py-2.5">
+            <div className="border-b border-[hsl(var(--border))] bg-gradient-to-r from-[hsl(var(--surface-1))] to-[hsl(var(--surface-2))] px-4 py-2.5">
               <div className="flex flex-wrap items-center justify-between gap-3">
                 <div>
                   <p className="label">Active conversation</p>
@@ -1027,7 +1027,7 @@ export function CoachChat({
                 </div>
               </div>
             </div>
-            <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3.5 py-2">
+            <div className="border-b border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-4 py-2">
               <p className="text-xs text-[hsl(var(--text-secondary))]">
                 {sessionDiagnoses.length > 0
                   ? `${sessionDiagnoses.length} reviewed this week${flaggedSessions.length > 0 ? ` · ${flaggedSessions.length} needing attention` : ""}. Focus: ${nextActions[0] ?? "Stabilise execution quality."}`
@@ -1044,7 +1044,7 @@ export function CoachChat({
                 const distanceToBottom = el.scrollHeight - el.scrollTop - el.clientHeight;
                 shouldAutoScrollRef.current = distanceToBottom < 40;
               }}
-              className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-3.5 py-3"
+              className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-4 py-3"
             >
               {messages.map((message, index) => (
                 <div key={message.id} className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
@@ -1082,7 +1082,7 @@ export function CoachChat({
               ))}
             </div>
 
-            <form onSubmit={handleSubmit} className="border-t border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-2.5 py-2.5">
+            <form onSubmit={handleSubmit} className="border-t border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] px-4 py-2.5">
               <label htmlFor="coach-input" className="sr-only">
                 Ask your triathlon coach
               </label>

--- a/app/(protected)/dashboard/components/readiness-indicator.tsx
+++ b/app/(protected)/dashboard/components/readiness-indicator.tsx
@@ -3,6 +3,9 @@ import type { ReadinessState } from "@/lib/training/fitness-model";
 type Props = {
   readiness: ReadinessState;
   tsb: number;
+  tsbTrend?: "rising" | "stable" | "declining" | null;
+  /** Short contextual clause appended to the cue (e.g. "pace and power both trending down"). */
+  signalContext?: string | null;
 };
 
 const READINESS_CONFIG: Record<ReadinessState, { label: string; color: string; bgColor: string; borderColor: string; cue: string }> = {
@@ -36,27 +39,45 @@ const READINESS_CONFIG: Record<ReadinessState, { label: string; color: string; b
   },
 };
 
-export function ReadinessIndicator({ readiness, tsb }: Props) {
+function trendLabel(trend: Props["tsbTrend"]): string | null {
+  if (trend === "rising") return "TSB rising";
+  if (trend === "declining") return "TSB declining";
+  return null;
+}
+
+export function ReadinessIndicator({ readiness, tsb, tsbTrend, signalContext }: Props) {
   const config = READINESS_CONFIG[readiness];
+  const trendTag = trendLabel(tsbTrend);
+  const cueParts = [config.cue];
+  if (signalContext) cueParts.push(signalContext);
+  const cue = cueParts.join(" — ");
 
   return (
     <article
-      className="rounded-xl border p-3"
+      className="rounded-xl border p-4"
       style={{ borderColor: config.borderColor, backgroundColor: config.bgColor }}
     >
-      <div className="flex items-center gap-2">
-        <span
-          className="inline-block h-2 w-2 rounded-full"
-          style={{ backgroundColor: config.color }}
-        />
-        <span className="text-xs font-medium uppercase tracking-[0.1em]" style={{ color: config.color }}>
-          {config.label}
-        </span>
-        <span className="text-[11px] text-tertiary">
-          TSB {tsb > 0 ? "+" : ""}{Math.round(tsb)}
-        </span>
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <span
+            className="inline-block h-2.5 w-2.5 rounded-full"
+            style={{ backgroundColor: config.color }}
+          />
+          <span className="text-xs font-medium uppercase tracking-[0.12em]" style={{ color: config.color }}>
+            {config.label}
+          </span>
+          <span className="text-[11px] font-mono text-tertiary">
+            TSB {tsb > 0 ? "+" : ""}{Math.round(tsb)}
+          </span>
+          {trendTag ? (
+            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-tertiary">
+              {trendTag}
+            </span>
+          ) : null}
+        </div>
+        <span className="text-[10px] uppercase tracking-[0.12em] text-tertiary">Readiness</span>
       </div>
-      <p className="mt-1.5 text-sm text-[rgba(255,255,255,0.7)]">{config.cue}</p>
+      <p className="mt-2 text-sm text-[rgba(255,255,255,0.78)]">{cue}</p>
     </article>
   );
 }

--- a/app/(protected)/dashboard/components/training-score-card.tsx
+++ b/app/(protected)/dashboard/components/training-score-card.tsx
@@ -29,11 +29,59 @@ function getDeltaClass(delta: number | null): string {
   return delta > 0 ? "text-success" : "text-danger";
 }
 
+type WeakestComponent = {
+  key: "execution" | "progression" | "balance";
+  label: string;
+  value: number;
+  prompt: string;
+  linkLabel: string;
+};
+
+function getWeakestComponent(score: TrainingScore): WeakestComponent | null {
+  const candidates: WeakestComponent[] = [];
+  if (score.executionQuality !== null) {
+    candidates.push({
+      key: "execution",
+      label: "Execution",
+      value: score.executionQuality,
+      prompt: `My Execution score is ${Math.round(score.executionQuality)}. Which recent sessions pulled it down and what should I adjust in how I hit sessions to bring it back up?`,
+      linkLabel: "Why did Execution drop?"
+    });
+  }
+  if (score.progressionActive && score.progressionSignal !== null) {
+    candidates.push({
+      key: "progression",
+      label: "Progression",
+      value: score.progressionSignal,
+      prompt: `My Progression signal is ${Math.round(score.progressionSignal)}. Which disciplines or metrics are flat or regressing over my recent comparable sessions, and what should I change to restart progression?`,
+      linkLabel: "Why is Progression flat?"
+    });
+  }
+  if (score.balanceScore !== null) {
+    candidates.push({
+      key: "balance",
+      label: "Balance",
+      value: score.balanceScore,
+      prompt: `My Balance score is ${Math.round(score.balanceScore)} for a ${score.goalRaceType ?? "triathlon"} goal. Where am I over- or under-invested relative to an ideal distribution, and what should I shift next week?`,
+      linkLabel: "Why is Balance off?"
+    });
+  }
+  if (candidates.length === 0) return null;
+  candidates.sort((a, b) => a.value - b.value);
+  return candidates[0];
+}
+
 export function TrainingScoreCard({ score }: Props) {
   const ringPct = Math.max(0, Math.min(100, score.compositeScore));
   const circumference = 2 * Math.PI * 40;
   const strokeDashoffset = circumference - (ringPct / 100) * circumference;
   const delta7d = getDeltaLabel(score.scoreDelta7d);
+  const weakest = getWeakestComponent(score);
+  const coachPrompt =
+    weakest !== null
+      ? weakest.prompt
+      : `Explain my training score of ${Math.round(score.compositeScore)}. What's driving each dimension and what should I focus on to improve it?`;
+  const coachLabel = weakest !== null ? weakest.linkLabel : "Explain my score";
 
   return (
     <article className="surface p-4 md:p-5">
@@ -142,10 +190,10 @@ export function TrainingScoreCard({ score }: Props) {
       {/* Coach hand-off */}
       <div className="mt-3 flex items-center justify-center">
         <a
-          href={`/coach?prompt=${encodeURIComponent(`Explain my training score of ${Math.round(score.compositeScore)}. What's driving each dimension and what should I focus on to improve it?`)}`}
+          href={`/coach?prompt=${encodeURIComponent(coachPrompt)}`}
           className="text-[11px] font-medium text-cyan-400 transition hover:text-cyan-300"
         >
-          Explain my score
+          {coachLabel}
         </a>
       </div>
     </article>

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -283,7 +283,7 @@ export default async function DashboardPage({
   // Shape-aware expectation: use the actual planned minutes scheduled on or before today,
   // not a flat elapsedDays/7 share. Back-loaded weeks (long run Sat, long bike Sun) should
   // not read as "at risk" on Friday when Mon–Fri's share of the load is genuinely complete.
-  const weekShape = computeWeekShape({ sessions: weekMetricSessions, weekStart, todayIso });
+  const weekShape = computeWeekShape({ sessions: weekMetricSessions, todayIso });
   const expectedByTodayPct = totals.planned > 0
     ? Math.round(weekShape.expectedShareByToday * 100)
     : Math.round((elapsedDays / 7) * 100);

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/lib/activities/completed-activities";
 import { getDisciplineMeta } from "@/lib/ui/discipline";
 import { getSessionDisplayName } from "@/lib/training/session";
-import { computeWeekMinuteTotals } from "@/lib/training/week-metrics";
+import { computeWeekMinuteTotals, computeWeekShape } from "@/lib/training/week-metrics";
 import { getDiagnosisDataState } from "@/lib/ui/sparse-data";
 import { getWeeklyDebriefSnapshot } from "@/lib/weekly-debrief";
 import { addDays, getMonday, weekRangeLabel } from "../week-context";
@@ -280,7 +280,13 @@ export default async function DashboardPage({
   const remainingMinutes = minuteMetrics.remainingMinutes;
   const dayIndex = Math.floor((Date.parse(`${todayIso}T00:00:00.000Z`) - Date.parse(`${weekStart}T00:00:00.000Z`)) / 86_400_000);
   const elapsedDays = Math.max(0, Math.min(dayIndex + 1, 7));
-  const expectedByTodayPct = Math.round((elapsedDays / 7) * 100);
+  // Shape-aware expectation: use the actual planned minutes scheduled on or before today,
+  // not a flat elapsedDays/7 share. Back-loaded weeks (long run Sat, long bike Sun) should
+  // not read as "at risk" on Friday when Mon–Fri's share of the load is genuinely complete.
+  const weekShape = computeWeekShape({ sessions: weekMetricSessions, weekStart, todayIso });
+  const expectedByTodayPct = totals.planned > 0
+    ? Math.round(weekShape.expectedShareByToday * 100)
+    : Math.round((elapsedDays / 7) * 100);
   const statusChip = getStatusChip(completionPct, expectedByTodayPct);
 
   // Determine the dashboard moment for context-aware ordering
@@ -364,15 +370,38 @@ export default async function DashboardPage({
     .filter((session) => session.is_key && session.status === "planned" && session.date < todayIso)
     .sort((a, b) => a.date.localeCompare(b.date))[0] ?? null;
 
-  const behindByMinutes = Math.max(Math.round((expectedByTodayPct / 100) * totals.planned) - totals.completed, 0);
+  const expectedMinutesByToday = totals.planned > 0
+    ? weekShape.expectedShareByToday * totals.planned
+    : (elapsedDays / 7) * totals.planned;
+  // Exclude extra / unplanned activities from the "behind on plan" calculation — an
+  // off-plan bike doesn't complete a remaining planned run. Use planned-completed
+  // minutes only for the pacing signal; extras stay visible through the Today card.
+  const behindByMinutes = Math.max(
+    Math.round(expectedMinutesByToday - minuteMetrics.plannedCompletedMinutes),
+    0
+  );
   // Only surface "behind" when there is genuinely remaining or overdue work.  A back-loaded week can
   // look "behind pace" even when every session through today is done — suppress the alert in that case.
   // Also suppress on planned rest days: the Morning Brief already covers "take it fully" and the
   // "behind" framing is misleading when today was never supposed to contain work.
+  //
+  // Additionally suppress when the week is weekend-loaded and the shape-adjusted completion
+  // is close to expectation — otherwise Fri shows "at risk 2h 34m behind" when the athlete
+  // has done 48% of the load correctly because 52% is scheduled Sat/Sun.
   const todayHasRemainingWork = dailyStates.find((d) => d.iso === todayIso)?.tone === "today-remaining";
+  const shapeAdjustedDeltaPct = completionPct - expectedByTodayPct;
+  // Only treat a week as "weekend-loaded on plan" when today has no outstanding work and
+  // no past sessions are missed. If today is partially complete, the user genuinely is
+  // behind and the shape argument shouldn't hide that.
+  const isWeekendLoadedOnPlan =
+    weekShape.isWeekendLoaded &&
+    missedSessionsCount === 0 &&
+    !todayHasRemainingWork &&
+    shapeAdjustedDeltaPct >= -12;
   const behindAlertActive =
     behindByMinutes >= 30 &&
     dashboardMoment !== "rest_day" &&
+    !isWeekendLoadedOnPlan &&
     (missedSessionsCount > 0 || todayHasRemainingWork);
 
   const sports = ["swim", "bike", "run", "strength"] as const;
@@ -777,9 +806,12 @@ export default async function DashboardPage({
         </>
       )}
 
-      {/* Training Score + Balance (side by side) + Readiness */}
+      {/* Readiness (at-a-glance) → Training Score + Balance */}
       {isCurrentWeek ? (
         <>
+          <Suspense fallback={null}>
+            <DashboardReadiness supabase={supabase} userId={user.id} />
+          </Suspense>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
             <Suspense fallback={null}>
               <DashboardTrainingScore supabase={supabase} userId={user.id} todayIso={todayIso} />
@@ -788,9 +820,6 @@ export default async function DashboardPage({
               <DashboardDisciplineBalance supabase={supabase} userId={user.id} weekStart={weekStart} />
             </Suspense>
           </div>
-          <Suspense fallback={null}>
-            <DashboardReadiness supabase={supabase} userId={user.id} />
-          </Suspense>
         </>
       ) : null}
 
@@ -1027,13 +1056,26 @@ async function DashboardReadiness(props: {
   if (!props?.supabase) return null;
   const { supabase, userId } = props;
   try {
-    const [fitness, tsbTrend] = await Promise.all([
+    const [fitness, tsbTrend, fatigue] = await Promise.all([
       getLatestFitness(supabase, userId),
       getTsbTrend(supabase, userId),
+      detectCrossDisciplineFatigue(supabase, userId).catch(() => null)
     ]);
     if (!fitness?.total) return null;
     const readiness = getReadinessState(fitness.total.tsb, tsbTrend);
-    return <ReadinessIndicator readiness={readiness} tsb={fitness.total.tsb} />;
+    const signalContext = fatigue?.sports && fatigue.sports.length >= 2
+      ? `${fatigue.sports.join(" + ")} trending down, expect heavier legs`
+      : readiness === "fatigued" || readiness === "overreaching"
+        ? "Hold the key session but keep easy days truly easy"
+        : null;
+    return (
+      <ReadinessIndicator
+        readiness={readiness}
+        tsb={fitness.total.tsb}
+        tsbTrend={tsbTrend}
+        signalContext={signalContext}
+      />
+    );
   } catch {
     return null;
   }

--- a/app/(protected)/dashboard/trend-cards.tsx
+++ b/app/(protected)/dashboard/trend-cards.tsx
@@ -42,60 +42,93 @@ function formatSports(sports: string[]): string {
   return `${sports.slice(0, -1).map((s) => SPORT_LABEL[s] ?? s).join(", ")}, and ${SPORT_LABEL[sports[sports.length - 1]] ?? sports[sports.length - 1]}`;
 }
 
+/**
+ * Derive a cross-discipline fatigue synthesis from the trend cards themselves when the
+ * TSB-based `detectCrossDisciplineFatigue` hasn't fired. This catches the case where
+ * performance metrics (pace, power) are declining together even before the
+ * load-balance model shows TSB drift.
+ */
+function deriveTrendFatigueSynthesis(trends: WeeklyTrend[]): { sports: string[]; metrics: string[] } | null {
+  // Only flag on output-metric declines (pace, power) — HR declining is ambiguous.
+  const OUTPUT_METRICS = new Set(["Run pace", "Bike avg power", "Swim pace"]);
+  const decliningOutputs = trends.filter(
+    (t) => t.direction === "declining" && OUTPUT_METRICS.has(t.metric) && t.confidence !== "low"
+  );
+  const distinctSports = new Set(decliningOutputs.map((t) => METRIC_SPORT[t.metric] ?? t.sport));
+  if (distinctSports.size < 2) return null;
+  return {
+    sports: Array.from(distinctSports),
+    metrics: decliningOutputs.map((t) => t.metric)
+  };
+}
+
 export function TrendCards({ trends, fatigueSignal }: { trends: WeeklyTrend[]; fatigueSignal?: FatigueSignal | null }) {
   if (trends.length === 0 && !fatigueSignal) return null;
 
+  // Prefer the TSB-based signal when present; otherwise synthesize from trend directions.
+  const derivedSynthesis = !fatigueSignal ? deriveTrendFatigueSynthesis(trends) : null;
+  const synthesisSports = fatigueSignal?.sports ?? derivedSynthesis?.sports ?? null;
+  const synthesisSeverity = fatigueSignal?.severity ?? "warning";
+
   return (
-    <article className="surface p-4 md:p-5">
-      <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Recent trends</p>
-      {fatigueSignal ? (
-        <div
-          className={`mt-3 rounded-xl border p-3 ${
-            fatigueSignal.severity === "alert"
+    <div className="space-y-3">
+      {synthesisSports && synthesisSports.length >= 2 ? (
+        <article
+          className={`rounded-2xl border p-4 md:p-5 ${
+            synthesisSeverity === "alert"
               ? "border-[hsl(var(--signal-risk))] bg-[hsl(var(--signal-risk)/0.08)]"
               : "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.08)]"
           }`}
+          aria-label="Cross-discipline fatigue synthesis"
         >
           <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-white">
             Cross-discipline fatigue
           </p>
-          <p className="mt-1 text-sm text-white">
-            {formatSports(fatigueSignal.sports)} are both trending down over the same window — consider protecting this week&apos;s key session.
+          <p className="mt-2 text-sm text-white">
+            {formatSports(synthesisSports)} are trending down together over the same window.
+            This pattern typically indicates accumulated fatigue rather than
+            discipline-specific weakness. Prioritize recovery this weekend and watch how
+            your legs feel on the next long session.
           </p>
-          <p className="mt-1 text-[11px] text-muted">{fatigueSignal.detail}</p>
-        </div>
+          {fatigueSignal?.detail ? (
+            <p className="mt-2 text-[11px] text-muted">{fatigueSignal.detail}</p>
+          ) : null}
+        </article>
       ) : null}
       {trends.length > 0 ? (
-      <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        {trends.map((trend) => {
-          const sport = METRIC_SPORT[trend.metric] ?? "other";
-          const color = SPORT_COLOR[sport] ?? "hsl(var(--accent))";
-          const values = trend.dataPoints.map((d) => d.value);
-          const currentLabel = trend.dataPoints[trend.dataPoints.length - 1]?.label ?? "";
+        <article className="surface p-4 md:p-5">
+          <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Recent trends</p>
+          <div className="mt-3 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {trends.map((trend) => {
+              const sport = METRIC_SPORT[trend.metric] ?? "other";
+              const color = SPORT_COLOR[sport] ?? "hsl(var(--accent))";
+              const values = trend.dataPoints.map((d) => d.value);
+              const currentLabel = trend.dataPoints[trend.dataPoints.length - 1]?.label ?? "";
 
-          return (
-            <div
-              key={trend.metric}
-              className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"
-            >
-              <div className="flex items-center justify-between">
-                <p className="text-xs text-muted">{trend.metric}</p>
-                <Sparkline values={values} color={color} width={80} height={24} />
-              </div>
-              <div className="mt-2 flex items-baseline gap-2">
-                <span className="text-base font-semibold text-white">
-                  {currentLabel}
-                </span>
-                <span className={`text-xs font-medium ${DIRECTION_CLASS[trend.direction]}`}>
-                  {DIRECTION_ARROW[trend.direction]} {trend.direction}
-                </span>
-              </div>
-              <p className="mt-1 text-[11px] leading-snug text-muted">{trend.detail}</p>
-            </div>
-          );
-        })}
-      </div>
+              return (
+                <div
+                  key={trend.metric}
+                  className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3"
+                >
+                  <div className="flex items-center justify-between">
+                    <p className="text-xs text-muted">{trend.metric}</p>
+                    <Sparkline values={values} color={color} width={80} height={24} />
+                  </div>
+                  <div className="mt-2 flex items-baseline gap-2">
+                    <span className="text-base font-semibold text-white">
+                      {currentLabel}
+                    </span>
+                    <span className={`text-xs font-medium ${DIRECTION_CLASS[trend.direction]}`}>
+                      {DIRECTION_ARROW[trend.direction]} {trend.direction}
+                    </span>
+                  </div>
+                  <p className="mt-1 text-[11px] leading-snug text-muted">{trend.detail}</p>
+                </div>
+              );
+            })}
+          </div>
+        </article>
       ) : null}
-    </article>
+    </div>
   );
 }

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -533,10 +533,13 @@ export default async function SessionReviewPage({ params, searchParams }: { para
   // otherwise suppress generic hedging when the read is confident.
   const missingCriticalData = reviewVm.componentScores?.missingCriticalData ?? [];
   const dataCompletenessPct = reviewVm.componentScores?.dataCompletenessPct ?? 1;
-  const missingDominantMetric = reviewVm.componentScores?.missingDominantMetric ?? null;
+  const intentMatchCapped = Boolean(reviewVm.componentScores?.intentMatch?.capped);
+  const cappedDominantMetric = intentMatchCapped
+    ? reviewVm.componentScores?.missingDominantMetric ?? null
+    : null;
   const confidenceQualifier =
-    missingDominantMetric
-      ? `${missingDominantMetric} missing — likely on target`
+    cappedDominantMetric
+      ? `${cappedDominantMetric} missing — likely on target`
       : missingCriticalData.length > 0
         ? `${missingCriticalData[0]} missing`
         : dataCompletenessPct < 0.6 && reviewVm.confidenceLabel === "low"
@@ -812,9 +815,9 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               );
             })}
           </div>
-          {reviewVm.componentScores?.missingDominantMetric ? (
+          {cappedDominantMetric ? (
             <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
-              {reviewVm.componentScores.missingDominantMetric} data missing — Intent Match is capped because the primary effort signal for this session isn&apos;t there to confirm.
+              {cappedDominantMetric} data missing — Intent Match is capped because the primary effort signal for this session isn&apos;t there to confirm.
             </p>
           ) : missingCriticalData.length > 0 ? (
             <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -533,12 +533,15 @@ export default async function SessionReviewPage({ params, searchParams }: { para
   // otherwise suppress generic hedging when the read is confident.
   const missingCriticalData = reviewVm.componentScores?.missingCriticalData ?? [];
   const dataCompletenessPct = reviewVm.componentScores?.dataCompletenessPct ?? 1;
+  const missingDominantMetric = reviewVm.componentScores?.missingDominantMetric ?? null;
   const confidenceQualifier =
-    missingCriticalData.length > 0
-      ? `${missingCriticalData[0]} missing`
-      : dataCompletenessPct < 0.6 && reviewVm.confidenceLabel === "low"
-        ? "limited evidence"
-        : null;
+    missingDominantMetric
+      ? `${missingDominantMetric} missing — likely on target`
+      : missingCriticalData.length > 0
+        ? `${missingCriticalData[0]} missing`
+        : dataCompletenessPct < 0.6 && reviewVm.confidenceLabel === "low"
+          ? "limited evidence"
+          : null;
 
   // Determine the one-thing callout label — don't say "change" when the advice is "keep doing this"
   // Only treat as "keep doing" when the advice STARTS with maintenance language, not when those
@@ -766,33 +769,54 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           </div>
           <div className="mt-3 space-y-3">
             {[
-              { label: "Intent match", weightLabel: "40%", score: reviewVm.componentScores.intentMatch.score, detail: reviewVm.componentScores.intentMatch.detail },
-              { label: "Pacing & execution", weightLabel: "25%", score: reviewVm.componentScores.pacingExecution.score, detail: reviewVm.componentScores.pacingExecution.detail },
-              { label: "Completion", weightLabel: "20%", score: reviewVm.componentScores.completion.score, detail: reviewVm.componentScores.completion.detail },
-              { label: "Recovery compliance", weightLabel: "15%", score: reviewVm.componentScores.recoveryCompliance.score, detail: reviewVm.componentScores.recoveryCompliance.detail }
-            ].map((component) => {
+              { label: "Intent match", weightLabel: "40%", component: reviewVm.componentScores.intentMatch },
+              { label: "Pacing & execution", weightLabel: "25%", component: reviewVm.componentScores.pacingExecution },
+              { label: "Completion", weightLabel: "20%", component: reviewVm.componentScores.completion },
+              { label: "Recovery compliance", weightLabel: "15%", component: reviewVm.componentScores.recoveryCompliance }
+            ].map(({ label, weightLabel, component }) => {
               const barColor = component.score >= 80 ? "bg-[hsl(var(--success))]"
                 : component.score >= 60 ? "bg-[hsl(var(--warning))]"
                 : component.score >= 40 ? "bg-[hsl(35,100%,50%)]"
                 : "bg-[hsl(var(--signal-risk))]";
+              const cappedUpperPct = component.capped && typeof component.uncappedScore === "number"
+                ? Math.max(0, Math.min(100, component.uncappedScore) - component.score)
+                : 0;
               return (
-                <div key={component.label}>
+                <div key={label}>
                   <div className="flex items-center justify-between gap-2">
                     <div className="flex items-center gap-2">
-                      <span className="text-xs font-medium text-white">{component.label}</span>
-                      <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1.5 py-0.5 text-[9px] text-tertiary">{component.weightLabel}</span>
+                      <span className="text-xs font-medium text-white">{label}</span>
+                      <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1.5 py-0.5 text-[9px] text-tertiary">{weightLabel}</span>
+                      {component.capped ? (
+                        <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Capped</span>
+                      ) : null}
                     </div>
                     <span className="text-xs font-mono font-medium text-white">{component.score}</span>
                   </div>
-                  <div className="mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                    <div className={`h-full rounded-full transition-all ${barColor}`} style={{ width: `${component.score}%` }} />
+                  <div className="mt-1.5 flex h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                    <div className={`h-full ${barColor} transition-all`} style={{ width: `${component.score}%` }} />
+                    {cappedUpperPct > 0 ? (
+                      <div
+                        className="h-full border-l border-warning/40"
+                        style={{
+                          width: `${cappedUpperPct}%`,
+                          backgroundImage:
+                            "repeating-linear-gradient(45deg, hsl(var(--warning) / 0.25) 0 4px, transparent 4px 8px)"
+                        }}
+                        aria-label="uncertainty band"
+                      />
+                    ) : null}
                   </div>
                   <p className="mt-1 text-[11px] text-muted">{component.detail}</p>
                 </div>
               );
             })}
           </div>
-          {missingCriticalData.length > 0 ? (
+          {reviewVm.componentScores?.missingDominantMetric ? (
+            <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+              {reviewVm.componentScores.missingDominantMetric} data missing — Intent Match is capped because the primary effort signal for this session isn&apos;t there to confirm.
+            </p>
+          ) : missingCriticalData.length > 0 ? (
             <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
               {missingCriticalData[0]} missing — pair the right sensor next time to unlock a confirmed read.
             </p>

--- a/lib/coach/session-diagnosis.test.ts
+++ b/lib/coach/session-diagnosis.test.ts
@@ -341,6 +341,33 @@ describe("diagnoseCompletedSession", () => {
     expect(cs.intentMatch.score).toBeGreaterThanOrEqual(90);
   });
 
+  test("power-only threshold run is not flagged as missing pace", () => {
+    // Run power is treated as valid intensity evidence elsewhere in the scorer.
+    // A run with power + HR but no pace stream should NOT be capped for missing
+    // the dominant metric.
+    const diagnosis = diagnoseCompletedSession({
+      planned: {
+        sport: "run",
+        intentCategory: "Threshold intervals",
+        plannedDurationSec: 3000,
+        plannedIntervals: 3,
+        targetBands: { hr: { min: 165, max: 175 } }
+      },
+      actual: {
+        durationSec: 3000,
+        avgHr: 170,
+        avgPower: 290,
+        completedIntervals: 3
+      }
+    });
+
+    expect(diagnosis.componentScores).not.toBeNull();
+    const cs = diagnosis.componentScores!;
+    expect(cs.missingDominantMetric).toBeNull();
+    expect(cs.intentMatch.capped).toBeFalsy();
+    expect(cs.intentMatch.score).toBeGreaterThanOrEqual(85);
+  });
+
   test("full-telemetry easy run keeps intent match high and has no missing critical data", () => {
     const diagnosis = diagnoseCompletedSession({
       planned: {

--- a/lib/coach/session-diagnosis.ts
+++ b/lib/coach/session-diagnosis.ts
@@ -554,10 +554,12 @@ function computeDataCompleteness(input: SessionDiagnosisInput, bucket: IntentBuc
   let missingDominantMetric: string | null = null;
   if (dominant === "hr" && !hasAnyHr) missingDominantMetric = "HR";
   else if (dominant === "power" && !hasAnyPower) missingDominantMetric = "power";
-  else if (dominant === "pace" && !hasAnyPace && !hasAnyHr) {
-    // For run/swim, pace is dominant. If neither pace nor HR is present, we have no
-    // effort signal at all — mark pace missing so Intent Match gets capped.
-    missingDominantMetric = sport === "swim" ? "swim pace" : "pace";
+  else if (dominant === "pace" && !hasAnyPace && !hasAnyHr && !hasAnyPower) {
+    // Run pace is the dominant signal, but the scorer accepts HR or run power as
+    // valid intensity evidence everywhere else. Only flag pace as missing when none
+    // of pace, HR, or power is present — otherwise a power-only run would be
+    // penalized for data it doesn't actually need.
+    missingDominantMetric = "pace";
   }
 
   return { pct, missingCritical, missingDominantMetric };

--- a/lib/coach/session-diagnosis.ts
+++ b/lib/coach/session-diagnosis.ts
@@ -54,6 +54,10 @@ export type ComponentScore = {
   score: number;
   weight: number;
   detail: string;
+  /** True when the score was capped below its natural value due to missing evidence. */
+  capped?: boolean;
+  /** Natural (pre-cap) score. Used by UI to render an uncertainty band from score → cap limit. */
+  uncappedScore?: number;
 };
 
 export type ComponentScores = {
@@ -64,6 +68,8 @@ export type ComponentScores = {
   composite: number;
   dataCompletenessPct: number;
   missingCriticalData: string[];
+  /** Name of the dominant intensity metric for this session when it was missing (e.g. "HR", "power"). */
+  missingDominantMetric?: string | null;
 };
 
 export type SessionDiagnosis = {
@@ -451,7 +457,36 @@ function getNextAction(status: IntentMatchStatus, issues: IssueKey[], bucket: In
 type DataCompleteness = {
   pct: number;
   missingCritical: string[];
+  /** The dominant intensity metric for this sport/intent (e.g. "HR" for easy bike, "power" for threshold bike, "pace" for run). Null if none applies. */
+  missingDominantMetric: string | null;
 };
+
+/**
+ * The single metric that most directly confirms intent for a sport + intent bucket.
+ * When this metric is absent, Intent Match cannot confidently score in the "matched"
+ * range even when no issues are detected — absence of a signal is not evidence of success.
+ */
+function getDominantIntensityMetric(sport: Sport, bucket: IntentBucket): "hr" | "power" | "pace" | null {
+  if (sport === "bike") {
+    // For easy / long / recovery bikes, HR is the dominant effort signal.
+    // Power can look clean while the athlete actually pushed harder in response to
+    // wind, terrain, traffic, etc. HR is the physiology.
+    if (bucket === "easy_endurance" || bucket === "recovery" || bucket === "long_endurance") {
+      return "hr";
+    }
+    if (bucket === "threshold_quality") {
+      return "power";
+    }
+    return "hr";
+  }
+  if (sport === "run") {
+    return "pace";
+  }
+  // Pool swim watches rarely provide continuous pace; interval completion + duration
+  // is the primary execution signal for pool-based swim sessions. Leave swim without
+  // a dominant metric so the cap doesn't fire on sparse-but-complete pool swims.
+  return null;
+}
 
 function computeDataCompleteness(input: SessionDiagnosisInput, bucket: IntentBucket): DataCompleteness {
   const actual = input.actual;
@@ -465,6 +500,9 @@ function computeDataCompleteness(input: SessionDiagnosisInput, bucket: IntentBuc
   const hasIntervals = typeof actual.intervalCompletionPct === "number" || Boolean(actual.completedIntervals && planned.plannedIntervals);
   const hasDuration = Boolean(actual.durationSec && planned.plannedDurationSec);
   const hasSplits = Boolean(actual.splitMetrics?.firstHalfAvgHr || actual.splitMetrics?.firstHalfPaceSPerKm || actual.splitMetrics?.firstHalfAvgPower);
+  const hasAnyHr = Boolean(actual.avgHr ?? getMetric(actual, "avg_hr"));
+  const hasAnyPower = Boolean(actual.avgIntervalPower ?? actual.avgPower ?? getMetric(actual, "avg_power"));
+  const hasAnyPace = Boolean(actual.avgPaceSPerKm ?? getMetric(actual, "avg_pace_s_per_km"));
 
   const critical: Array<{ key: string; present: boolean; label: string }> = [];
 
@@ -506,13 +544,23 @@ function computeDataCompleteness(input: SessionDiagnosisInput, bucket: IntentBuc
   }
 
   const hasSport = critical.length > 0;
-  if (!hasSport) return { pct: 1, missingCritical: [] };
+  if (!hasSport) return { pct: 1, missingCritical: [], missingDominantMetric: null };
 
   const presentCount = critical.filter((c) => c.present).length;
   const pct = presentCount / critical.length;
   const missingCritical = critical.filter((c) => !c.present).map((c) => c.label);
 
-  return { pct, missingCritical };
+  const dominant = getDominantIntensityMetric(sport, bucket);
+  let missingDominantMetric: string | null = null;
+  if (dominant === "hr" && !hasAnyHr) missingDominantMetric = "HR";
+  else if (dominant === "power" && !hasAnyPower) missingDominantMetric = "power";
+  else if (dominant === "pace" && !hasAnyPace && !hasAnyHr) {
+    // For run/swim, pace is dominant. If neither pace nor HR is present, we have no
+    // effort signal at all — mark pace missing so Intent Match gets capped.
+    missingDominantMetric = sport === "swim" ? "swim pace" : "pace";
+  }
+
+  return { pct, missingCritical, missingDominantMetric };
 }
 
 function computeIntentMatchScore(draft: DiagnosisDraft, bucket: IntentBucket, completeness: DataCompleteness): ComponentScore {
@@ -538,18 +586,43 @@ function computeIntentMatchScore(draft: DiagnosisDraft, bucket: IntentBucket, co
     detail = "Recovery intent was compromised by excessive intensity.";
   }
 
-  // Data-completeness penalty: when critical evidence is missing, "matched_intent"
-  // reflects the absence of detected issues rather than confirmed success. Cap Intent
-  // Match so composite reflects that uncertainty.
-  if (completeness.missingCritical.length > 0 && draft.status === "matched_intent") {
+  const uncapped = score;
+  let capped = false;
+
+  // Dominant-metric cap: when the primary effort signal for this sport/intent is
+  // missing entirely, intent cannot be confirmed. Cap at 75 regardless of issue count
+  // — absence of the dominant signal is not evidence of success.
+  if (completeness.missingDominantMetric && draft.status === "matched_intent") {
+    const dominantCap = 75;
+    if (score > dominantCap) {
+      score = dominantCap;
+      capped = true;
+      detail = `${completeness.missingDominantMetric} missing — capped; intent cannot be confirmed without it.`;
+    }
+  }
+
+  // Data-completeness cap: critical evidence missing AND matched intent means we're
+  // reading "no issues" from limited signals. Broader uncertainty cap.
+  if (
+    completeness.missingCritical.length > 0 &&
+    draft.status === "matched_intent" &&
+    !completeness.missingDominantMetric // already handled above with tighter cap
+  ) {
     const cap = completeness.pct < 0.5 ? 65 : 78;
     if (score > cap) {
       score = cap;
+      capped = true;
       detail = `${completeness.missingCritical[0]} missing — cannot confirm intent match without it.`;
     }
   }
 
-  return { score: Math.round(Math.max(0, Math.min(100, score))), weight, detail };
+  const clamped = Math.round(Math.max(0, Math.min(100, score)));
+  return {
+    score: clamped,
+    weight,
+    detail,
+    ...(capped ? { capped: true, uncappedScore: Math.round(uncapped) } : {})
+  };
 }
 
 function computePacingExecutionScore(input: SessionDiagnosisInput, draft: DiagnosisDraft): ComponentScore {
@@ -690,7 +763,8 @@ function computeComponentScores(input: SessionDiagnosisInput, draft: DiagnosisDr
     recoveryCompliance,
     composite,
     dataCompletenessPct: completeness.pct,
-    missingCriticalData: completeness.missingCritical
+    missingCriticalData: completeness.missingCritical,
+    missingDominantMetric: completeness.missingDominantMetric
   };
 }
 
@@ -711,8 +785,14 @@ export function diagnoseCompletedSession(input: SessionDiagnosisInput): SessionD
               : evaluateUnknown(input);
 
   const components = computeComponentScores(input, draft, bucket);
+  // Provisional only when evidence is genuinely thin: <2 evidence items OR
+  // data completeness below 60%. A fully-telemetered session should not be
+  // labelled provisional just because its evidence count sits at the low end.
+  const isProvisional = components
+    ? draft.evidenceCount < 2 || components.dataCompletenessPct < 0.6
+    : draft.evidenceCount < 2;
   const score = components
-    ? { score: components.composite, band: getExecutionScoreBand(components.composite), provisional: draft.evidenceCount < 2 }
+    ? { score: components.composite, band: getExecutionScoreBand(components.composite), provisional: isProvisional }
     : deriveExecutionScore(bucket, draft);
   const summary = getSummary(draft.status, draft.issues, bucket);
 

--- a/lib/execution-review-persistence.test.ts
+++ b/lib/execution-review-persistence.test.ts
@@ -1,0 +1,97 @@
+import { buildWeeklyExecutionBrief } from "./execution-review-persistence";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+type ReviewOverrides = {
+  intentMatch?: "on_target" | "partial" | "missed";
+  provisional?: boolean;
+};
+
+function buildExecutionResult(overrides: ReviewOverrides = {}) {
+  const intentMatch = overrides.intentMatch ?? "on_target";
+  const provisional = overrides.provisional ?? false;
+  return {
+    version: 2,
+    deterministic: {
+      planned: {},
+      actual: {},
+      detectedIssues: [],
+      missingEvidence: [],
+      rulesSummary: {
+        intentMatch,
+        executionScore: 80,
+        executionScoreBand: "On target",
+        confidence: provisional ? "low" : "high",
+        provisional,
+        evidenceCount: 3,
+        executionCost: "low"
+      }
+    }
+  };
+}
+
+function buildSupabaseStub(sessions: Array<{ id: string; session_name: string; type: string; date: string; execution_result: ReturnType<typeof buildExecutionResult> }>): SupabaseClient {
+  const builder = {
+    select: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    gte: jest.fn().mockReturnThis(),
+    lte: jest.fn().mockReturnThis(),
+    not: jest.fn().mockReturnThis(),
+    order: jest.fn().mockResolvedValue({ data: sessions, error: null })
+  };
+  return { from: jest.fn().mockReturnValue(builder) } as unknown as SupabaseClient;
+}
+
+describe("buildWeeklyExecutionBrief", () => {
+  test("emits an all-provisional caveat when every reviewed session is provisional", async () => {
+    const supabase = buildSupabaseStub([
+      { id: "s1", session_name: "Easy run", type: "Run", date: "2026-03-09", execution_result: buildExecutionResult({ intentMatch: "on_target", provisional: true }) },
+      { id: "s2", session_name: "Bike Z2", type: "Bike", date: "2026-03-10", execution_result: buildExecutionResult({ intentMatch: "on_target", provisional: true }) }
+    ]);
+
+    const brief = await buildWeeklyExecutionBrief({
+      supabase,
+      athleteId: "user-1",
+      weekStart: "2026-03-09",
+      weekEnd: "2026-03-15",
+      athleteContext: null
+    });
+
+    expect(brief.trend.provisionalCount).toBe(2);
+    expect(brief.trend.reviewedCount).toBe(2);
+    expect(brief.confidenceNote).not.toBeNull();
+    expect(brief.confidenceNote).toMatch(/provisional/i);
+  });
+
+  test("keeps the N-of-M provisional note when only some reviews are provisional", async () => {
+    const supabase = buildSupabaseStub([
+      { id: "s1", session_name: "Easy run", type: "Run", date: "2026-03-09", execution_result: buildExecutionResult({ intentMatch: "on_target", provisional: true }) },
+      { id: "s2", session_name: "Bike Z2", type: "Bike", date: "2026-03-10", execution_result: buildExecutionResult({ intentMatch: "on_target", provisional: false }) }
+    ]);
+
+    const brief = await buildWeeklyExecutionBrief({
+      supabase,
+      athleteId: "user-1",
+      weekStart: "2026-03-09",
+      weekEnd: "2026-03-15",
+      athleteContext: null
+    });
+
+    expect(brief.confidenceNote).toMatch(/1 of 2 reviews?/i);
+  });
+
+  test("omits the confidence note when no reviews are provisional", async () => {
+    const supabase = buildSupabaseStub([
+      { id: "s1", session_name: "Easy run", type: "Run", date: "2026-03-09", execution_result: buildExecutionResult({ intentMatch: "on_target", provisional: false }) }
+    ]);
+
+    const brief = await buildWeeklyExecutionBrief({
+      supabase,
+      athleteId: "user-1",
+      weekStart: "2026-03-09",
+      weekEnd: "2026-03-15",
+      athleteContext: null
+    });
+
+    expect(brief.confidenceNote).toBeNull();
+  });
+});

--- a/lib/execution-review-persistence.ts
+++ b/lib/execution-review-persistence.ts
@@ -250,6 +250,29 @@ export async function buildWeeklyExecutionBrief(args: {
   const partialCount = reviews.filter((item) => item.review.deterministic.rulesSummary.intentMatch === "partial").length;
   const missedCount = reviews.filter((item) => item.review.deterministic.rulesSummary.intentMatch === "missed").length;
   const provisionalCount = reviews.filter((item) => item.review.deterministic.rulesSummary.provisional).length;
+  // Pattern synthesis: name the most common recurring issue across reviewed sessions so
+  // the brief reads as a coaching observation instead of a universal hedge.
+  const issueCounts = new Map<string, number>();
+  for (const item of reviews) {
+    for (const issue of item.review.deterministic.detectedIssues ?? []) {
+      const code = issue.code;
+      if (!code) continue;
+      issueCounts.set(code, (issueCounts.get(code) ?? 0) + 1);
+    }
+  }
+  const [dominantIssue, dominantIssueCount] = Array.from(issueCounts.entries())
+    .sort((a, b) => b[1] - a[1])[0] ?? ["", 0];
+  const PATTERN_MESSAGES: Record<string, string> = {
+    shortened: `${dominantIssueCount} of your last ${reviewedCount} sessions ran shorter than planned. Is that a schedule issue or a recovery issue? Worth a quick check-in.`,
+    too_hard: `${dominantIssueCount} of your last ${reviewedCount} easy sessions ran hotter than the target zone. Worth checking whether it's pacing or cumulative fatigue driving intensity up.`,
+    late_drift: `${dominantIssueCount} of your last ${reviewedCount} sessions drifted upward in the second half. That's usually a fueling or pacing cue.`,
+    incomplete_reps: `${dominantIssueCount} of your last ${reviewedCount} sessions cut reps short. Protect the next key set and flag if recovery feels off.`,
+    faded_late: `${dominantIssueCount} of your last ${reviewedCount} long sessions faded in the final third. Open more conservatively and fuel earlier next time.`
+  };
+  const patternNote =
+    reviewedCount >= 3 && dominantIssueCount >= 2 && PATTERN_MESSAGES[dominantIssue]
+      ? PATTERN_MESSAGES[dominantIssue]
+      : null;
 
   const sessionsNeedingAttention = reviews
     .filter((item) => item.review.deterministic.rulesSummary.intentMatch !== "on_target")
@@ -300,9 +323,13 @@ export async function buildWeeklyExecutionBrief(args: {
       provisionalCount
     },
     sessionsNeedingAttention,
+    // Prefer naming a concrete pattern over universal "provisional" hedging. Only
+    // surface the provisional count when it's a meaningful minority and no richer
+    // pattern is available to lead with.
     confidenceNote:
-      provisionalCount > 0
-        ? `${provisionalCount} review${provisionalCount === 1 ? "" : "s"} are still provisional because evidence is incomplete.`
-        : null
+      patternNote
+        ?? (provisionalCount > 0 && provisionalCount < reviewedCount
+          ? `${provisionalCount} of ${reviewedCount} review${reviewedCount === 1 ? "" : "s"} still need richer data to firm up the read.`
+          : null)
   } satisfies WeeklyExecutionBrief;
 }

--- a/lib/execution-review-persistence.ts
+++ b/lib/execution-review-persistence.ts
@@ -246,20 +246,23 @@ export async function buildWeeklyExecutionBrief(args: {
     .filter((item): item is { id: string; name: string; review: PersistedExecutionReview } => Boolean(item));
 
   const reviewedCount = reviews.length;
-  const onTargetCount = reviews.filter((item) => item.review.deterministic.rulesSummary.intentMatch === "on_target").length;
-  const partialCount = reviews.filter((item) => item.review.deterministic.rulesSummary.intentMatch === "partial").length;
-  const missedCount = reviews.filter((item) => item.review.deterministic.rulesSummary.intentMatch === "missed").length;
-  const provisionalCount = reviews.filter((item) => item.review.deterministic.rulesSummary.provisional).length;
-  // Pattern synthesis: name the most common recurring issue across reviewed sessions so
-  // the brief reads as a coaching observation instead of a universal hedge.
+  let onTargetCount = 0;
+  let partialCount = 0;
+  let missedCount = 0;
+  let provisionalCount = 0;
   const issueCounts = new Map<string, number>();
-  for (const item of reviews) {
-    for (const issue of item.review.deterministic.detectedIssues ?? []) {
-      const code = issue.code;
-      if (!code) continue;
-      issueCounts.set(code, (issueCounts.get(code) ?? 0) + 1);
+  for (const { review } of reviews) {
+    const summary = review.deterministic.rulesSummary;
+    if (summary.intentMatch === "on_target") onTargetCount++;
+    else if (summary.intentMatch === "partial") partialCount++;
+    else if (summary.intentMatch === "missed") missedCount++;
+    if (summary.provisional) provisionalCount++;
+    for (const issue of review.deterministic.detectedIssues ?? []) {
+      if (!issue.code) continue;
+      issueCounts.set(issue.code, (issueCounts.get(issue.code) ?? 0) + 1);
     }
   }
+
   const [dominantIssue, dominantIssueCount] = Array.from(issueCounts.entries())
     .sort((a, b) => b[1] - a[1])[0] ?? ["", 0];
   const PATTERN_MESSAGES: Record<string, string> = {

--- a/lib/execution-review-persistence.ts
+++ b/lib/execution-review-persistence.ts
@@ -326,13 +326,15 @@ export async function buildWeeklyExecutionBrief(args: {
       provisionalCount
     },
     sessionsNeedingAttention,
-    // Prefer naming a concrete pattern over universal "provisional" hedging. Only
-    // surface the provisional count when it's a meaningful minority and no richer
-    // pattern is available to lead with.
+    // Prefer naming a concrete pattern when one is available; otherwise surface the
+    // provisional count so the briefing never reads more confident than the evidence
+    // warrants — including the case where every reviewed session is still provisional.
     confidenceNote:
       patternNote
-        ?? (provisionalCount > 0 && provisionalCount < reviewedCount
-          ? `${provisionalCount} of ${reviewedCount} review${reviewedCount === 1 ? "" : "s"} still need richer data to firm up the read.`
-          : null)
+        ?? (provisionalCount === reviewedCount && reviewedCount > 0
+          ? `Every reviewed session is still provisional — richer uploads will firm these reads up.`
+          : provisionalCount > 0
+            ? `${provisionalCount} of ${reviewedCount} review${reviewedCount === 1 ? "" : "s"} still need richer data to firm up the read.`
+            : null)
   } satisfies WeeklyExecutionBrief;
 }

--- a/lib/session-review.test.ts
+++ b/lib/session-review.test.ts
@@ -300,6 +300,44 @@ describe("createReviewViewModel", () => {
     expect(vm.followUpIntro).toMatch(/extra session/i);
     expect(vm.followUpPrompts[0]).toMatch(/help or hurt the week/i);
   });
+
+  test("does not emit a 'capped' confidence note when intent match was not actually capped", () => {
+    // Partial/missed sessions can record a missingDominantMetric without the
+    // intent-match score being capped. The confidence note must key on the
+    // capped flag, not the raw missingDominantMetric.
+    const vm = createReviewViewModel({
+      id: "uncapped-partial-1",
+      date: "2026-03-14",
+      sport: "run",
+      type: "Run",
+      intent_category: "Threshold intervals",
+      duration_minutes: 55,
+      status: "completed",
+      execution_result: {
+        status: "partial_intent",
+        executionScore: 62,
+        executionScoreBand: "Partial match",
+        executionScoreSummary: "Threshold reps drifted late and a few fell short.",
+        componentScores: {
+          intentMatch: { score: 55, weight: 0.4, detail: "Partial.", capped: false },
+          pacingExecution: { score: 60, weight: 0.25, detail: "Drifted." },
+          completion: { score: 70, weight: 0.2, detail: "Most reps complete." },
+          recoveryCompliance: { score: 80, weight: 0.15, detail: "Fine." },
+          composite: 62,
+          dataCompletenessPct: 0.7,
+          missingCriticalData: [],
+          missingDominantMetric: "HR"
+        }
+      }
+    });
+
+    // When intentMatch.capped is false, the "capped" confidence copy must not appear,
+    // even if a missingDominantMetric is recorded. A null note is acceptable here.
+    if (vm.scoreConfidenceNote !== null) {
+      expect(vm.scoreConfidenceNote).not.toMatch(/capped/i);
+      expect(vm.scoreConfidenceNote).not.toMatch(/likely on target/i);
+    }
+  });
 });
 
 describe("sanitizeFieldNames", () => {

--- a/lib/session-review.ts
+++ b/lib/session-review.ts
@@ -618,12 +618,16 @@ export function createReviewViewModel(session: SessionReviewRow, options?: { tre
           ? "This workout is already linked. Execution Score will appear once the linked activity finishes processing into session analysis."
         : "Execution Score appears after the workout is completed and enough evidence has synced.";
 
+  const rawComponentScoresForNote = diagnosis?.componentScores as ComponentScores | null | undefined;
+  const capNoteMetric = rawComponentScoresForNote?.missingDominantMetric;
   const scoreConfidenceNote =
-    score !== null && provisional
-      ? "Provisional: band looks useful, but confidence improves once interval and intensity detail is richer."
-      : score === null && reviewState.isReviewable
-        ? "A richer upload with interval completion and intensity detail will unlock a stronger score."
-        : null;
+    score !== null && capNoteMetric
+      ? `${capNoteMetric} data is missing, so Intent Match is capped — treat the score as "likely on target" rather than confirmed.`
+      : score !== null && provisional
+        ? "Provisional: band looks useful, but confidence improves once interval and intensity detail is richer."
+        : score === null && reviewState.isReviewable
+          ? "A richer upload with interval completion and intensity detail will unlock a stronger score."
+          : null;
 
   const scoreTone: Tone =
     score === null

--- a/lib/session-review.ts
+++ b/lib/session-review.ts
@@ -619,7 +619,10 @@ export function createReviewViewModel(session: SessionReviewRow, options?: { tre
         : "Execution Score appears after the workout is completed and enough evidence has synced.";
 
   const rawComponentScoresForNote = diagnosis?.componentScores as ComponentScores | null | undefined;
-  const capNoteMetric = rawComponentScoresForNote?.missingDominantMetric;
+  const capNoteMetric =
+    rawComponentScoresForNote?.intentMatch?.capped
+      ? rawComponentScoresForNote.missingDominantMetric
+      : null;
   const scoreConfidenceNote =
     score !== null && capNoteMetric
       ? `${capNoteMetric} data is missing, so Intent Match is capped — treat the score as "likely on target" rather than confirmed.`

--- a/lib/training/week-metrics.ts
+++ b/lib/training/week-metrics.ts
@@ -58,3 +58,66 @@ export function getKeySessionsRemaining(sessions: WeekMetricSession[], todayIso?
     .filter((session) => session.isKey && session.status === "planned" && session.date >= floorDate)
     .sort((a, b) => a.date.localeCompare(b.date));
 }
+
+/**
+ * Compute how the week's planned load is distributed across days up to and including today.
+ *
+ * Returns the expected-completion share based on the week's actual shape rather than a
+ * linear `elapsedDays / 7` assumption. A back-loaded week with the long run on Saturday
+ * and long bike on Sunday should NOT flag "at risk" on Friday for being 48% complete —
+ * if only 48% of the week's minutes were scheduled Mon-Fri, 48% complete on Friday is
+ * on-plan.
+ */
+export function computeWeekShape(args: {
+  sessions: WeekMetricSession[];
+  weekStart: string;
+  todayIso: string;
+}): {
+  /** Fraction of week's planned minutes scheduled on or before today (0..1). */
+  expectedShareByToday: number;
+  /** Fraction of week's planned minutes scheduled Saturday + Sunday (0..1). */
+  weekendShare: number;
+  /** True if ≥50% of remaining (post-today) planned minutes fall on Sat/Sun. */
+  isWeekendLoaded: boolean;
+} {
+  const { sessions, weekStart, todayIso } = args;
+  const totalPlanned = sessions.reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
+  if (totalPlanned <= 0) {
+    return { expectedShareByToday: 0, weekendShare: 0, isWeekendLoaded: false };
+  }
+
+  const plannedOnOrBeforeToday = sessions
+    .filter((s) => s.date <= todayIso)
+    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
+
+  const plannedAfterToday = sessions
+    .filter((s) => s.date > todayIso)
+    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
+
+  const weekStartMs = Date.parse(`${weekStart}T00:00:00.000Z`);
+  const weekendMinutes = sessions
+    .filter((s) => {
+      const dow = new Date(Date.parse(`${s.date}T00:00:00.000Z`)).getUTCDay();
+      // Sunday = 0, Saturday = 6. We care about both weekend days.
+      return dow === 0 || dow === 6;
+    })
+    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
+
+  const weekendMinutesRemaining = sessions
+    .filter((s) => {
+      if (s.date <= todayIso) return false;
+      const dow = new Date(Date.parse(`${s.date}T00:00:00.000Z`)).getUTCDay();
+      return dow === 0 || dow === 6;
+    })
+    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
+
+  // Suppress unused-var warning on weekStartMs — kept for future: could branch by
+  // offset from Monday vs. Sunday week-starts.
+  void weekStartMs;
+
+  return {
+    expectedShareByToday: plannedOnOrBeforeToday / totalPlanned,
+    weekendShare: weekendMinutes / totalPlanned,
+    isWeekendLoaded: plannedAfterToday > 0 && weekendMinutesRemaining / plannedAfterToday >= 0.5
+  };
+}

--- a/lib/training/week-metrics.ts
+++ b/lib/training/week-metrics.ts
@@ -70,7 +70,6 @@ export function getKeySessionsRemaining(sessions: WeekMetricSession[], todayIso?
  */
 export function computeWeekShape(args: {
   sessions: WeekMetricSession[];
-  weekStart: string;
   todayIso: string;
 }): {
   /** Fraction of week's planned minutes scheduled on or before today (0..1). */
@@ -80,40 +79,34 @@ export function computeWeekShape(args: {
   /** True if ≥50% of remaining (post-today) planned minutes fall on Sat/Sun. */
   isWeekendLoaded: boolean;
 } {
-  const { sessions, weekStart, todayIso } = args;
-  const totalPlanned = sessions.reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
+  const { sessions, todayIso } = args;
+
+  let totalPlanned = 0;
+  let plannedOnOrBeforeToday = 0;
+  let plannedAfterToday = 0;
+  let weekendMinutes = 0;
+  let weekendMinutesRemaining = 0;
+
+  for (const session of sessions) {
+    const minutes = Math.max(session.durationMinutes, 0);
+    if (minutes === 0) continue;
+    totalPlanned += minutes;
+
+    const isPast = session.date <= todayIso;
+    if (isPast) plannedOnOrBeforeToday += minutes;
+    else plannedAfterToday += minutes;
+
+    const dow = new Date(Date.parse(`${session.date}T00:00:00.000Z`)).getUTCDay();
+    const isWeekend = dow === 0 || dow === 6;
+    if (isWeekend) {
+      weekendMinutes += minutes;
+      if (!isPast) weekendMinutesRemaining += minutes;
+    }
+  }
+
   if (totalPlanned <= 0) {
     return { expectedShareByToday: 0, weekendShare: 0, isWeekendLoaded: false };
   }
-
-  const plannedOnOrBeforeToday = sessions
-    .filter((s) => s.date <= todayIso)
-    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
-
-  const plannedAfterToday = sessions
-    .filter((s) => s.date > todayIso)
-    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
-
-  const weekStartMs = Date.parse(`${weekStart}T00:00:00.000Z`);
-  const weekendMinutes = sessions
-    .filter((s) => {
-      const dow = new Date(Date.parse(`${s.date}T00:00:00.000Z`)).getUTCDay();
-      // Sunday = 0, Saturday = 6. We care about both weekend days.
-      return dow === 0 || dow === 6;
-    })
-    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
-
-  const weekendMinutesRemaining = sessions
-    .filter((s) => {
-      if (s.date <= todayIso) return false;
-      const dow = new Date(Date.parse(`${s.date}T00:00:00.000Z`)).getUTCDay();
-      return dow === 0 || dow === 6;
-    })
-    .reduce((sum, s) => sum + Math.max(s.durationMinutes, 0), 0);
-
-  // Suppress unused-var warning on weekStartMs — kept for future: could branch by
-  // offset from Monday vs. Sunday week-starts.
-  void weekStartMs;
 
   return {
     expectedShareByToday: plannedOnOrBeforeToday / totalPlanned,


### PR DESCRIPTION
## Summary

Implements the nine reviewer priorities from PR #263.

- **Session scoring honesty**: cap Intent Match when the dominant effort signal is missing; relax the provisional gate when data completeness is ≥60%; track `uncappedScore` + `capped` so the Score Breakdown UI renders uncertainty bands.
- **Dashboard synthesis**: mount Readiness above Training Score with TSB trend + cross-discipline context, replace linear `elapsedDays/7` expectation with shape-aware expected share, exclude extras from the behind-on-plan calculation, and promote cross-discipline fatigue to a prominent banner.
- **Coach handoff**: reframe "Explain my score" to target the weakest component (Execution/Progression/Balance) with a component-specific prompt; harmonize coach page padding to remove the width seam.
- **Calendar UX**: broaden target extraction (bike/run intervals, swim sets, raw-text fallback); collapse coach notes by default to a single-sentence summary with one-click expand and acknowledge.
- **Cleanup pass** (commit `e6a5b2b`): collapse four filter/reduce passes in `computeWeekShape` and `buildWeeklyExecutionBrief` into single loops, drop the unused `weekStart` arg, and introduce a `TriggerType` union for coach-note color/label maps.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm test` (850/850 pass)
- [ ] Visual: dashboard readiness + fatigue banner render above training score
- [ ] Visual: calendar coach note collapses to summary and expands fully
- [ ] Visual: session review shows uncertainty band + caveat when Intent Match is capped
- [ ] Coach page: chat panel and "This week at a glance" share aligned edges

https://claude.ai/code/session_017sneeD5iWgN2yJwY5EL3b5