### PR TITLE
feat(ai-review): variance corpus for weekly debrief two-pass generator

### DIFF
--- a/lib/weekly-debrief/analytic-findings.ts
+++ b/lib/weekly-debrief/analytic-findings.ts
@@ -10,6 +10,7 @@ import type {
   WeeklyDebriefActivityEvidence,
   WeeklyDebriefCheckIn
 } from "./types";
+import type { WeeklyDebriefPriorHeadline } from "./variance-corpus";
 
 export const weeklyFindingsSchema = z.object({
   weekCharacter: z.string().min(1).max(120),
@@ -59,7 +60,13 @@ Hard constraints:
 - primaryInsight.confidence: "high" only if the pattern is supported by ≥3 sessions OR a multi-week trend; "medium" for a 2-session or cross-signal pattern; "low" when the signal is present but under-evidenced.
 - Do not repeat claims verbatim across patterns. Distinct patterns only.
 - If the week has too few completed sessions to detect a meaningful pattern, say so in primaryInsight.insight and set confidence: "low".
-- No hype, no diagnosis, no certainty beyond the data.`;
+- No hype, no diagnosis, no certainty beyond the data.
+
+Variance (priorHeadlines):
+- priorHeadlines is a list of the athlete's most recent weekly debriefs (coachHeadline, executiveSummary, nonObviousInsight, takeawayTitle). Treat it as a "do not repeat" corpus — not as evidence about training.
+- weekCharacter, every patterns[].claim, and primaryInsight.insight must avoid reusing the opening phrasings, metaphors, or framings that appear in priorHeadlines. If this week's signals genuinely match a prior pattern, describe the continuation in fresh language rather than restating the previous phrasing.
+- Specifically do not echo prior takeawayTitle phrases (e.g. "The week had one clear strength and one clear wobble") inside weekCharacter or primaryInsight.
+- Reusing concrete numbers, dates, or session names is fine — only the prose framings must be different.`;
 
 export async function generateAnalyticFindings(args: {
   facts: WeeklyDebriefFacts;
@@ -70,6 +77,7 @@ export async function generateAnalyticFindings(args: {
   recentFeedback?: Array<{ weekStart: string; helpful: boolean | null; accurate: boolean | null; note: string | null }>;
   trendsThisWeek?: Array<{ discipline: string; trend: string; confidence: string; summary: string }> | null;
   scoreTrajectory?: Array<{ date: string; composite: number; execution: number | null; progression: number | null; balance: number | null }> | null;
+  priorHeadlines?: WeeklyDebriefPriorHeadline[];
 }): Promise<{ findings: WeeklyFindings | null; source: "ai" | "fallback" }> {
   const result = await callOpenAIWithFallback<WeeklyFindings>({
     logTag: "weekly-debrief-findings",
@@ -109,7 +117,8 @@ export async function generateAnalyticFindings(args: {
                 } : null,
                 recentFeedback: args.recentFeedback ?? null,
                 trendsThisWeek: args.trendsThisWeek ?? null,
-                scoreTrajectory: args.scoreTrajectory ?? null
+                scoreTrajectory: args.scoreTrajectory ?? null,
+                priorHeadlines: args.priorHeadlines && args.priorHeadlines.length > 0 ? args.priorHeadlines : null
               })
             }
           ]

--- a/lib/weekly-debrief/narrative.ts
+++ b/lib/weekly-debrief/narrative.ts
@@ -11,12 +11,13 @@ import type {
 import { weeklyDebriefNarrativeSchema } from "./types";
 import { normalizeNarrativePayload, hydrateNarrativePayload } from "./deterministic";
 import type { WeeklyFindings } from "./analytic-findings";
+import type { WeeklyDebriefPriorHeadline } from "./variance-corpus";
 
 const SINGLE_PASS_INSTRUCTIONS = "You write Weekly Debrief copy for endurance athletes. Use only the provided facts and evidence. Be calm, precise, coach-like, and proportionate to evidence. Read the sport-specific activityEvidence closely: for runs, prioritize splits, HR drift, pace fade, elevation, and zone context over lap-by-lap narration; for swims, prioritize rep structure, rest, pool context, stroke metrics, and second-half fade over generic summary; for rides, prioritize power, load, cadence, and execution control. Distinguish facts, observations, and carry-forward suggestions. Avoid hype, diagnosis, and certainty beyond the data. If trendsThisWeek is provided, weave relevant session-over-session trends into observations (e.g. 'Your threshold run shows steady improvement over the last 3 weeks'). If scoreTrajectory is provided, reference the composite Training Score trajectory where it adds insight (e.g. score direction, which dimension is strongest/weakest). Do not over-emphasise scores — use them to contextualise, not replace, the evidence-based narrative. carryForward items must be complete, self-contained sentences — do not end mid-thought. Each carryForward item has a 280-character limit; use the full space when needed but always end with a complete sentence.\n" +
   "\n" +
   "nonObviousInsight (≤360 chars, required): surface one cross-session pattern the athlete would not see by skimming individual reviews — e.g. 'Every hard session this week was preceded by a poor sleep rating (2/5) — execution is holding but recovery signals are stacking.' or 'Threshold power has held the same 260W ceiling for three weeks while HR at that power has dropped 4bpm — aerobic base is expanding under the ceiling.' Ground every claim in a specific number, date, or trend visible in the facts/evidence/trendsThisWeek/scoreTrajectory. Do not repeat the executiveSummary. If no cross-session signal emerges, say so honestly ('Too few completed sessions this week to surface a cross-session pattern; focus on next week for a trend read.').\n" +
   "\n" +
-  "Voice variance: avoid opening phrasings you have used in prior weeks (if recentFeedback or prior headlines are visible in the context, do not reuse them). Each week should sound distinct.";
+  "Voice variance: priorHeadlines lists the athlete's most recent coachHeadline / executiveSummary / nonObviousInsight / takeawayTitle. Treat it as a 'do not reuse' corpus: do not echo those opening phrasings, metaphors, or framings. Concrete numbers, dates, and session names may repeat — the prose must not. Each week should sound distinct.";
 
 const FINDINGS_DRIVEN_INSTRUCTIONS = "You write Weekly Debrief copy for endurance athletes. An analytic pass has already extracted structured findings — your job is voice and format, not re-analysis.\n" +
   "\n" +
@@ -30,7 +31,7 @@ const FINDINGS_DRIVEN_INSTRUCTIONS = "You write Weekly Debrief copy for enduranc
   "Voice rules:\n" +
   "- Calm, precise, coach-like. No hype. No diagnosis beyond the data.\n" +
   "- Sport-specific: for runs weigh splits, HR drift, pace fade; for swims weigh rep structure, rest, stroke metrics; for rides weigh power, load, cadence.\n" +
-  "- Avoid opening phrasings from prior weeks — each week must sound distinct.\n" +
+  "- Avoid opening phrasings from prior weeks — each week must sound distinct. priorHeadlines (if present) is a 'do not reuse' corpus of the athlete's recent coachHeadline/executiveSummary/nonObviousInsight/takeawayTitle; do not echo those framings.\n" +
   "- If findings.confidenceNote is present, honour it: don't overclaim signals the analytic pass already flagged as under-evidenced.\n" +
   "- Do not repeat the executiveSummary inside nonObviousInsight. They serve different purposes.";
 
@@ -45,6 +46,7 @@ export async function generateNarrative(args: {
   trendsThisWeek?: Array<{ discipline: string; trend: string; confidence: string; summary: string }> | null;
   scoreTrajectory?: Array<{ date: string; composite: number; execution: number | null; progression: number | null; balance: number | null }> | null;
   findings?: WeeklyFindings | null;
+  priorHeadlines?: WeeklyDebriefPriorHeadline[];
 }) {
   let calibrationNote = "";
   if (args.recentFeedback && args.recentFeedback.length > 0) {
@@ -100,7 +102,8 @@ export async function generateNarrative(args: {
                 recentFeedback: args.recentFeedback ?? null,
                 trendsThisWeek: args.trendsThisWeek ?? null,
                 scoreTrajectory: args.scoreTrajectory ?? null,
-                findings: args.findings ?? null
+                findings: args.findings ?? null,
+                priorHeadlines: args.priorHeadlines && args.priorHeadlines.length > 0 ? args.priorHeadlines : null
               })
             }
           ]

--- a/lib/weekly-debrief/persistence.ts
+++ b/lib/weekly-debrief/persistence.ts
@@ -32,6 +32,7 @@ import {
 import { buildWeeklyDebriefFacts } from "./facts";
 import { generateNarrative } from "./narrative";
 import { generateAnalyticFindings } from "./analytic-findings";
+import { extractPriorHeadlines } from "./variance-corpus";
 
 async function loadWeeklyDebriefInputs(args: {
   supabase: SupabaseClient;
@@ -280,14 +281,28 @@ export async function computeWeeklyDebrief(args: {
   const inputs = await loadWeeklyDebriefInputs(args);
   const base = buildWeeklyDebriefFacts(inputs);
 
-  // Load recent feedback, session comparison trends, and training scores in parallel
-  const [{ data: feedbackRows }, { data: comparisonRows }, { data: scoreRows }] = await Promise.all([
+  // Load recent feedback, prior headlines (variance corpus), session comparison trends,
+  // and training scores in parallel.
+  const [
+    { data: feedbackRows },
+    { data: priorDebriefRows },
+    { data: comparisonRows },
+    { data: scoreRows }
+  ] = await Promise.all([
     args.supabase
       .from("weekly_debriefs")
       .select("week_start, helpful, accurate, feedback_note")
       .eq("athlete_id", args.athleteId)
       .lt("week_start", args.weekStart)
       .or("helpful.is.not.null,accurate.is.not.null")
+      .order("week_start", { ascending: false })
+      .limit(4),
+    args.supabase
+      .from("weekly_debriefs")
+      .select("week_start, narrative, coach_share, facts")
+      .eq("athlete_id", args.athleteId)
+      .eq("status", "ready")
+      .lt("week_start", args.weekStart)
       .order("week_start", { ascending: false })
       .limit(4),
     args.supabase
@@ -313,6 +328,10 @@ export async function computeWeeklyDebrief(args: {
     accurate: r.accurate as boolean | null,
     note: r.feedback_note as string | null,
   }));
+
+  const priorHeadlines = extractPriorHeadlines(
+    (priorDebriefRows ?? []) as Array<{ week_start: string; narrative?: unknown; coach_share?: unknown; facts?: unknown }>
+  );
 
   // Build trends summary from session comparisons
   type CompRow = { discipline: string; trend_direction: string; trend_confidence: string; comparison_summary: string };
@@ -350,6 +369,7 @@ export async function computeWeeklyDebrief(args: {
     recentFeedback: recentFeedback.length > 0 ? recentFeedback : undefined,
     trendsThisWeek,
     scoreTrajectory,
+    priorHeadlines: priorHeadlines.length > 0 ? priorHeadlines : undefined,
   });
 
   const generated = await generateNarrative({
@@ -363,6 +383,7 @@ export async function computeWeeklyDebrief(args: {
     trendsThisWeek,
     scoreTrajectory,
     findings: analytic.findings,
+    priorHeadlines: priorHeadlines.length > 0 ? priorHeadlines : undefined,
   });
   const narrative = generated.narrative;
   const facts = weeklyDebriefFactsSchema.parse({

--- a/lib/weekly-debrief/types.ts
+++ b/lib/weekly-debrief/types.ts
@@ -3,7 +3,7 @@ import { clip } from "@/lib/openai";
 import type { AthleteContextSnapshot } from "@/lib/athlete-context";
 import type { PersistedExecutionReview } from "@/lib/execution-review";
 
-export const WEEKLY_DEBRIEF_GENERATION_VERSION = 7;
+export const WEEKLY_DEBRIEF_GENERATION_VERSION = 8;
 
 /** @deprecated Use clip() from lib/openai.ts — this alias exists only for schema transform compatibility. */
 export const truncateStr = clip;

--- a/lib/weekly-debrief/variance-corpus.test.ts
+++ b/lib/weekly-debrief/variance-corpus.test.ts
@@ -1,0 +1,115 @@
+import { extractPriorHeadlines } from "./variance-corpus";
+
+describe("extractPriorHeadlines", () => {
+  test("maps narrative / coach_share / facts fields into the corpus", () => {
+    const rows = [
+      {
+        week_start: "2026-04-13",
+        narrative: {
+          executiveSummary: "Three threshold sessions held while volume climbed.",
+          nonObviousInsight: "Threshold HR dropped 4bpm at the same power across three weeks.",
+          highlights: ["a", "b", "c"],
+          observations: ["obs"],
+          carryForward: ["one", "two"]
+        },
+        coach_share: {
+          headline: "Threshold ceiling is holding",
+          summary: "Steady-state gains under rising CTL.",
+          wins: ["a"],
+          concerns: ["b"],
+          carryForward: ["one", "two"]
+        },
+        facts: {
+          primaryTakeawayTitle: "The main work held"
+        }
+      },
+      {
+        week_start: "2026-04-06",
+        narrative: {
+          executiveSummary: "Recovery week, signals quiet.",
+          nonObviousInsight: "Resting HR fell 3bpm as training load dropped."
+        },
+        coach_share: { headline: "Recovery landed cleanly" },
+        facts: { primaryTakeawayTitle: "Consistency held" }
+      }
+    ];
+
+    const corpus = extractPriorHeadlines(rows);
+
+    expect(corpus).toHaveLength(2);
+    expect(corpus[0]).toEqual({
+      weekStart: "2026-04-13",
+      coachHeadline: "Threshold ceiling is holding",
+      executiveSummary: "Three threshold sessions held while volume climbed.",
+      nonObviousInsight: "Threshold HR dropped 4bpm at the same power across three weeks.",
+      takeawayTitle: "The main work held"
+    });
+    expect(corpus[1].coachHeadline).toBe("Recovery landed cleanly");
+  });
+
+  test("tolerates legacy rows that lack nonObviousInsight", () => {
+    const [entry] = extractPriorHeadlines([
+      {
+        week_start: "2026-03-30",
+        narrative: {
+          executiveSummary: "A mostly intact week.",
+          highlights: ["x", "y", "z"],
+          observations: ["obs"],
+          carryForward: ["one", "two"]
+        },
+        coach_share: { headline: "Mostly intact" },
+        facts: { primaryTakeawayTitle: "The week had one clear strength and one clear wobble" }
+      }
+    ]);
+
+    expect(entry.nonObviousInsight).toBeNull();
+    expect(entry.executiveSummary).toBe("A mostly intact week.");
+    expect(entry.takeawayTitle).toBe("The week had one clear strength and one clear wobble");
+  });
+
+  test("skips rows where nothing usable is present", () => {
+    const corpus = extractPriorHeadlines([
+      { week_start: "2026-03-23", narrative: null, coach_share: null, facts: null },
+      { week_start: "2026-03-16", narrative: {}, coach_share: {}, facts: {} },
+      { week_start: "", narrative: { executiveSummary: "ignored" } }
+    ]);
+
+    expect(corpus).toEqual([]);
+  });
+
+  test("ignores non-string values without throwing", () => {
+    const corpus = extractPriorHeadlines([
+      {
+        week_start: "2026-03-09",
+        narrative: { executiveSummary: 42, nonObviousInsight: null },
+        coach_share: { headline: ["not", "a", "string"] },
+        facts: { primaryTakeawayTitle: "Valid title" }
+      }
+    ]);
+
+    expect(corpus).toEqual([
+      {
+        weekStart: "2026-03-09",
+        coachHeadline: null,
+        executiveSummary: null,
+        nonObviousInsight: null,
+        takeawayTitle: "Valid title"
+      }
+    ]);
+  });
+
+  test("trims whitespace-only strings to null", () => {
+    const [entry] = extractPriorHeadlines([
+      {
+        week_start: "2026-03-02",
+        narrative: { executiveSummary: "   ", nonObviousInsight: "  real insight  " },
+        coach_share: { headline: "" },
+        facts: { primaryTakeawayTitle: "Title" }
+      }
+    ]);
+
+    expect(entry.executiveSummary).toBeNull();
+    expect(entry.nonObviousInsight).toBe("real insight");
+    expect(entry.coachHeadline).toBeNull();
+  });
+});

--- a/lib/weekly-debrief/variance-corpus.ts
+++ b/lib/weekly-debrief/variance-corpus.ts
@@ -1,0 +1,57 @@
+/**
+ * Variance corpus for the weekly-debrief two-pass generator.
+ *
+ * Prior weekly debriefs are summarised into a compact list of phrasings the
+ * athlete has already seen — the executive summary lead, the non-obvious
+ * insight, the coach-share headline, and the deterministic takeaway title.
+ * The analytic and narrative passes consume this list and are instructed not
+ * to reuse the same framings, addressing the "only two coach_headline
+ * variants across all weeks" templated-feel problem flagged in the AI content
+ * review.
+ */
+
+export type WeeklyDebriefPriorHeadline = {
+  weekStart: string;
+  coachHeadline: string | null;
+  executiveSummary: string | null;
+  nonObviousInsight: string | null;
+  takeawayTitle: string | null;
+};
+
+type PriorWeeklyDebriefRow = {
+  week_start: string;
+  narrative?: unknown;
+  coach_share?: unknown;
+  facts?: unknown;
+};
+
+function readString(source: unknown, key: string): string | null {
+  if (!source || typeof source !== "object") return null;
+  const value = (source as Record<string, unknown>)[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+/**
+ * Convert prior weekly_debriefs rows into a variance corpus for the next
+ * generation. Ordered most-recent-first so the model weights the freshest
+ * phrasings highest.
+ */
+export function extractPriorHeadlines(rows: PriorWeeklyDebriefRow[]): WeeklyDebriefPriorHeadline[] {
+  return rows
+    .filter((row) => typeof row.week_start === "string" && row.week_start.length > 0)
+    .map((row) => ({
+      weekStart: row.week_start,
+      coachHeadline: readString(row.coach_share, "headline"),
+      executiveSummary: readString(row.narrative, "executiveSummary"),
+      nonObviousInsight: readString(row.narrative, "nonObviousInsight"),
+      takeawayTitle: readString(row.facts, "primaryTakeawayTitle")
+    }))
+    .filter((entry) =>
+      entry.coachHeadline != null ||
+      entry.executiveSummary != null ||
+      entry.nonObviousInsight != null ||
+      entry.takeawayTitle != null
+    );
+}


### PR DESCRIPTION
## Summary
- Stage 3.4 of the AI content improvement plan: weekly debriefs were feeling templated (4 of 5 shared the same `takeawayTitle`, only two `coachHeadline` variants across all weeks) because the analytic and narrative passes were never shown what the athlete had already read.
- New `extractPriorHeadlines()` pulls the last 4 ready debriefs' `coachHeadline` / `executiveSummary` / `nonObviousInsight` / `primaryTakeawayTitle` into a compact corpus.
- The corpus is threaded into both the analytic pass (constrains `weekCharacter`, pattern claims, `primaryInsight`) and the narrative pass, with prompt language treating it as a "do not reuse" list while explicitly permitting reuse of concrete numbers, dates, and session names.
- `WEEKLY_DEBRIEF_GENERATION_VERSION` bumped 7 → 8 so existing weeks recompute on next refresh.

## Test plan
- [x] `npm run typecheck`
- [x] `npx jest lib/weekly-debrief` (21/21 pass, incl. 5 new `variance-corpus` tests)
- [x] `npx eslint lib/weekly-debrief` clean
- [ ] Spot-check against a real athlete with ≥2 persisted debriefs: confirm headlines/insights differ week over week

🤖 Generated with [Claude Code](https://claude.com/claude-code)