### PR TITLE
fix(activities): hide Link activity button when no candidates exist

### DIFF
--- a/app/(protected)/activities/[activityId]/activity-linking-card.tsx
+++ b/app/(protected)/activities/[activityId]/activity-linking-card.tsx
@@ -75,16 +75,18 @@ export function ActivityLinkingCard({
               </ul>
             )}
             <div className="mt-3 flex flex-wrap gap-2">
-              <button
-                className="btn-primary text-xs"
-                disabled={pending || !selectedSessionId}
-                onClick={() => startTransition(async () => {
-                  const result = await linkActivityAction(activityId, selectedSessionId);
-                  if (result?.error) setMessage(result.error);
-                })}
-              >
-                Link activity
-              </button>
+              {candidates.length > 0 && (
+                <button
+                  className="btn-primary text-xs"
+                  disabled={pending || !selectedSessionId}
+                  onClick={() => startTransition(async () => {
+                    const result = await linkActivityAction(activityId, selectedSessionId);
+                    if (result?.error) setMessage(result.error);
+                  })}
+                >
+                  Link activity
+                </button>
+              )}
               <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void markUnplannedAction(activityId))}>This wasn&apos;t planned</button>
             </div>
             {isUnplanned ? <p className="mt-2 text-xs text-muted">Marked as intentionally unplanned.</p> : null}


### PR DESCRIPTION
## Summary
- **Bug:** "Link activity" button rendered on the activity detail page even when no planned sessions existed for that day
- **Effect:** Button appeared clickable (green/primary style) but did nothing — `selectedSessionId` was empty so it was silently disabled
- **Fix:** Only render the button when `candidates.length > 0`

## Test plan
- [ ] Upload an activity on a day with no planned sessions — verify "Link activity" button is hidden
- [ ] Upload an activity on a day with planned sessions — verify "Link activity" button appears and works
- [ ] Verify "This wasn't planned" button still shows in both cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)