### PR TITLE
feat(ai-review): two-pass weekly debrief with analytic findings

### DIFF
--- a/lib/weekly-debrief/analytic-findings.test.ts
+++ b/lib/weekly-debrief/analytic-findings.test.ts
@@ -1,0 +1,88 @@
+import { weeklyFindingsSchema, type WeeklyFindings } from "./analytic-findings";
+
+describe("weeklyFindingsSchema", () => {
+  const validFindings: WeeklyFindings = {
+    weekCharacter: "Consolidation week — volume held while intensity rose",
+    patterns: [
+      {
+        claim: "Every threshold effort this week was preceded by fatigue ≥4",
+        evidence: "Tue threshold run (fatigue 4/5), Thu threshold bike (fatigue 5/5), Sat tempo run (fatigue 4/5)"
+      },
+      {
+        claim: "Z2 pace-at-HR improved 12s/km across two easy runs",
+        evidence: "Mon easy 5:24/km @ 142bpm vs. Fri easy 5:12/km @ 141bpm"
+      }
+    ],
+    primaryInsight: {
+      insight: "Threshold ceiling is holding while aerobic base expands — easy pace at the same HR improved 12s/km this week.",
+      sourceSignals: ["z2-pace-at-hr", "rolling-trend-4wk"],
+      confidence: "medium"
+    },
+    tensions: [
+      "Composite score rose but durability fade increased late in the threshold bike"
+    ],
+    carryForwardCandidates: [
+      "Keep the Tue/Thu threshold spacing — it is producing gains without decoupling.",
+      "If fatigue reports another 4+ before a hard session, swap the hard day for Z2 rather than pushing through."
+    ],
+    confidenceNote: null
+  };
+
+  test("accepts a well-formed findings payload", () => {
+    const parsed = weeklyFindingsSchema.safeParse(validFindings);
+    expect(parsed.success).toBe(true);
+  });
+
+  test("rejects empty patterns array", () => {
+    const parsed = weeklyFindingsSchema.safeParse({ ...validFindings, patterns: [] });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects more than 4 patterns", () => {
+    const parsed = weeklyFindingsSchema.safeParse({
+      ...validFindings,
+      patterns: Array.from({ length: 5 }, (_, i) => ({
+        claim: `claim ${i}`,
+        evidence: `evidence ${i}`
+      }))
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects fewer than 2 carryForwardCandidates", () => {
+    const parsed = weeklyFindingsSchema.safeParse({
+      ...validFindings,
+      carryForwardCandidates: ["only one"]
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects primaryInsight without any sourceSignals", () => {
+    const parsed = weeklyFindingsSchema.safeParse({
+      ...validFindings,
+      primaryInsight: { ...validFindings.primaryInsight, sourceSignals: [] }
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("rejects invalid confidence value", () => {
+    const parsed = weeklyFindingsSchema.safeParse({
+      ...validFindings,
+      primaryInsight: { ...validFindings.primaryInsight, confidence: "certain" }
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("accepts empty tensions array (upper-bounded, not required)", () => {
+    const parsed = weeklyFindingsSchema.safeParse({ ...validFindings, tensions: [] });
+    expect(parsed.success).toBe(true);
+  });
+
+  test("accepts nullable confidenceNote", () => {
+    const withNote = weeklyFindingsSchema.safeParse({
+      ...validFindings,
+      confidenceNote: "Only 2 threshold sessions this week; pattern is suggestive not conclusive."
+    });
+    expect(withNote.success).toBe(true);
+  });
+});

--- a/lib/weekly-debrief/analytic-findings.ts
+++ b/lib/weekly-debrief/analytic-findings.ts
@@ -1,0 +1,126 @@
+import "openai/shims/node";
+import { z } from "zod";
+import { zodTextFormat } from "openai/helpers/zod";
+import type { AthleteContextSnapshot } from "@/lib/athlete-context";
+import { callOpenAIWithFallback } from "@/lib/ai/call-with-fallback";
+import { getCoachModel } from "@/lib/openai";
+import type {
+  WeeklyDebriefFacts,
+  WeeklyDebriefEvidenceItem,
+  WeeklyDebriefActivityEvidence,
+  WeeklyDebriefCheckIn
+} from "./types";
+
+export const weeklyFindingsSchema = z.object({
+  weekCharacter: z.string().min(1).max(120),
+  patterns: z.array(z.object({
+    claim: z.string().min(1).max(220),
+    evidence: z.string().min(1).max(240)
+  })).min(1).max(4),
+  primaryInsight: z.object({
+    insight: z.string().min(1).max(320),
+    sourceSignals: z.array(z.string().min(1).max(80)).min(1).max(4),
+    confidence: z.enum(["high", "medium", "low"])
+  }),
+  tensions: z.array(z.string().min(1).max(220)).max(3),
+  carryForwardCandidates: z.array(z.string().min(1).max(280)).min(2).max(3),
+  confidenceNote: z.string().min(1).max(220).nullable()
+});
+
+export type WeeklyFindings = z.infer<typeof weeklyFindingsSchema>;
+
+const FINDINGS_FALLBACK_SENTINEL: WeeklyFindings = {
+  weekCharacter: "unavailable",
+  patterns: [{ claim: "unavailable", evidence: "unavailable" }],
+  primaryInsight: {
+    insight: "unavailable",
+    sourceSignals: ["unavailable"],
+    confidence: "low"
+  },
+  tensions: [],
+  carryForwardCandidates: ["unavailable", "unavailable"],
+  confidenceNote: null
+};
+
+const ANALYTIC_INSTRUCTIONS = `You are an analytic pass. Your job is to extract structured findings for an endurance athlete's weekly debrief. A later narrative pass will turn these into prose — you do not write for the athlete, you write for the narrative pass.
+
+Output structured JSON only. No prose, no coach voice.
+
+Goals, ranked:
+1. Spot cross-session patterns the athlete would not see by skimming individual reviews (e.g. "every threshold session this week was preceded by fatigue 4+ — execution held but the cost is stacking").
+2. Name tensions where signals disagree (e.g. HR suggests easy, RPE suggests hard; composite score up while durability down).
+3. Surface ONE primaryInsight — the most important non-obvious finding. It must reference specific numbers, dates, or trends visible in facts/evidence/trendsThisWeek/scoreTrajectory/activityEvidence, and cite which signals grounded it via sourceSignals (e.g. ["decoupling", "historical-comparable", "z2-pace-at-hr"]).
+4. Propose 2–3 carryForwardCandidates as complete, self-contained sentences the narrative pass may refine or adopt.
+5. Summarise the week in one weekCharacter phrase (≤120 chars) — an archetype the narrative voice can hang off (e.g. "Consolidation week under rising CTL", "Recovery stalled — intensity bled into easy days").
+6. confidenceNote: what the analytic pass could not pin down (small sample, missing HR data, only one key session completed, etc.). Null if nothing material.
+
+Hard constraints:
+- Every patterns[].evidence must cite at least one specific number, date, or named session from the input.
+- primaryInsight.confidence: "high" only if the pattern is supported by ≥3 sessions OR a multi-week trend; "medium" for a 2-session or cross-signal pattern; "low" when the signal is present but under-evidenced.
+- Do not repeat claims verbatim across patterns. Distinct patterns only.
+- If the week has too few completed sessions to detect a meaningful pattern, say so in primaryInsight.insight and set confidence: "low".
+- No hype, no diagnosis, no certainty beyond the data.`;
+
+export async function generateAnalyticFindings(args: {
+  facts: WeeklyDebriefFacts;
+  evidence: WeeklyDebriefEvidenceItem[];
+  activityEvidence: WeeklyDebriefActivityEvidence[];
+  athleteContext: AthleteContextSnapshot | null;
+  checkIn: WeeklyDebriefCheckIn | null;
+  recentFeedback?: Array<{ weekStart: string; helpful: boolean | null; accurate: boolean | null; note: string | null }>;
+  trendsThisWeek?: Array<{ discipline: string; trend: string; confidence: string; summary: string }> | null;
+  scoreTrajectory?: Array<{ date: string; composite: number; execution: number | null; progression: number | null; balance: number | null }> | null;
+}): Promise<{ findings: WeeklyFindings | null; source: "ai" | "fallback" }> {
+  const result = await callOpenAIWithFallback<WeeklyFindings>({
+    logTag: "weekly-debrief-findings",
+    fallback: FINDINGS_FALLBACK_SENTINEL,
+    buildRequest: () => ({
+      model: getCoachModel({ deep: true }),
+      instructions: ANALYTIC_INSTRUCTIONS,
+      reasoning: { effort: "medium" },
+      max_output_tokens: 8000,
+      text: {
+        format: zodTextFormat(weeklyFindingsSchema, "weekly_findings", {
+          description: "Structured analytic findings for the weekly debrief narrative pass."
+        })
+      },
+      input: [
+        {
+          role: "user" as const,
+          content: [
+            {
+              type: "input_text" as const,
+              text: JSON.stringify({
+                facts: args.facts,
+                evidence: args.evidence,
+                activityEvidence: args.activityEvidence,
+                athleteContext: args.athleteContext ? {
+                  weeklyState: args.athleteContext.weeklyState,
+                  declared: {
+                    weeklyConstraints: args.athleteContext.declared.weeklyConstraints,
+                    limiters: args.athleteContext.declared.limiters.slice(0, 3).map((limiter) => limiter.value)
+                  }
+                } : null,
+                checkIn: args.checkIn ? {
+                  fatigue: args.checkIn.fatigueScore,
+                  stress: args.checkIn.stressScore,
+                  motivation: args.checkIn.motivationScore,
+                  notes: args.checkIn.weekNotes
+                } : null,
+                recentFeedback: args.recentFeedback ?? null,
+                trendsThisWeek: args.trendsThisWeek ?? null,
+                scoreTrajectory: args.scoreTrajectory ?? null
+              })
+            }
+          ]
+        }
+      ]
+    }),
+    schema: weeklyFindingsSchema
+  });
+
+  if (result.source === "fallback") {
+    return { findings: null, source: "fallback" };
+  }
+  return { findings: result.value, source: "ai" };
+}

--- a/lib/weekly-debrief/narrative.ts
+++ b/lib/weekly-debrief/narrative.ts
@@ -10,6 +10,29 @@ import type {
 } from "./types";
 import { weeklyDebriefNarrativeSchema } from "./types";
 import { normalizeNarrativePayload, hydrateNarrativePayload } from "./deterministic";
+import type { WeeklyFindings } from "./analytic-findings";
+
+const SINGLE_PASS_INSTRUCTIONS = "You write Weekly Debrief copy for endurance athletes. Use only the provided facts and evidence. Be calm, precise, coach-like, and proportionate to evidence. Read the sport-specific activityEvidence closely: for runs, prioritize splits, HR drift, pace fade, elevation, and zone context over lap-by-lap narration; for swims, prioritize rep structure, rest, pool context, stroke metrics, and second-half fade over generic summary; for rides, prioritize power, load, cadence, and execution control. Distinguish facts, observations, and carry-forward suggestions. Avoid hype, diagnosis, and certainty beyond the data. If trendsThisWeek is provided, weave relevant session-over-session trends into observations (e.g. 'Your threshold run shows steady improvement over the last 3 weeks'). If scoreTrajectory is provided, reference the composite Training Score trajectory where it adds insight (e.g. score direction, which dimension is strongest/weakest). Do not over-emphasise scores — use them to contextualise, not replace, the evidence-based narrative. carryForward items must be complete, self-contained sentences — do not end mid-thought. Each carryForward item has a 280-character limit; use the full space when needed but always end with a complete sentence.\n" +
+  "\n" +
+  "nonObviousInsight (≤360 chars, required): surface one cross-session pattern the athlete would not see by skimming individual reviews — e.g. 'Every hard session this week was preceded by a poor sleep rating (2/5) — execution is holding but recovery signals are stacking.' or 'Threshold power has held the same 260W ceiling for three weeks while HR at that power has dropped 4bpm — aerobic base is expanding under the ceiling.' Ground every claim in a specific number, date, or trend visible in the facts/evidence/trendsThisWeek/scoreTrajectory. Do not repeat the executiveSummary. If no cross-session signal emerges, say so honestly ('Too few completed sessions this week to surface a cross-session pattern; focus on next week for a trend read.').\n" +
+  "\n" +
+  "Voice variance: avoid opening phrasings you have used in prior weeks (if recentFeedback or prior headlines are visible in the context, do not reuse them). Each week should sound distinct.";
+
+const FINDINGS_DRIVEN_INSTRUCTIONS = "You write Weekly Debrief copy for endurance athletes. An analytic pass has already extracted structured findings — your job is voice and format, not re-analysis.\n" +
+  "\n" +
+  "How to use findings:\n" +
+  "- nonObviousInsight: start from findings.primaryInsight.insight and phrase it for an athlete. Do NOT invent a different insight. If findings.primaryInsight.confidence is 'low', hedge the language ('appears', 'worth watching') instead of stating it as fact. Keep ≤360 chars.\n" +
+  "- executiveSummary: lead with findings.weekCharacter as the angle, then ground it in 1–2 specifics from facts/evidence. Do not reuse weekCharacter verbatim — translate it into prose.\n" +
+  "- highlights: 3 concrete wins grounded in evidence; draw from findings.patterns where relevant.\n" +
+  "- observations: 1–3 items. Prefer findings.patterns and findings.tensions — these are the cross-session signals the athlete needs surfaced.\n" +
+  "- carryForward: 2 items. Adopt or refine from findings.carryForwardCandidates; each must be a complete self-contained sentence ≤280 chars.\n" +
+  "\n" +
+  "Voice rules:\n" +
+  "- Calm, precise, coach-like. No hype. No diagnosis beyond the data.\n" +
+  "- Sport-specific: for runs weigh splits, HR drift, pace fade; for swims weigh rep structure, rest, stroke metrics; for rides weigh power, load, cadence.\n" +
+  "- Avoid opening phrasings from prior weeks — each week must sound distinct.\n" +
+  "- If findings.confidenceNote is present, honour it: don't overclaim signals the analytic pass already flagged as under-evidenced.\n" +
+  "- Do not repeat the executiveSummary inside nonObviousInsight. They serve different purposes.";
 
 export async function generateNarrative(args: {
   facts: WeeklyDebriefFacts;
@@ -21,8 +44,8 @@ export async function generateNarrative(args: {
   recentFeedback?: Array<{ weekStart: string; helpful: boolean | null; accurate: boolean | null; note: string | null }>;
   trendsThisWeek?: Array<{ discipline: string; trend: string; confidence: string; summary: string }> | null;
   scoreTrajectory?: Array<{ date: string; composite: number; execution: number | null; progression: number | null; balance: number | null }> | null;
+  findings?: WeeklyFindings | null;
 }) {
-  // Build calibration note from recent feedback
   let calibrationNote = "";
   if (args.recentFeedback && args.recentFeedback.length > 0) {
     const inaccurateCount = args.recentFeedback.filter((f) => f.accurate === false).length;
@@ -36,17 +59,14 @@ export async function generateNarrative(args: {
     }
   }
 
+  const hasFindings = args.findings != null;
+  const baseInstructions = hasFindings ? FINDINGS_DRIVEN_INSTRUCTIONS : SINGLE_PASS_INSTRUCTIONS;
+
   const result = await callOpenAIWithFallback<WeeklyDebriefNarrative>({
     logTag: "weekly-debrief",
     fallback: args.deterministicFallback,
     buildRequest: () => ({
-      instructions:
-        "You write Weekly Debrief copy for endurance athletes. Use only the provided facts and evidence. Be calm, precise, coach-like, and proportionate to evidence. Read the sport-specific activityEvidence closely: for runs, prioritize splits, HR drift, pace fade, elevation, and zone context over lap-by-lap narration; for swims, prioritize rep structure, rest, pool context, stroke metrics, and second-half fade over generic summary; for rides, prioritize power, load, cadence, and execution control. Distinguish facts, observations, and carry-forward suggestions. Avoid hype, diagnosis, and certainty beyond the data. If trendsThisWeek is provided, weave relevant session-over-session trends into observations (e.g. 'Your threshold run shows steady improvement over the last 3 weeks'). If scoreTrajectory is provided, reference the composite Training Score trajectory where it adds insight (e.g. score direction, which dimension is strongest/weakest). Do not over-emphasise scores — use them to contextualise, not replace, the evidence-based narrative. carryForward items must be complete, self-contained sentences — do not end mid-thought. Each carryForward item has a 280-character limit; use the full space when needed but always end with a complete sentence.\n" +
-        "\n" +
-        "nonObviousInsight (≤360 chars, required): surface one cross-session pattern the athlete would not see by skimming individual reviews — e.g. 'Every hard session this week was preceded by a poor sleep rating (2/5) — execution is holding but recovery signals are stacking.' or 'Threshold power has held the same 260W ceiling for three weeks while HR at that power has dropped 4bpm — aerobic base is expanding under the ceiling.' Ground every claim in a specific number, date, or trend visible in the facts/evidence/trendsThisWeek/scoreTrajectory. Do not repeat the executiveSummary. If no cross-session signal emerges, say so honestly ('Too few completed sessions this week to surface a cross-session pattern; focus on next week for a trend read.').\n" +
-        "\n" +
-        "Voice variance: avoid opening phrasings you have used in prior weeks (if recentFeedback or prior headlines are visible in the context, do not reuse them). Each week should sound distinct." +
-        calibrationNote,
+      instructions: baseInstructions + calibrationNote,
       reasoning: { effort: "low" },
       max_output_tokens: 4000,
       text: {
@@ -80,6 +100,7 @@ export async function generateNarrative(args: {
                 recentFeedback: args.recentFeedback ?? null,
                 trendsThisWeek: args.trendsThisWeek ?? null,
                 scoreTrajectory: args.scoreTrajectory ?? null,
+                findings: args.findings ?? null
               })
             }
           ]

--- a/lib/weekly-debrief/persistence.ts
+++ b/lib/weekly-debrief/persistence.ts
@@ -31,6 +31,7 @@ import {
 } from "./deterministic";
 import { buildWeeklyDebriefFacts } from "./facts";
 import { generateNarrative } from "./narrative";
+import { generateAnalyticFindings } from "./analytic-findings";
 
 async function loadWeeklyDebriefInputs(args: {
   supabase: SupabaseClient;
@@ -338,6 +339,19 @@ export async function computeWeeklyDebrief(args: {
       }))
     : null;
 
+  // Two-pass: analytic findings (gpt-5.4, effort: medium) → narrative (gpt-5-mini).
+  // If the analytic pass falls back, the narrative pass runs single-pass on raw inputs.
+  const analytic = await generateAnalyticFindings({
+    facts: base.facts,
+    evidence: base.evidence,
+    activityEvidence: base.activityEvidence,
+    athleteContext: inputs.athleteContext,
+    checkIn: inputs.checkIn,
+    recentFeedback: recentFeedback.length > 0 ? recentFeedback : undefined,
+    trendsThisWeek,
+    scoreTrajectory,
+  });
+
   const generated = await generateNarrative({
     facts: base.facts,
     evidence: base.evidence,
@@ -348,6 +362,7 @@ export async function computeWeeklyDebrief(args: {
     recentFeedback: recentFeedback.length > 0 ? recentFeedback : undefined,
     trendsThisWeek,
     scoreTrajectory,
+    findings: analytic.findings,
   });
   const narrative = generated.narrative;
   const facts = weeklyDebriefFactsSchema.parse({

--- a/lib/weekly-debrief/types.ts
+++ b/lib/weekly-debrief/types.ts
@@ -3,7 +3,7 @@ import { clip } from "@/lib/openai";
 import type { AthleteContextSnapshot } from "@/lib/athlete-context";
 import type { PersistedExecutionReview } from "@/lib/execution-review";
 
-export const WEEKLY_DEBRIEF_GENERATION_VERSION = 6;
+export const WEEKLY_DEBRIEF_GENERATION_VERSION = 7;
 
 /** @deprecated Use clip() from lib/openai.ts — this alias exists only for schema transform compatibility. */
 export const truncateStr = clip;


### PR DESCRIPTION
## Summary
- Split weekly debrief generation: analytic pass (`gpt-5.4`, reasoning `medium`) emits structured findings (weekCharacter, patterns, primaryInsight, tensions, carryForwardCandidates); narrative pass (`gpt-5-mini`) translates them into coach voice.
- Narrative prompt forks on findings presence — if the analytic pass falls back, the single-pass prompt runs on raw inputs (current behaviour preserved). Deterministic fallback remains the last resort.
- Bumps `WEEKLY_DEBRIEF_GENERATION_VERSION` 6 → 7 so existing weeks recompute on next refresh.
- Activates `OPENAI_COACH_DEEP_MODEL` (was defined but unused). Targets the templated-feel problem (4/5 historical debriefs shared the same `takeaway_title`).

Includes the earlier reliability fix (`36b443e`) from `fix/ai-content-refresh-reliability` as its base commit.

## Test plan
- [ ] `npm run typecheck`
- [ ] `npm run lint`
- [ ] `npm run test`
- [ ] `npm run refresh-ai -- --user=<uuid> --scope=weekly --since=<iso-date>` on a real account — confirm fresh debriefs render without `[weekly-debrief-findings]` fallback warnings
- [ ] Spot-check 3 regenerated weeks: insights are non-obvious, headlines differ, voice varies across weeks

🤖 Generated with [Claude Code](https://claude.com/claude-code)