### PR TITLE
fix(workouts): accept zero-duration FIT files and add distance/speed fallback

### DIFF
--- a/lib/workouts/activity-parser.fit.test.ts
+++ b/lib/workouts/activity-parser.fit.test.ts
@@ -296,20 +296,60 @@ describe("parseFitFile", () => {
     expect(result.elapsedDurationSec).toBe(1500);
   });
 
-  test("throws when session, laps, records, session-span, and activity all lack usable duration", async () => {
+  test("accepts 0-duration when all fallbacks are exhausted (manual-entry FIT)", async () => {
+    parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
+      callback(null, {
+        sessions: [
+          {
+            start_time: "2026-04-17T07:00:00.000Z",
+            timestamp: "2026-04-17T07:00:00.000Z",
+            sport: "training",
+            sub_sport: "strength_training",
+            total_elapsed_time: 0,
+            total_timer_time: 0,
+            total_moving_time: 0,
+            total_distance: 0,
+            avg_speed: 0
+          }
+        ],
+        laps: [
+          {
+            start_time: "2026-04-17T07:00:00.000Z",
+            timestamp: "2026-04-17T07:00:00.000Z",
+            total_elapsed_time: 0,
+            total_timer_time: 0
+          }
+        ]
+      });
+    });
+
+    const result = await parseFitFile(Buffer.from("fit"));
+
+    expect(result.durationSec).toBe(0);
+    expect(result.movingDurationSec).toBeUndefined();
+    expect(result.elapsedDurationSec).toBeUndefined();
+    expect(result.sportType).toBe("strength");
+  });
+
+  test("derives duration from distance/avg_speed when time fields are missing", async () => {
     parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
       callback(null, {
         sessions: [
           {
             start_time: "2026-03-14T11:00:00.000Z",
-            sport: "running"
+            timestamp: "2026-03-14T11:00:00.000Z",
+            sport: "running",
+            total_distance: 10000,
+            avg_speed: 2.778
           }
-        ],
-        records: [{ timestamp: "2026-03-14T11:00:00.000Z" }]
+        ]
       });
     });
 
-    await expect(parseFitFile(Buffer.from("fit"))).rejects.toThrow("FIT file missing usable duration.");
+    const result = await parseFitFile(Buffer.from("fit"));
+
+    expect(result.durationSec).toBe(3600);
+    expect(result.elapsedDurationSec).toBe(3600);
   });
 
   test("uses session duration even when laps and records disagree", async () => {

--- a/lib/workouts/activity-parser.fit.test.ts
+++ b/lib/workouts/activity-parser.fit.test.ts
@@ -352,6 +352,22 @@ describe("parseFitFile", () => {
     expect(result.elapsedDurationSec).toBe(3600);
   });
 
+  test("throws for endurance sports when all duration fallbacks are exhausted", async () => {
+    parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
+      callback(null, {
+        sessions: [
+          {
+            start_time: "2026-03-14T11:00:00.000Z",
+            sport: "running"
+          }
+        ],
+        records: [{ timestamp: "2026-03-14T11:00:00.000Z" }]
+      });
+    });
+
+    await expect(parseFitFile(Buffer.from("fit"))).rejects.toThrow("FIT file missing usable duration.");
+  });
+
   test("uses session duration even when laps and records disagree", async () => {
     parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
       callback(null, {

--- a/lib/workouts/activity-parser.ts
+++ b/lib/workouts/activity-parser.ts
@@ -131,6 +131,13 @@ function deriveElapsedFromActivity(activity: unknown): number | undefined {
   return positiveInt(firstPositiveNumber([record.total_timer_time, record.total_elapsed_time]));
 }
 
+function deriveElapsedFromDistanceSpeed(session: Record<string, unknown>): number | undefined {
+  const distance = positiveNumber(session.total_distance);
+  const speed = positiveNumber(session.avg_speed) ?? positiveNumber(session.enhanced_avg_speed);
+  if (!distance || !speed) return undefined;
+  return positiveInt(distance / speed);
+}
+
 function normalizeSport(raw?: string) {
   const sport = (raw ?? "").toLowerCase();
   if (sport.includes("run")) return "run";
@@ -520,22 +527,18 @@ export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
     ?? deriveElapsedFromLaps(fit?.laps)
     ?? deriveElapsedFromRecords(fit?.records)
     ?? deriveElapsedFromSessionSpan(session)
-    ?? deriveElapsedFromActivity(fit?.activity);
+    ?? deriveElapsedFromActivity(fit?.activity)
+    ?? deriveElapsedFromDistanceSpeed(session);
   const durationSec = movingDurationSec ?? elapsedDurationSec ?? 0;
   const poolLengthM = firstPositiveNumber([session.pool_length, session.pool_length_m]);
 
   if (durationSec <= 0) {
-    const sessionKeys = Object.keys(session).sort();
-    const topKeys = Object.keys(fit ?? {}).sort();
-    console.error("[UPLOAD_PARSE] FIT duration fallbacks exhausted", {
-      sessionKeys,
-      topKeys,
+    console.warn("[UPLOAD_PARSE] FIT duration fallbacks exhausted — accepting 0-duration activity", {
+      sport: session.sport ?? null,
+      subSport: session.sub_sport ?? null,
       lapsCount: Array.isArray(fit?.laps) ? fit.laps.length : 0,
-      recordsCount: Array.isArray(fit?.records) ? fit.records.length : 0,
-      sessionTimestamp: session.timestamp ?? null,
-      sessionStart: session.start_time ?? null
+      recordsCount: Array.isArray(fit?.records) ? fit.records.length : 0
     });
-    throw new Error("FIT file missing usable duration.");
   }
 
   const sportRaw = typeof session.sport === "string" ? session.sport : undefined;

--- a/lib/workouts/activity-parser.ts
+++ b/lib/workouts/activity-parser.ts
@@ -533,11 +533,20 @@ export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
   const poolLengthM = firstPositiveNumber([session.pool_length, session.pool_length_m]);
 
   if (durationSec <= 0) {
-    console.warn("[UPLOAD_PARSE] FIT duration fallbacks exhausted — accepting 0-duration activity", {
+    const sportLower = `${session.sport ?? ""}`.toLowerCase();
+    const subSportLower = `${session.sub_sport ?? ""}`.toLowerCase();
+    const isManualEntryCandidate =
+      sportLower === "training" ||
+      subSportLower.includes("strength") ||
+      subSportLower.includes("cardio") ||
+      sportLower === "fitness_equipment" ||
+      sportLower === "generic";
+    if (!isManualEntryCandidate) {
+      throw new Error("FIT file missing usable duration.");
+    }
+    console.warn("[UPLOAD_PARSE] FIT duration fallbacks exhausted — accepting 0-duration manual-entry activity", {
       sport: session.sport ?? null,
-      subSport: session.sub_sport ?? null,
-      lapsCount: Array.isArray(fit?.laps) ? fit.laps.length : 0,
-      recordsCount: Array.isArray(fit?.records) ? fit.records.length : 0
+      subSport: session.sub_sport ?? null
     });
   }
 


### PR DESCRIPTION
## Summary
- **Accept 0-duration FIT files** instead of throwing "FIT file missing usable duration" — manually-created Garmin Connect activities (e.g. strength training) have all time fields set to 0 with no records
- **Add distance/speed derivation fallback** (`total_distance / avg_speed`) for FIT files that have those fields but no explicit time data
- Log a warning when 0-duration is accepted so we have visibility without blocking uploads

## Test plan
- [x] Existing 8 activity-parser tests still pass
- [x] New test: accepts 0-duration manual-entry FIT (strength training shape)
- [x] New test: derives duration from distance/avg_speed when time fields missing
- [x] `npm run typecheck` passes
- [ ] Upload the problematic FIT file (`22559054408_ACTIVITY.fit`) and verify it ingests without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)