### PR TITLE
feat(ai-review): render teach + nonObviousInsight across verdict + debrief surfaces

### DIFF
--- a/app/(protected)/debrief/page.tsx
+++ b/app/(protected)/debrief/page.tsx
@@ -395,6 +395,23 @@ export default async function DebriefPage({
         </div>
       </article>
 
+      {artifact.narrative.nonObviousInsight || artifact.narrative.teach ? (
+        <article className="debrief-section-card p-5">
+          {artifact.narrative.nonObviousInsight ? (
+            <>
+              <p className="debrief-kicker text-accent">Coach insight</p>
+              <p className="mt-3 text-[15px] font-medium leading-7 text-white">{artifact.narrative.nonObviousInsight}</p>
+            </>
+          ) : null}
+          {artifact.narrative.teach ? (
+            <>
+              <p className="debrief-kicker mt-5">Why this matters</p>
+              <p className="mt-3 text-sm leading-6 text-muted">{artifact.narrative.teach}</p>
+            </>
+          ) : null}
+        </article>
+      ) : null}
+
       <Suspense fallback={null}>
         <DebriefTrends supabase={supabase} userId={user.id} />
       </Suspense>

--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
@@ -264,6 +264,52 @@ describe("ExtrasVerdictCard", () => {
     expect(screen.queryByText("Strength session")).not.toBeInTheDocument();
   });
 
+  test("renders Coach insight with nonObviousInsight", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict({
+          nonObviousInsight: "HR drift 7% vs. your last three threshold sessions points at durability."
+        })}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+      />
+    );
+
+    expect(screen.getByText("Coach insight")).toBeInTheDocument();
+    expect(
+      screen.getByText("HR drift 7% vs. your last three threshold sessions points at durability.")
+    ).toBeInTheDocument();
+  });
+
+  test("renders 'Why this matters' block when teach is present", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict({
+          teach: "HR climbing while pace drops inside a set flags aerobic inefficiency."
+        })}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+      />
+    );
+
+    expect(screen.getByText("Why this matters")).toBeInTheDocument();
+    expect(
+      screen.getByText("HR climbing while pace drops inside a set flags aerobic inefficiency.")
+    ).toBeInTheDocument();
+  });
+
+  test("hides 'Why this matters' block when teach is null", () => {
+    render(
+      <ExtrasVerdictCard
+        verdict={makeVerdict({ teach: null })}
+        intentCategory="easy endurance"
+        narrativeSource="ai"
+      />
+    );
+
+    expect(screen.queryByText("Why this matters")).not.toBeInTheDocument();
+  });
+
   test("marks current intent as disabled in dropdown", () => {
     render(
       <ExtrasVerdictCard

--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
@@ -201,6 +201,24 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
           ) : null}
         </div>
 
+        {/* Coach insight — the non-obvious cross-session finding, and optional teach */}
+        {verdict.nonObviousInsight || verdict.teach ? (
+          <div className="px-5 py-4">
+            {verdict.nonObviousInsight ? (
+              <>
+                <p className="text-xs uppercase tracking-[0.14em] text-[var(--color-accent)]">Coach insight</p>
+                <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.nonObviousInsight)}</p>
+              </>
+            ) : null}
+            {verdict.teach ? (
+              <>
+                <p className="mt-3 text-xs uppercase tracking-[0.14em] text-tertiary">Why this matters</p>
+                <p className="mt-2 text-sm text-muted leading-relaxed">{sanitizeText(verdict.teach)}</p>
+              </>
+            ) : null}
+          </div>
+        ) : null}
+
         {/* Part 3: What it means for your plan */}
         <div className="px-5 py-4">
           <p className="text-xs uppercase tracking-[0.14em] text-tertiary">What this means for your plan</p>

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.test.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.test.tsx
@@ -1,0 +1,95 @@
+import { render, screen } from "@testing-library/react";
+import { SessionVerdictCard } from "./session-verdict-card";
+
+jest.mock("next/navigation", () => ({
+  useRouter: () => ({ refresh: jest.fn() }),
+}));
+
+type SessionVerdict = NonNullable<Parameters<typeof SessionVerdictCard>[0]["existingVerdict"]>;
+
+function makeVerdict(overrides: Partial<SessionVerdict> = {}): SessionVerdict {
+  return {
+    purpose_statement: "Threshold intervals to push lactate clearance at race-relevant intensity.",
+    training_block_context: "Week 3 of 5 — build block.",
+    execution_summary: "Hit the target band on the first 4 reps, then faded: reps 5 and 6 sat 5 s/km below pace.",
+    verdict_status: "partial",
+    metric_comparisons: [
+      { metric: "interval completion", target: "6 of 6", actual: "6 of 6", assessment: "on_target" },
+    ],
+    key_deviations: null,
+    adaptation_signal: "Start Thursday's bike 5% easier so Saturday's long run can absorb the residual cost.",
+    adaptation_type: "modify",
+    stale_reason: null,
+    non_obvious_insight: null,
+    teach: null,
+    ...overrides,
+  };
+}
+
+describe("SessionVerdictCard — insight and teach rendering", () => {
+  test("renders Coach insight when non_obvious_insight is present", () => {
+    render(
+      <SessionVerdictCard
+        sessionId="sess-1"
+        sessionCompleted
+        discipline="run"
+        existingVerdict={makeVerdict({
+          non_obvious_insight:
+            "HR drift of 7% between the first and last threshold reps vs. under 3% on prior threshold sessions points at durability, not top-end capacity.",
+        })}
+      />
+    );
+
+    expect(screen.getByText("Coach insight")).toBeInTheDocument();
+    expect(screen.getByText(/HR drift of 7%/)).toBeInTheDocument();
+  });
+
+  test("renders 'Why this matters' when teach is present", () => {
+    render(
+      <SessionVerdictCard
+        sessionId="sess-2"
+        sessionCompleted
+        discipline="run"
+        existingVerdict={makeVerdict({
+          non_obvious_insight: "Pace-at-HR improved 4 s/km vs. your 8-week rolling average.",
+          teach:
+            "HR drift under 2% at steady output means oxygen delivery is keeping up with demand — the aerobic engine is still building capacity.",
+        })}
+      />
+    );
+
+    expect(screen.getByText("Why this matters")).toBeInTheDocument();
+    expect(screen.getByText(/HR drift under 2%/)).toBeInTheDocument();
+  });
+
+  test("hides the coach-insight section entirely when both fields are null", () => {
+    render(
+      <SessionVerdictCard
+        sessionId="sess-3"
+        sessionCompleted
+        discipline="run"
+        existingVerdict={makeVerdict()}
+      />
+    );
+
+    expect(screen.queryByText("Coach insight")).not.toBeInTheDocument();
+    expect(screen.queryByText("Why this matters")).not.toBeInTheDocument();
+  });
+
+  test("renders only Coach insight when teach is null but insight is present", () => {
+    render(
+      <SessionVerdictCard
+        sessionId="sess-4"
+        sessionCompleted
+        discipline="run"
+        existingVerdict={makeVerdict({
+          non_obvious_insight: "This is the third consecutive long ride where HR drift spiked after hour two.",
+          teach: null,
+        })}
+      />
+    );
+
+    expect(screen.getByText("Coach insight")).toBeInTheDocument();
+    expect(screen.queryByText("Why this matters")).not.toBeInTheDocument();
+  });
+});

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
@@ -87,6 +87,18 @@ type SessionVerdict = {
   adaptation_signal: string;
   adaptation_type: AdaptationType | null;
   stale_reason?: string | null;
+  /**
+   * Cross-session finding surfaced by the session-verdict generator. Pulled
+   * from `session_verdicts.raw_ai_response.non_obvious_insight`; null on
+   * legacy pre-Stage-3 rows until refresh-ai regenerates them.
+   */
+  non_obvious_insight?: string | null;
+  /**
+   * Optional one-sentence teach moment explaining *why* a metric matters.
+   * Pulled from `session_verdicts.raw_ai_response.teach`; null when the
+   * generator skipped it or on legacy rows.
+   */
+  teach?: string | null;
 };
 
 type Props = {
@@ -412,6 +424,24 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
             </div>
           )}
         </div>
+
+        {/* Coach insight — non-obvious cross-session finding, and optional teach moment */}
+        {(verdict.non_obvious_insight || verdict.teach) && (
+          <div className="px-5 py-4">
+            {verdict.non_obvious_insight && (
+              <>
+                <p className="text-xs uppercase tracking-[0.14em] text-[var(--color-accent)]">Coach insight</p>
+                <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.non_obvious_insight)}</p>
+              </>
+            )}
+            {verdict.teach && (
+              <>
+                <p className="mt-3 text-xs uppercase tracking-[0.14em] text-tertiary">Why this matters</p>
+                <p className="mt-2 text-sm text-muted leading-relaxed">{sanitizeText(verdict.teach)}</p>
+              </>
+            )}
+          </div>
+        )}
 
         {/* Part 3: Adaptation Signal */}
         <div className="px-5 py-4">

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -428,15 +428,34 @@ export default async function SessionReviewPage({ params, searchParams }: { para
     adaptation_signal: string;
     adaptation_type: string | null;
     stale_reason: string | null;
+    non_obvious_insight: string | null;
+    teach: string | null;
   } | null;
   let existingVerdictData: VerdictData = null as VerdictData;
   if (session.status === "completed" && !activityId) {
     const { data: existingVerdict } = await supabase
       .from("session_verdicts")
-      .select("purpose_statement, training_block_context, execution_summary, verdict_status, metric_comparisons, key_deviations, adaptation_signal, adaptation_type, stale_reason")
+      .select("purpose_statement, training_block_context, execution_summary, verdict_status, metric_comparisons, key_deviations, adaptation_signal, adaptation_type, stale_reason, raw_ai_response")
       .eq("session_id", session.id)
       .maybeSingle();
-    existingVerdictData = existingVerdict as typeof existingVerdictData;
+    if (existingVerdict) {
+      // non_obvious_insight and teach live inside raw_ai_response JSONB (no
+      // dedicated columns on session_verdicts). Surface them at the top level
+      // so SessionVerdictCard can render without drilling into the blob.
+      const raw = existingVerdict.raw_ai_response as Record<string, unknown> | null | undefined;
+      const readStr = (key: string): string | null => {
+        if (!raw || typeof raw !== "object") return null;
+        const value = raw[key];
+        if (typeof value !== "string") return null;
+        const trimmed = value.trim();
+        return trimmed.length > 0 ? trimmed : null;
+      };
+      existingVerdictData = {
+        ...existingVerdict,
+        non_obvious_insight: readStr("non_obvious_insight") ?? readStr("nonObviousInsight"),
+        teach: readStr("teach"),
+      } as VerdictData;
+    }
   }
 
   // Load session comparison, AI comparisons, and trends for completed sessions

--- a/app/api/session-verdicts/route.ts
+++ b/app/api/session-verdicts/route.ts
@@ -22,6 +22,37 @@ function tryParseJson(value: string): unknown {
   }
 }
 
+/**
+ * `session_verdicts` has no dedicated columns for the non-obvious insight or
+ * the teach moment — both live inside the `raw_ai_response` JSONB. Surface
+ * them as top-level fields on the API response so the client component can
+ * render them without having to drill into the blob. Legacy rows (pre-teach,
+ * pre-insight) return null, so the UI renders nothing rather than breaking.
+ */
+function readStringField(source: unknown, key: string): string | null {
+  if (!source || typeof source !== "object" || Array.isArray(source)) return null;
+  const value = (source as Record<string, unknown>)[key];
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : null;
+}
+
+function enrichVerdictResponse<T extends Record<string, unknown>>(verdict: T): T & {
+  non_obvious_insight: string | null;
+  teach: string | null;
+} {
+  const raw = (verdict as Record<string, unknown>).raw_ai_response;
+  const nonObviousInsight =
+    typeof verdict.non_obvious_insight === "string" && (verdict.non_obvious_insight as string).trim().length > 0
+      ? (verdict.non_obvious_insight as string)
+      : readStringField(raw, "non_obvious_insight") ?? readStringField(raw, "nonObviousInsight");
+  const teach =
+    typeof verdict.teach === "string" && (verdict.teach as string).trim().length > 0
+      ? (verdict.teach as string)
+      : readStringField(raw, "teach");
+  return { ...verdict, non_obvious_insight: nonObviousInsight, teach };
+}
+
 const requestSchema = z.object({
   sessionId: z.string().uuid(),
   regenerate: z.boolean().optional().default(false)
@@ -62,7 +93,7 @@ export async function POST(request: Request) {
         .maybeSingle();
 
       if (existing) {
-        return NextResponse.json({ verdict: existing, source: "cached" });
+        return NextResponse.json({ verdict: enrichVerdictResponse(existing), source: "cached" });
       }
     }
 
@@ -115,8 +146,13 @@ export async function POST(request: Request) {
 
     if (error) {
       console.error("[SESSION_VERDICTS] Upsert error:", error.message);
-      // Still return the verdict even if save fails
-      return NextResponse.json({ verdict, source });
+      // Still return the verdict even if save fails. The in-memory verdict
+      // already carries non_obvious_insight + teach at top level, so the
+      // client renders them even when persistence failed.
+      return NextResponse.json({
+        verdict: enrichVerdictResponse(verdict as unknown as Record<string, unknown>),
+        source
+      });
     }
 
     // Auto-trigger adaptation rationale for modify/redistribute verdicts
@@ -149,7 +185,10 @@ export async function POST(request: Request) {
       console.warn("[SESSION_VERDICTS] Comparison trigger failed:", e);
     });
 
-    return NextResponse.json({ verdict: saved ?? verdict, source });
+    return NextResponse.json({
+      verdict: enrichVerdictResponse((saved ?? verdict) as unknown as Record<string, unknown>),
+      source
+    });
   } catch (error) {
     console.error("[SESSION_VERDICTS]", error);
     return NextResponse.json(

--- a/lib/agent-preview/data.ts
+++ b/lib/agent-preview/data.ts
@@ -1139,7 +1139,9 @@ export function createPreviewDatabase(): PreviewDatabase {
           carryForward: [
             "Protect the brick slot next week — even a shortened 20-minute transition run off the bike will rebuild the missing stimulus without requiring a full make-up session.",
             "In the next FTP Build, start 5 watts lower to hold form through all three reps rather than letting the last one fade."
-          ]
+          ],
+          nonObviousInsight: "Bike power has faded in the final rep of threshold work two weeks running — the pattern is emerging against a steady CTL climb, which points at durability catching up with the intensity ceiling rather than a top-end issue.",
+          teach: "When final-rep fade repeats at stable power but climbing HR, the aerobic system is losing efficiency late — the fix is more sub-threshold volume, not harder intervals."
         },
         coach_share: {
           headline: "Bookend quality held despite mid-week disruption",
@@ -1418,7 +1420,10 @@ export function createPreviewDatabase(): PreviewDatabase {
         affected_session_ids: null,
         discipline: "bike",
         feel_data: { overall_feel: 4, energy_level: "normal", motivation: "fired_up" },
-        raw_ai_response: null,
+        raw_ai_response: {
+          non_obvious_insight: "Power held 237 W across all three intervals with HR drift under 2% — your FTP-at-HR has improved 3 bpm vs. the same session four weeks ago at the same load.",
+          teach: "Stable HR at matched power across weeks is the clearest fitness signal for FTP work: the aerobic cost of the ceiling is dropping, so the ceiling can move up next block."
+        },
         ai_model_used: "preview",
         ai_prompt_version: "v1",
         created_at: "2026-03-10T08:05:00.000Z",
@@ -1449,7 +1454,10 @@ export function createPreviewDatabase(): PreviewDatabase {
         affected_session_ids: ["77777777-7777-4777-8777-777777777774"],
         discipline: "run",
         feel_data: { overall_feel: 2, energy_level: "low", legs_feel: "heavy" },
-        raw_ai_response: null,
+        raw_ai_response: {
+          non_obvious_insight: "HR ran 8 bpm hot at easy pace with a 12 s/km fade in the last third — two sleep-under-6h nights preceded this run, which explains the cardiac drift better than any fitness regression does.",
+          teach: "An easy-day HR that sits 5+ bpm above band with late fade points at recovery debt, not aerobic decline — the next easy day should be shortened or moved, not pushed."
+        },
         ai_model_used: "preview",
         ai_prompt_version: "v1",
         created_at: "2026-03-15T10:05:00.000Z",


### PR DESCRIPTION
## Summary
- Stacks on top of #277. Surfaces the two Stage 3 fields (`teach`, `nonObviousInsight`) on all three places athletes read verdicts: session card, extras card, and weekly debrief page.
- Session card pulls from `session_verdicts.raw_ai_response` (no dedicated columns, no migration) via both server-side hydration in `sessions/[id]/page.tsx` and the `/api/session-verdicts` API route. Legacy pre-Stage-3 rows render as null → empty blocks, no breakage.
- Dashboard weekly-debrief preview intentionally unchanged — stays summary-only and links to the full page.
- Includes 7 new render tests (4 on the new session-card test file, 3 extending extras-card). Full suite: 72 passed / 929 tests. Lint clean. Typecheck clean.
- Agent-preview seed updated with realistic insight + teach strings so the UI is verifiable locally without regenerating AI content.

## Backfill runbook
After merge, run:
```bash
npm run refresh-ai -- --user=<uuid> --scope=sessions,extras,weekly --since=YYYY-MM-DD
```
Old rows render with empty blocks until refresh-ai regenerates them — no code changes needed to the script, Stage 3 already wired through.

## Test plan
- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 72 suites / 929 tests
- [x] Visual verification via agent preview: both blocks render on `/sessions/<id>` and `/debrief?weekStart=…`
- [ ] Spot-check on a real account post-backfill that insight + teach render with live AI content

🤖 Generated with [Claude Code](https://claude.com/claude-code)