### PR TITLE
fix(debrief): suppress legacy placeholder from Coach insight render

### DIFF
--- a/app/(protected)/debrief/page.tsx
+++ b/app/(protected)/debrief/page.tsx
@@ -5,6 +5,7 @@ import { DebriefFeedbackCard } from "./debrief-feedback-card";
 import { DebriefRefreshButton } from "./debrief-refresh-button";
 import { DetailsAccordion } from "../details-accordion";
 import { WEEKLY_DEBRIEF_GENERATION_VERSION, getAdjacentWeeklyDebriefs, getWeeklyDebriefSnapshot, refreshWeeklyDebrief } from "@/lib/weekly-debrief";
+import { LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER } from "@/lib/weekly-debrief/deterministic";
 import { localIsoDate } from "@/lib/activities/completed-activities";
 import { getMacroContext } from "@/lib/training/macro-context";
 import type { MacroContext } from "@/lib/training/macro-context";
@@ -395,22 +396,33 @@ export default async function DebriefPage({
         </div>
       </article>
 
-      {artifact.narrative.nonObviousInsight || artifact.narrative.teach ? (
-        <article className="debrief-section-card p-5">
-          {artifact.narrative.nonObviousInsight ? (
-            <>
-              <p className="debrief-kicker text-accent">Coach insight</p>
-              <p className="mt-3 text-[15px] font-medium leading-7 text-white">{artifact.narrative.nonObviousInsight}</p>
-            </>
-          ) : null}
-          {artifact.narrative.teach ? (
-            <>
-              <p className="debrief-kicker mt-5">Why this matters</p>
-              <p className="mt-3 text-sm leading-6 text-muted">{artifact.narrative.teach}</p>
-            </>
-          ) : null}
-        </article>
-      ) : null}
+      {(() => {
+        // Legacy pre-Stage-3 weekly_debriefs had no nonObviousInsight, so the
+        // read path injects a compat placeholder to satisfy zod validation —
+        // that placeholder is NOT athlete-facing copy. Sentinel-check it here
+        // so legacy rows render no Coach insight section at all (correct),
+        // not a "saved before this field existed" fake insight.
+        const rawInsight = artifact.narrative.nonObviousInsight;
+        const insight = rawInsight && rawInsight !== LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER ? rawInsight : null;
+        const teach = artifact.narrative.teach;
+        if (!insight && !teach) return null;
+        return (
+          <article className="debrief-section-card p-5">
+            {insight ? (
+              <>
+                <p className="debrief-kicker text-accent">Coach insight</p>
+                <p className="mt-3 text-[15px] font-medium leading-7 text-white">{insight}</p>
+              </>
+            ) : null}
+            {teach ? (
+              <>
+                <p className="debrief-kicker mt-5">Why this matters</p>
+                <p className="mt-3 text-sm leading-6 text-muted">{teach}</p>
+              </>
+            ) : null}
+          </article>
+        );
+      })()}
 
       <Suspense fallback={null}>
         <DebriefTrends supabase={supabase} userId={user.id} />

--- a/lib/weekly-debrief/deterministic.ts
+++ b/lib/weekly-debrief/deterministic.ts
@@ -316,10 +316,15 @@ function normalizePersistedFacts(rawFacts: unknown): Record<string, unknown> {
 /**
  * Legacy debriefs were saved before `nonObviousInsight` existed on
  * `weeklyDebriefNarrativeSchema`. Injecting a neutral placeholder keeps the
- * read-path rendering instead of throwing — the field is required on fresh
+ * read-path zod validation from throwing — the field is required on fresh
  * generations (prompt + generator) but tolerated on historical reads.
+ *
+ * The placeholder is schema-compat only: the UI must NOT surface it as
+ * athlete-facing copy. Exported so render sites can sentinel-check the
+ * value and hide the Coach insight section for legacy rows rather than
+ * showing "saved before this field existed" as a real coach note.
  */
-const LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER =
+export const LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER =
   "No cross-session insight was captured for this debrief (saved before this field existed).";
 
 function ensureNarrativeHasInsight(narrative: unknown): unknown {

--- a/lib/weekly-debrief/persisted-artifact-compat.test.ts
+++ b/lib/weekly-debrief/persisted-artifact-compat.test.ts
@@ -1,4 +1,4 @@
-import { normalizePersistedArtifact } from "./deterministic";
+import { normalizePersistedArtifact, LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER } from "./deterministic";
 import type { WeeklyDebriefRecord } from "./types";
 
 /**
@@ -83,6 +83,16 @@ describe("normalizePersistedArtifact — legacy shape compatibility", () => {
     expect(artifact.narrative.nonObviousInsight).toBeTruthy();
     expect(artifact.narrative.nonObviousInsight).toMatch(/saved before this field existed/i);
     expect(artifact.narrative.executiveSummary).toBe("A mostly intact week.");
+  });
+
+  test("injects the exact LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER sentinel so render sites can detect and hide it", () => {
+    const record = buildLegacyRecord();
+    const artifact = normalizePersistedArtifact(record, "ready");
+    // The UI sentinel-checks against this exact constant to suppress the
+    // Coach insight card for legacy rows. If the placeholder string is
+    // changed here without updating the render site, legacy rows will
+    // surface it as real athlete copy.
+    expect(artifact.narrative.nonObviousInsight).toBe(LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER);
   });
 
   test("preserves a present nonObviousInsight on newly-generated narratives", () => {


### PR DESCRIPTION
## Context
Addresses a P2 from code review on #278. The debrief page now renders \`narrative.nonObviousInsight\` whenever truthy, but \`normalizePersistedArtifact\` injects a compat placeholder ("No cross-session insight was captured for this debrief (saved before this field existed).") for legacy rows to keep zod validation happy. Without a guard, that placeholder surfaces as a real Coach insight card for every pre-Stage-3 weekly_debriefs row until refresh-ai regenerates them.

## Summary
- Export \`LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER\` from \`lib/weekly-debrief/deterministic.ts\` (was internal)
- Sentinel-check it at the render site in \`app/(protected)/debrief/page.tsx\` — legacy rows render no Coach insight section (correct behaviour) instead of the placeholder string
- Add a compat test asserting \`artifact.narrative.nonObviousInsight === LEGACY_NARRATIVE_INSIGHT_PLACEHOLDER\` so future placeholder edits without updating the render guard fail CI
- \`teach\` is unaffected — its schema is nullable, legacy rows land null, UI already hides

## Test plan
- [x] \`npm run typecheck\`
- [x] \`npm run lint\`
- [x] \`npm run test\` — 72 suites / 930 tests
- [ ] Post-merge: confirm on a dev account that a legacy debrief (pre-backfill) shows no Coach insight card, and that a refreshed debrief shows the real insight

## Notes
Targets \`feat/ai-render-teach-insight\` (#278) since that PR is the one that introduced the render. Will auto-retarget to \`main\` after #278 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)