### PR TITLE
claude/fix-fit-duration-error-elgLi

### DIFF
--- a/lib/workouts/activity-parser.fit.test.ts
+++ b/lib/workouts/activity-parser.fit.test.ts
@@ -258,7 +258,45 @@ describe("parseFitFile", () => {
     expect(result.elapsedDurationSec).toBe(3600);
   });
 
-  test("throws when session, laps, and records all lack usable duration", async () => {
+  test("falls back to session.timestamp span for manual entries with no laps or records", async () => {
+    parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
+      callback(null, {
+        sessions: [
+          {
+            start_time: "2026-03-14T11:00:00.000Z",
+            timestamp: "2026-03-14T11:45:00.000Z",
+            sport: "running"
+          }
+        ]
+      });
+    });
+
+    const result = await parseFitFile(Buffer.from("fit"));
+
+    expect(result.durationSec).toBe(2700);
+    expect(result.elapsedDurationSec).toBe(2700);
+  });
+
+  test("falls back to fit.activity.total_timer_time when session and laps omit duration", async () => {
+    parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
+      callback(null, {
+        sessions: [
+          {
+            start_time: "2026-03-14T11:00:00.000Z",
+            sport: "running"
+          }
+        ],
+        activity: { total_timer_time: 1500 }
+      });
+    });
+
+    const result = await parseFitFile(Buffer.from("fit"));
+
+    expect(result.durationSec).toBe(1500);
+    expect(result.elapsedDurationSec).toBe(1500);
+  });
+
+  test("throws when session, laps, records, session-span, and activity all lack usable duration", async () => {
     parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
       callback(null, {
         sessions: [

--- a/lib/workouts/activity-parser.ts
+++ b/lib/workouts/activity-parser.ts
@@ -118,6 +118,19 @@ function deriveElapsedFromRecords(records: unknown): number | undefined {
   return positiveInt((lastMs - firstMs) / 1000);
 }
 
+function deriveElapsedFromSessionSpan(session: Record<string, unknown>): number | undefined {
+  const startMs = new Date(session.start_time as string | number | Date).getTime();
+  const endMs = new Date(session.timestamp as string | number | Date).getTime();
+  if (!Number.isFinite(startMs) || !Number.isFinite(endMs) || endMs <= startMs) return undefined;
+  return positiveInt((endMs - startMs) / 1000);
+}
+
+function deriveElapsedFromActivity(activity: unknown): number | undefined {
+  const record = asRecord(Array.isArray(activity) ? activity[0] : activity);
+  if (!record) return undefined;
+  return positiveInt(firstPositiveNumber([record.total_timer_time, record.total_elapsed_time]));
+}
+
 function normalizeSport(raw?: string) {
   const sport = (raw ?? "").toLowerCase();
   if (sport.includes("run")) return "run";
@@ -505,11 +518,23 @@ export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
   const elapsedDurationSec =
     positiveInt(firstPositiveNumber([session.total_elapsed_time, session.total_time, movingDurationSec]))
     ?? deriveElapsedFromLaps(fit?.laps)
-    ?? deriveElapsedFromRecords(fit?.records);
+    ?? deriveElapsedFromRecords(fit?.records)
+    ?? deriveElapsedFromSessionSpan(session)
+    ?? deriveElapsedFromActivity(fit?.activity);
   const durationSec = movingDurationSec ?? elapsedDurationSec ?? 0;
   const poolLengthM = firstPositiveNumber([session.pool_length, session.pool_length_m]);
 
   if (durationSec <= 0) {
+    const sessionKeys = Object.keys(session).sort();
+    const topKeys = Object.keys(fit ?? {}).sort();
+    console.error("[UPLOAD_PARSE] FIT duration fallbacks exhausted", {
+      sessionKeys,
+      topKeys,
+      lapsCount: Array.isArray(fit?.laps) ? fit.laps.length : 0,
+      recordsCount: Array.isArray(fit?.records) ? fit.records.length : 0,
+      sessionTimestamp: session.timestamp ?? null,
+      sessionStart: session.start_time ?? null
+    });
     throw new Error("FIT file missing usable duration.");
   }
 


### PR DESCRIPTION
Manually-created Garmin Connect activities ship with only a session message —
no laps and no records — so the lap-sum and record-span fallbacks added in
#265 never fire. Fall back to session.timestamp - session.start_time (FIT
convention: session timestamp = message creation = end of session) and to
fit.activity.total_timer_time. Also log the session/top-level keys when every
fallback is exhausted so future cases can be diagnosed from the error log.