### PR TITLE
fix(strava): populate raw split halves so long-endurance reviews stop flagging HR/pace data as missing

### DIFF
--- a/lib/integrations/providers/strava/normalizer.test.ts
+++ b/lib/integrations/providers/strava/normalizer.test.ts
@@ -260,6 +260,57 @@ describe("normalizeStravaActivity", () => {
       expect((splits.paceFadePct as number)).toBeGreaterThan(0); // speed dropped
     });
 
+    it("populates raw first/last half HR and pace from splits (run)", () => {
+      // Consumers in lib/workouts/session-execution.ts#extractSplitMetrics and
+      // lib/coach/session-diagnosis.ts#hasSplits read the raw halves, not the
+      // derived percentages. Without these fields, Strava long-endurance runs
+      // falsely report "split metrics missing".
+      const withSplits: StravaActivitySummary = {
+        ...baseActivity,
+        splits_metric: [
+          { split: 1, distance: 1000, elapsed_time: 350, moving_time: 345, average_heartrate: 140, average_speed: 2.9 },
+          { split: 2, distance: 1000, elapsed_time: 348, moving_time: 345, average_heartrate: 142, average_speed: 2.88 },
+          { split: 3, distance: 1000, elapsed_time: 355, moving_time: 350, average_heartrate: 150, average_speed: 2.85 },
+          { split: 4, distance: 1000, elapsed_time: 360, moving_time: 355, average_heartrate: 155, average_speed: 2.8 },
+          { split: 5, distance: 1000, elapsed_time: 365, moving_time: 360, average_heartrate: 158, average_speed: 2.75 },
+          { split: 6, distance: 1000, elapsed_time: 370, moving_time: 365, average_heartrate: 160, average_speed: 2.7 }
+        ]
+      };
+      const result = normalizeStravaActivity(withSplits, "user-abc");
+      const splits = result.metrics_v2.splits as Record<string, unknown>;
+      const halves = result.metrics_v2.halves as Record<string, unknown>;
+
+      // first half HR avg = (140+142+150)/3 = 144, last half = (155+158+160)/3 = 157.67 → 158
+      expect(splits.firstHalfAvgHr).toBe(144);
+      expect(splits.lastHalfAvgHr).toBe(158);
+      // first half speed avg ≈ 2.8767 → pace 1000/2.8767 ≈ 347.62 s/km
+      expect(splits.firstHalfPaceSPerKm).toBeCloseTo(347.62, 1);
+      expect(splits.lastHalfPaceSPerKm).toBeCloseTo(363.64, 1);
+      // halves mirrors splits for consumer path-search compatibility
+      expect(halves.firstHalfAvgHr).toBe(144);
+      expect(halves.lastHalfPaceSPerKm).toBeCloseTo(363.64, 1);
+    });
+
+    it("omits pace halves for non-run sports but keeps HR halves", () => {
+      // Bike splits can carry HR but Strava pace halves aren't meaningful there.
+      const bikeWithSplits: StravaActivitySummary = {
+        ...baseActivity,
+        sport_type: "Ride",
+        splits_metric: [
+          { split: 1, distance: 1000, elapsed_time: 120, moving_time: 120, average_heartrate: 130, average_speed: 8.3 },
+          { split: 2, distance: 1000, elapsed_time: 120, moving_time: 120, average_heartrate: 132, average_speed: 8.3 },
+          { split: 3, distance: 1000, elapsed_time: 120, moving_time: 120, average_heartrate: 140, average_speed: 8.3 },
+          { split: 4, distance: 1000, elapsed_time: 120, moving_time: 120, average_heartrate: 142, average_speed: 8.3 }
+        ]
+      };
+      const result = normalizeStravaActivity(bikeWithSplits, "user-abc");
+      const splits = result.metrics_v2.splits as Record<string, unknown>;
+      expect(splits.firstHalfAvgHr).toBe(131);
+      expect(splits.lastHalfAvgHr).toBe(141);
+      expect(splits.firstHalfPaceSPerKm).toBeNull();
+      expect(splits.lastHalfPaceSPerKm).toBeNull();
+    });
+
     it("swim laps include per-lap pace, stroke rate, and rest detection", () => {
       const swimWithLaps: StravaActivitySummary = {
         ...baseActivity,

--- a/lib/integrations/providers/strava/normalizer.ts
+++ b/lib/integrations/providers/strava/normalizer.ts
@@ -210,11 +210,29 @@ function buildLapSummaries(laps: StravaLap[] | undefined, sport: string): Record
   });
 }
 
+type SplitHalves = {
+  firstHalfAvgHr: number | null;
+  lastHalfAvgHr: number | null;
+  firstHalfPaceSPerKm: number | null;
+  lastHalfPaceSPerKm: number | null;
+  hrDriftPct: number | null;
+  paceFadePct: number | null;
+};
+
+const EMPTY_SPLIT_HALVES: SplitHalves = {
+  firstHalfAvgHr: null,
+  lastHalfAvgHr: null,
+  firstHalfPaceSPerKm: null,
+  lastHalfPaceSPerKm: null,
+  hrDriftPct: null,
+  paceFadePct: null
+};
+
 function buildSplitSummaries(
   splits: StravaSplit[] | undefined,
   sport: string
-): { hrDriftPct: number | null; paceFadePct: number | null } {
-  if (!splits || splits.length < 4) return { hrDriftPct: null, paceFadePct: null };
+): SplitHalves {
+  if (!splits || splits.length < 4) return EMPTY_SPLIT_HALVES;
 
   const mid = Math.floor(splits.length / 2);
   const firstHalf = splits.slice(0, mid);
@@ -223,29 +241,48 @@ function buildSplitSummaries(
   // HR drift: average HR second half vs first half
   const firstHalfHrs = firstHalf.map((s) => s.average_heartrate).filter((v): v is number => v != null && v > 0);
   const lastHalfHrs = lastHalf.map((s) => s.average_heartrate).filter((v): v is number => v != null && v > 0);
+  let firstHalfAvgHr: number | null = null;
+  let lastHalfAvgHr: number | null = null;
   let hrDriftPct: number | null = null;
   if (firstHalfHrs.length > 0 && lastHalfHrs.length > 0) {
     const firstAvg = firstHalfHrs.reduce((a, b) => a + b, 0) / firstHalfHrs.length;
     const lastAvg = lastHalfHrs.reduce((a, b) => a + b, 0) / lastHalfHrs.length;
+    firstHalfAvgHr = Math.round(firstAvg);
+    lastHalfAvgHr = Math.round(lastAvg);
     if (firstAvg > 0) {
       hrDriftPct = Number((((lastAvg - firstAvg) / firstAvg) * 100).toFixed(1));
     }
   }
 
-  // Pace fade: average speed second half vs first half
+  // Pace fade: average speed second half vs first half. Pace halves only
+  // populated for run (same gate as top-level avg_pace_sec_per_km) — swim pace
+  // comes from stroke telemetry, bike doesn't use pace.
   const firstHalfSpeeds = firstHalf.map((s) => s.average_speed).filter((v): v is number => v != null && v > 0);
   const lastHalfSpeeds = lastHalf.map((s) => s.average_speed).filter((v): v is number => v != null && v > 0);
+  let firstHalfPaceSPerKm: number | null = null;
+  let lastHalfPaceSPerKm: number | null = null;
   let paceFadePct: number | null = null;
   if (firstHalfSpeeds.length > 0 && lastHalfSpeeds.length > 0) {
     const firstAvgSpeed = firstHalfSpeeds.reduce((a, b) => a + b, 0) / firstHalfSpeeds.length;
     const lastAvgSpeed = lastHalfSpeeds.reduce((a, b) => a + b, 0) / lastHalfSpeeds.length;
+    if (sport === "run") {
+      if (firstAvgSpeed > 0) firstHalfPaceSPerKm = Number((1000 / firstAvgSpeed).toFixed(2));
+      if (lastAvgSpeed > 0) lastHalfPaceSPerKm = Number((1000 / lastAvgSpeed).toFixed(2));
+    }
     if (firstAvgSpeed > 0) {
       // Negative means slowed down (higher pace = slower)
       paceFadePct = Number((((firstAvgSpeed - lastAvgSpeed) / firstAvgSpeed) * 100).toFixed(1));
     }
   }
 
-  return { hrDriftPct, paceFadePct };
+  return {
+    firstHalfAvgHr,
+    lastHalfAvgHr,
+    firstHalfPaceSPerKm,
+    lastHalfPaceSPerKm,
+    hrDriftPct,
+    paceFadePct
+  };
 }
 
 export function normalizeStravaActivity(
@@ -275,7 +312,8 @@ export function normalizeStravaActivity(
 
   const lapsCount = raw.laps?.length ?? null;
   const lapSummaries = buildLapSummaries(raw.laps, normalizedSport);
-  const { hrDriftPct, paceFadePct } = buildSplitSummaries(raw.splits_metric, normalizedSport);
+  const splitHalves = buildSplitSummaries(raw.splits_metric, normalizedSport);
+  const hasSplitData = Object.values(splitHalves).some((v) => v !== null);
 
   // Pause duration from elapsed vs moving time
   const pausedDurationSec = elapsedTimeSec > movingTimeSec
@@ -372,12 +410,8 @@ export function normalizeStravaActivity(
       count: pausedDurationSec != null && pausedDurationSec > 0 ? 1 : 0,
       totalPausedSec: pausedDurationSec ?? null
     },
-    splits: hrDriftPct !== null || paceFadePct !== null
-      ? { hrDriftPct, paceFadePct }
-      : null,
-    halves: hrDriftPct !== null || paceFadePct !== null
-      ? { hrDriftPct, paceFadePct }
-      : null,
+    splits: hasSplitData ? { ...splitHalves } : null,
+    halves: hasSplitData ? { ...splitHalves } : null,
     laps: lapSummaries,
     events: null
   };

--- a/lib/integrations/strava-metrics-backfill.ts
+++ b/lib/integrations/strava-metrics-backfill.ts
@@ -52,18 +52,44 @@ function delay(ms: number): Promise<void> {
 
 // ─── Core backfill ────────────────────────────────────────────────────────────
 
+export type BackfillOptions = {
+  /**
+   * When true, bypass the "already backfilled" skip check and re-process
+   * every Strava activity (optionally narrowed by externalActivityIds).
+   * Use when the normalizer shape has changed and historical rows need to
+   * be rewritten.
+   */
+  force?: boolean;
+  /**
+   * When set, only process activities whose external_activity_id matches
+   * one of these values. Values are compared as strings.
+   */
+  externalActivityIds?: string[];
+  onProgress?: (progress: BackfillProgress) => void;
+};
+
 /**
  * Re-fetch all Strava activities for a user from the detailed endpoint
  * and update their metrics_v2, laps, pace, and other enriched fields.
  *
- * Only processes activities that are missing metrics_v2 (or have no
- * schemaVersion). Activities already backfilled are skipped.
+ * By default, only processes activities that are missing metrics_v2 (or
+ * have no schemaVersion / no laps array). Pass `force: true` to re-process
+ * every activity — required when the normalizer output shape itself has
+ * changed and historical rows need to be rewritten.
  */
 export async function backfillStravaMetrics(
   userId: string,
   connection: ExternalConnection,
-  onProgress?: (progress: BackfillProgress) => void
+  optsOrProgress?: BackfillOptions | ((progress: BackfillProgress) => void)
 ): Promise<BackfillResult> {
+  // Back-compat: previous callers passed a bare onProgress callback.
+  const opts: BackfillOptions =
+    typeof optsOrProgress === "function" ? { onProgress: optsOrProgress } : optsOrProgress ?? {};
+  const onProgress = opts.onProgress;
+  const force = opts.force === true;
+  const idFilter = opts.externalActivityIds && opts.externalActivityIds.length > 0
+    ? new Set(opts.externalActivityIds.map((v) => String(v)))
+    : null;
   const supabase = getAdminClient();
 
   // Find all Strava activities missing metrics_v2
@@ -91,7 +117,7 @@ export async function backfillStravaMetrics(
     .eq("external_provider", "strava");
 
   const alreadyBackfilled = new Set<string>();
-  if (withMetrics) {
+  if (withMetrics && !force) {
     for (const row of withMetrics) {
       const mv2 = row.metrics_v2 as Record<string, unknown> | null;
       // Only consider fully enriched if laps is a real array (not null) —
@@ -103,7 +129,12 @@ export async function backfillStravaMetrics(
     }
   }
 
-  const needsBackfill = activities.filter((a) => !alreadyBackfilled.has(a.id));
+  const needsBackfill = activities.filter((a) => {
+    if (idFilter && (!a.external_activity_id || !idFilter.has(String(a.external_activity_id)))) {
+      return false;
+    }
+    return force || !alreadyBackfilled.has(a.id);
+  });
 
   if (needsBackfill.length === 0) {
     return { updated: 0, skipped: activities.length, failed: 0, rateLimited: false, total: activities.length };

--- a/scripts/strava-resync.ts
+++ b/scripts/strava-resync.ts
@@ -1,0 +1,83 @@
+/**
+ * One-off: force re-fetch & re-normalize Strava activities for a user,
+ * bypassing the "already backfilled" skip check in backfillStravaMetrics.
+ *
+ * Use when the Strava normalizer shape changes and historical rows need
+ * to be rewritten (e.g. the split-halves fix that added firstHalfAvgHr /
+ * lastHalfAvgHr / firstHalfPaceSPerKm / lastHalfPaceSPerKm to metrics_v2).
+ *
+ * Requires env vars (pulled from .env.local):
+ *   NEXT_PUBLIC_SUPABASE_URL
+ *   SUPABASE_SERVICE_ROLE_KEY
+ *   STRAVA_CLIENT_ID, STRAVA_CLIENT_SECRET (for token refresh)
+ *
+ * Usage:
+ *   npx tsx --env-file=.env.local scripts/strava-resync.ts <email> [externalActivityId ...]
+ *
+ * Examples:
+ *   # Re-sync ALL Strava activities for the user
+ *   npx tsx --env-file=.env.local scripts/strava-resync.ts damien.mcgrath7@gmail.com
+ *
+ *   # Re-sync a single Strava activity by its Strava ID
+ *   npx tsx --env-file=.env.local scripts/strava-resync.ts damien.mcgrath7@gmail.com 12345678901
+ */
+
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import { getConnection, refreshIfExpired } from "../lib/integrations/token-service";
+import { backfillStravaMetrics } from "../lib/integrations/strava-metrics-backfill";
+
+async function main() {
+  const [email, ...externalIds] = process.argv.slice(2);
+
+  if (!email) {
+    console.error("Usage: npx tsx --env-file=.env.local scripts/strava-resync.ts <email> [externalActivityId ...]");
+    process.exit(1);
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error("Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY");
+    process.exit(1);
+  }
+
+  const admin = createSupabaseClient(url, key);
+
+  // Default listUsers page size is 50 — bump it so we don't miss the target
+  // user in a larger DB. 1000 is the Supabase per-page ceiling.
+  const { data: userRow, error: userErr } = await admin.auth.admin.listUsers({ perPage: 1000 });
+  if (userErr) {
+    console.error("Failed to list users:", userErr.message);
+    process.exit(1);
+  }
+  const user = userRow.users.find((u) => u.email?.toLowerCase() === email.toLowerCase());
+  if (!user) {
+    console.error(`No user found with email ${email}`);
+    process.exit(1);
+  }
+
+  console.log(`[RESYNC] user ${email} → ${user.id}`);
+
+  const connection = await getConnection(user.id, "strava");
+  if (!connection) {
+    console.error("No Strava connection for this user.");
+    process.exit(1);
+  }
+
+  const fresh = await refreshIfExpired(connection);
+
+  const result = await backfillStravaMetrics(user.id, fresh, {
+    force: true,
+    externalActivityIds: externalIds.length > 0 ? externalIds : undefined,
+    onProgress: (p) => {
+      console.log(`[RESYNC] ${p.current}/${p.total} — updated=${p.updated} failed=${p.failed}`);
+    }
+  });
+
+  console.log("[RESYNC] done", result);
+}
+
+main().catch((err) => {
+  console.error("[RESYNC] fatal:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- Strava normalizer now emits `firstHalfAvgHr`, `lastHalfAvgHr`, `firstHalfPaceSPerKm`, `lastHalfPaceSPerKm` in `metrics_v2.splits`/`halves` alongside the existing drift/fade percentages. Pace halves are gated to run, matching the FIT parser and top-level `avg_pace_sec_per_km`.
- Fixes the user-facing bug where Strava-imported long-endurance sessions falsely reported "split metrics (HR drift or pace fade) missing — pair the right sensor next time" and had Intent Match capped, even when Strava returned per-km splits with HR and speed. Root cause was a shape mismatch between the normalizer output and what `extractSplitMetrics` / `hasSplits` / the drift+paceFade ratios expect.
- Adds a `force` option and `externalActivityIds` filter to `backfillStravaMetrics`, plus `scripts/strava-resync.ts` so historical rows can be re-normalized without being skipped. The backfill path is an UPDATE by id, so existing `session_activity_links` rows are preserved.

## Test plan
- [x] `npm run typecheck`
- [x] `npx jest lib/integrations/providers/strava/normalizer.test.ts` — 50/50 (2 new cases covering raw HR and pace halves for runs + HR-only halves for bike)
- [x] `npx jest lib/coach/session-diagnosis.test.ts lib/workouts/session-execution.test.ts` — 59/59 pass
- [x] `npx jest lib/integrations lib/workouts lib/session-review.test.ts lib/weekly-debrief.test.ts` — 190/190 pass (back-compat shim for the old `onProgress`-only `backfillStravaMetrics` signature verified by existing tests)
- [ ] Run the re-sync script against a real user and confirm the warning clears on `/sessions/aeb23b38-a8d0-4707-947b-79b3fc51a5f7`:
  ```
  npx tsx --env-file=.env.local scripts/strava-resync.ts damien.mcgrath7@gmail.com
  ```

🤖 Generated with [Claude Code](https://claude.com/claude-code)