### PR TITLE
fix(ai): stop weekly debriefs falling back on every run

### DIFF
--- a/lib/execution-review.ts
+++ b/lib/execution-review.ts
@@ -717,7 +717,7 @@ export async function generateCoachVerdict(args: {
     buildRequest: () => ({
       instructions: buildCoachVerdictInstructions(),
       reasoning: { effort: "low" },
-      max_output_tokens: 1600,
+      max_output_tokens: 3000,
       text: {
         format: zodTextFormat(coachVerdictSchema, "session_coach_verdict", {
           description: "Structured session review verdict."

--- a/lib/weekly-debrief/narrative.ts
+++ b/lib/weekly-debrief/narrative.ts
@@ -1,4 +1,5 @@
 import type { AthleteContextSnapshot } from "@/lib/athlete-context";
+import { zodTextFormat } from "openai/helpers/zod";
 import { callOpenAIWithFallback } from "@/lib/ai/call-with-fallback";
 import type {
   WeeklyDebriefFacts,
@@ -46,6 +47,13 @@ export async function generateNarrative(args: {
         "\n" +
         "Voice variance: avoid opening phrasings you have used in prior weeks (if recentFeedback or prior headlines are visible in the context, do not reuse them). Each week should sound distinct." +
         calibrationNote,
+      reasoning: { effort: "low" },
+      max_output_tokens: 4000,
+      text: {
+        format: zodTextFormat(weeklyDebriefNarrativeSchema, "weekly_debrief_narrative", {
+          description: "Structured weekly debrief narrative."
+        })
+      },
       input: [
         {
           role: "user" as const,

--- a/lib/workouts/post-sync-effects.ts
+++ b/lib/workouts/post-sync-effects.ts
@@ -35,11 +35,19 @@ export async function postSessionSyncSideEffects(args: {
   activityId: string;
   /** ISO date (YYYY-MM-DD) of the session, used to determine which week's debrief to refresh. */
   sessionDate?: string | null;
+  /**
+   * When true, skip the weekly debrief refresh. Use this from batch callers
+   * (e.g. refresh-ai-content.ts) that will refresh debriefs once per week
+   * separately, instead of N times per session.
+   */
+  skipDebriefRefresh?: boolean;
 }): Promise<void> {
   const effects: Promise<void>[] = [
     generateVerdictChain(args.supabase, args.userId, args.sessionId),
-    refreshDebriefForSession(args.supabase, args.userId, args.sessionDate ?? null),
   ];
+  if (!args.skipDebriefRefresh) {
+    effects.push(refreshDebriefForSession(args.supabase, args.userId, args.sessionDate ?? null));
+  }
 
   await Promise.allSettled(effects);
 }

--- a/scripts/refresh-ai-content.ts
+++ b/scripts/refresh-ai-content.ts
@@ -190,7 +190,8 @@ async function refreshSessions(supabase: SupabaseClient, args: Args): Promise<vo
       userId: args.userId,
       sessionId: session.id,
       activityId,
-      sessionDate: session.date
+      sessionDate: session.date,
+      skipDebriefRefresh: true
     });
   });
   console.log(`[sessions] ${ok} refreshed, ${failed} failed.`);


### PR DESCRIPTION
## Summary
- Weekly-debrief call now enforces JSON output via `zodTextFormat(weeklyDebriefNarrativeSchema, …)` and sets `max_output_tokens: 4000`. Previously asked for JSON in prose instructions only, so every call failed JSON parsing and quietly returned the deterministic fallback.
- Session-review verdict `max_output_tokens` lifted 1600 → 3000 so schema-rich sessions (FTP tests saw 2944-char truncation) no longer hit `max_output_tokens`.
- `postSessionSyncSideEffects` gains `skipDebriefRefresh`; `scripts/refresh-ai-content.ts` now passes it so the sessions pass doesn't redundantly rebuild each week's debrief before the dedicated `weekly` pass runs.

## Test plan
- [x] `npm run typecheck`
- [x] `npx jest lib/weekly-debrief.test.ts lib/execution-review` (3 suites, 24 tests)
- [ ] Re-run `npm run refresh-ai -- --user=<uuid>` against a real account — expect no `[weekly-debrief] Falling back: could not parse model output as JSON` lines and only one debrief refresh per week

🤖 Generated with [Claude Code](https://claude.com/claude-code)