### PR TITLE
feat(ai-review): require comparable reference + surface pacing/cadence halves

### DIFF
--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.test.tsx
@@ -27,6 +27,7 @@ function makeVerdict(overrides: Partial<CoachVerdict> = {}): CoachVerdict {
     },
     nonObviousInsight: overrides.nonObviousInsight ?? "No comparative history available yet for this intent category.",
     teach: overrides.teach ?? null,
+    comparableReference: overrides.comparableReference ?? null,
     uncertainty: {
       label: "confident_read",
       detail: "Enough data to assess this session confidently.",

--- a/lib/ai/prompts/session-verdict-examples.test.ts
+++ b/lib/ai/prompts/session-verdict-examples.test.ts
@@ -21,4 +21,16 @@ describe("SESSION_VERDICT_FEW_SHOT", () => {
       expect(example.teach === null || typeof example.teach === "string").toBe(true);
     }
   });
+
+  test("every example declares comparable_reference (string or null) and cites a dated prior session when set", () => {
+    for (const example of SESSION_VERDICT_FEW_SHOT) {
+      expect(
+        example.comparable_reference === null ||
+          typeof example.comparable_reference === "string"
+      ).toBe(true);
+      if (typeof example.comparable_reference === "string") {
+        expect(example.comparable_reference).toMatch(/\d{4}-\d{2}-\d{2}/);
+      }
+    }
+  });
 });

--- a/lib/ai/prompts/session-verdict-examples.ts
+++ b/lib/ai/prompts/session-verdict-examples.ts
@@ -27,6 +27,8 @@ export const SESSION_VERDICT_FEW_SHOT: SessionVerdictOutput[] = [
       "Pace-at-138 bpm improved 4 s/km vs. your 8-week rolling average — aerobic ceiling is moving up under the same cardiac cost.",
     teach:
       "HR drift under 2% over 60 min of Z2 means oxygen delivery is keeping up with demand — the clearest signal the aerobic engine is still building capacity.",
+    comparable_reference:
+      "2026-02-14 Z2 run: 138 bpm at 5:32/km over 60 min — today 138 bpm at 5:28/km over 60 min, same HR cost, 4 s/km faster.",
     adaptation_signal:
       "Protect this pattern. Keep Wednesday's bike conservative so Thursday's key threshold run lands fresh. No plan changes needed.",
     adaptation_type: "proceed",
@@ -57,6 +59,8 @@ export const SESSION_VERDICT_FEW_SHOT: SessionVerdictOutput[] = [
       "HR drift of 7% between the first and last threshold reps vs. under 3% on your prior three threshold sessions points at durability, not top-end capacity, as the current limiter.",
     teach:
       "When pace drops but HR climbs inside an interval set, the aerobic system is losing efficiency before the legs — the fix is more volume, not harder intervals.",
+    comparable_reference:
+      "2026-04-06 threshold run: 168 bpm avg at 4:15/km with <3% drift, exec 86 — today 172 bpm on reps 1-4 but drifted to 178 bpm at 4:25/km by rep 6.",
     adaptation_signal:
       "Start Thursday's bike 5% easier than planned so Saturday's long run can absorb the residual cost. Next threshold attempt: hold the band across all 6 reps rather than pushing the first 4.",
     adaptation_type: "modify",
@@ -87,6 +91,8 @@ export const SESSION_VERDICT_FEW_SHOT: SessionVerdictOutput[] = [
       "At 28 °C, your HR at 5:20/km pace runs 6-8 bpm higher than on a 15 °C day — this session's drift reads as heat, not decoupling. The last two long runs at cool temps held HR flat.",
     teach:
       "Heat raises HR at the same pace because blood diverts to skin for cooling — hot-day HR under-reads fitness. Judge by effort and pace-at-cool-HR, not raw numbers.",
+    comparable_reference:
+      "2026-04-06 long run (15 °C): 148 bpm at 5:20/km held flat across both halves — today 148 bpm first half, 154 bpm second half at 5:26/km under 28 °C heat.",
     adaptation_signal:
       "No plan changes. Keep Tuesday's recovery spin easy given the Hard feel late in today's run. Next long run in cooler conditions will give a clean durability read.",
     adaptation_type: "proceed",

--- a/lib/ai/prompts/session-verdict.test.ts
+++ b/lib/ai/prompts/session-verdict.test.ts
@@ -1,4 +1,5 @@
 import {
+  buildFallbackComparableReference,
   buildFallbackVerdict,
   buildVerdictInstructions,
   humanizeExecutionResult,
@@ -117,6 +118,71 @@ describe("humanizeExecutionResult", () => {
 
   test("returns null for null input", () => {
     expect(humanizeExecutionResult(null)).toBeNull();
+  });
+
+  test("surfaces cadence halves when both halves are present", () => {
+    const result = humanizeExecutionResult({
+      firstHalfAvgCadence: 178,
+      lastHalfAvgCadence: 172,
+    });
+    expect(result).toHaveProperty("cadence_drift_first_to_second_half");
+    expect(result!.cadence_drift_first_to_second_half).toMatch(/178 → 172 spm.*-6/);
+  });
+
+  test("surfaces swim pace halves", () => {
+    const result = humanizeExecutionResult({
+      firstHalfPacePer100mSec: 115,
+      lastHalfPacePer100mSec: 120,
+    });
+    expect(result).toHaveProperty("swim_pace_fade_first_to_second_half");
+    expect(result!.swim_pace_fade_first_to_second_half).toMatch(/1:55\/100m → 2:00\/100m/);
+  });
+
+  test("surfaces power halves with signed delta", () => {
+    const result = humanizeExecutionResult({
+      firstHalfAvgPower: 210,
+      lastHalfAvgPower: 198,
+    });
+    expect(result).toHaveProperty("power_drift_first_to_second_half");
+    expect(result!.power_drift_first_to_second_half).toMatch(/210 → 198 W/);
+  });
+
+  test("skips halves when only one side is populated", () => {
+    const result = humanizeExecutionResult({
+      firstHalfAvgCadence: 178,
+      lastHalfAvgCadence: null,
+    });
+    expect(result).not.toHaveProperty("cadence_drift_first_to_second_half");
+  });
+});
+
+describe("buildFallbackComparableReference", () => {
+  test("returns null when no comparables are available", () => {
+    expect(buildFallbackComparableReference([])).toBeNull();
+  });
+
+  test("returns a dated reference when a comparable is available", () => {
+    const ref = buildFallbackComparableReference([
+      {
+        sessionId: "prior-1",
+        date: "2026-04-06",
+        title: "Threshold bike",
+        durationMin: 60,
+        avgHr: 168,
+        avgPower: 245,
+        avgPaceSPerKm: null,
+        avgPacePer100mSec: null,
+        intentMatch: "on_target",
+        executionScore: 86,
+        takeaway: "Controlled, repeatable."
+      }
+    ]);
+    expect(ref).not.toBeNull();
+    expect(ref).toMatch(/2026-04-06/);
+    expect(ref).toMatch(/Threshold bike/);
+    expect(ref).toMatch(/exec 86/);
+    expect(ref).toMatch(/168 bpm/);
+    expect(ref).toMatch(/245 W/);
   });
 });
 

--- a/lib/ai/prompts/session-verdict.test.ts
+++ b/lib/ai/prompts/session-verdict.test.ts
@@ -184,6 +184,45 @@ describe("buildFallbackComparableReference", () => {
     expect(ref).toMatch(/168 bpm/);
     expect(ref).toMatch(/245 W/);
   });
+
+  test("formats run pace as min:sec/km when avgPaceSPerKm is present", () => {
+    const ref = buildFallbackComparableReference([
+      {
+        sessionId: "prior-1",
+        date: "2026-04-06",
+        title: "Threshold run",
+        durationMin: 45,
+        avgHr: 168,
+        avgPower: null,
+        avgPaceSPerKm: 255,
+        avgPacePer100mSec: null,
+        intentMatch: "on_target",
+        executionScore: 82,
+        takeaway: null
+      }
+    ]);
+    expect(ref).toMatch(/4:15\/km/);
+    expect(ref).toMatch(/168 bpm/);
+  });
+
+  test("formats swim pace as min:sec/100m when avgPacePer100mSec is present", () => {
+    const ref = buildFallbackComparableReference([
+      {
+        sessionId: "prior-1",
+        date: "2026-04-06",
+        title: "Swim CSS",
+        durationMin: 45,
+        avgHr: null,
+        avgPower: null,
+        avgPaceSPerKm: null,
+        avgPacePer100mSec: 95,
+        intentMatch: "on_target",
+        executionScore: 80,
+        takeaway: null
+      }
+    ]);
+    expect(ref).toMatch(/1:35\/100m/);
+  });
 });
 
 describe("sanitizeRawFieldNames", () => {

--- a/lib/ai/prompts/session-verdict.ts
+++ b/lib/ai/prompts/session-verdict.ts
@@ -6,6 +6,7 @@ import { callOpenAIWithFallback } from "@/lib/ai/call-with-fallback";
 import { normalizeUnitString } from "@/lib/execution-review";
 import { getMacroContext } from "@/lib/training/macro-context";
 import { buildExtendedSignals, EMPTY_EXTENDED_SIGNALS, type ExtendedSignals } from "@/lib/analytics/extended-signals";
+import type { HistoricalComparable } from "@/lib/analytics/historical-comparables";
 import {
   fetchSessionVerdictPriorHeadlines,
   SESSION_VARIANCE_PROMPT,
@@ -54,6 +55,14 @@ export const sessionVerdictOutputSchema = z.object({
    * platitudes. Rotate focus across sessions.
    */
   teach: z.string().min(1).max(200).nullable(),
+  /**
+   * Concrete citation of at least one prior same-intent session the reader
+   * can anchor to (date + metric delta). Required non-null whenever
+   * `extendedSignals.historicalComparables` has at least one entry, so the
+   * model cannot ignore the comparables that were injected. Null only when
+   * no comparables are available.
+   */
+  comparable_reference: z.string().min(1).max(240).nullable(),
   adaptation_signal: z.string().min(1).max(800),
   adaptation_type: z.enum(["proceed", "flag_review", "modify", "redistribute"]),
   affected_session_ids: z.array(z.string()).max(5)
@@ -400,6 +409,16 @@ export function buildVerdictInstructions(): string {
     "- If no mechanism is worth teaching on this session, set `teach` to null. Do not manufacture a teach moment to fill the field.",
     "- `teach` is separate from `non_obvious_insight`: insight observes *what* is true; teach explains *why* it matters for training.",
     "",
+    "COMPARABLE REFERENCE (`comparable_reference`) — ≤240 chars:",
+    "- When `extendedSignals.historicalComparables` has ≥1 entry, `comparable_reference` MUST be non-null and cite at least one prior session by date + metric delta (HR, pace, power, execution score, or its stored takeaway). Example: \"2026-04-13 threshold run: 168 bpm at 4:15/km; today 172 bpm at 4:15/km over the same 6× 5 min.\"",
+    "- When `historicalComparables` is empty, set `comparable_reference` to null. Do not invent a prior session.",
+    "- `comparable_reference` is the hard-wired proof the injected history was actually used. It complements `non_obvious_insight` rather than duplicating it.",
+    "",
+    "PACING & CADENCE HALVES (`executionResult` human-readable halves):",
+    "- `hr_drift_first_to_second_half`, `pace_fade_first_to_second_half`, `cadence_drift_first_to_second_half`, `swim_pace_fade_first_to_second_half`, `stroke_rate_drift_first_to_second_half`, and `power_drift_first_to_second_half` surface the two halves of the session when available.",
+    "- Cite them in `execution_summary` or `key_deviations` when the halves differ materially (cadence drop ≥3 spm, pace fade ≥3%, power drop ≥5%, stroke-rate drift on swim) — this is the cleanest negative-split / durability read available.",
+    "- When a half comparison is absent from `executionResult`, do not claim a split pattern.",
+    "",
     SESSION_VARIANCE_PROMPT,
     "",
     "FEEL DATA — CRITICAL:",
@@ -487,6 +506,32 @@ function formatPace100m(sec: number): string {
   const m = Math.floor(sec / 60);
   const s = Math.round(sec % 60);
   return `${m}:${s.toString().padStart(2, "0")}/100m`;
+}
+
+/**
+ * Compose a deterministic `comparable_reference` from the injected history.
+ * Used by the fallback verdict and the post-process enforcement when the
+ * model forgets to cite a comparable. Returns null when no prior session is
+ * available — the schema allows null and fabricating a reference would
+ * violate the "no invented facts" contract.
+ */
+export function buildFallbackComparableReference(
+  comparables: HistoricalComparable[]
+): string | null {
+  if (!Array.isArray(comparables) || comparables.length === 0) return null;
+  const first = comparables[0];
+  if (!first) return null;
+  const titleSegment = first.title ? ` ${first.title}` : "";
+  const metricBits: string[] = [];
+  if (typeof first.executionScore === "number") metricBits.push(`exec ${first.executionScore}`);
+  if (typeof first.avgHr === "number") metricBits.push(`${Math.round(first.avgHr)} bpm`);
+  if (typeof first.avgPower === "number") metricBits.push(`${Math.round(first.avgPower)} W`);
+  const base = metricBits.length > 0
+    ? `${first.date}${titleSegment}: ${metricBits.join(", ")}`
+    : `${first.date}${titleSegment}`;
+  const takeaway = first.takeaway ? ` — ${first.takeaway}` : "";
+  const full = `${base}${takeaway}`;
+  return full.length > 240 ? `${full.slice(0, 237)}...` : full;
 }
 
 export function buildFallbackVerdict(ctx: SessionVerdictContext): SessionVerdictOutput {
@@ -606,6 +651,7 @@ export function buildFallbackVerdict(ctx: SessionVerdictContext): SessionVerdict
   const comparables = ctx.extendedSignals?.historicalComparables ?? [];
   const decoupling = ctx.extendedSignals?.aerobicDecoupling ?? null;
   const weatherNotable = ctx.extendedSignals?.weather?.notable ?? [];
+  const comparableReference = buildFallbackComparableReference(comparables);
   let nonObviousInsight: string;
   if (decoupling && (decoupling.severity === "significant_drift" || decoupling.severity === "poor_durability")) {
     nonObviousInsight = `Cardiac-to-output drift of ${decoupling.percent.toFixed(1)}% from first to second half points at aerobic durability — not top-end capacity — as the current limiter.`;
@@ -630,6 +676,7 @@ export function buildFallbackVerdict(ctx: SessionVerdictContext): SessionVerdict
     key_deviations: [],
     non_obvious_insight: nonObviousInsight,
     teach: null,
+    comparable_reference: comparableReference,
     adaptation_signal: adaptationSignal,
     adaptation_type: adaptationType,
     affected_session_ids: []
@@ -704,13 +751,32 @@ export function humanizeExecutionResult(raw: Record<string, unknown> | null): Re
   // Elevation
   if (typeof raw.elevationGainM === "number") result["elevation_gain"] = `${Math.round(raw.elevationGainM)} m`;
 
-  // Split metrics (HR drift, pace fade)
+  // Split metrics (HR drift, pace fade, cadence drift, swim halves, power halves)
   if (typeof raw.firstHalfAvgHr === "number" && typeof raw.lastHalfAvgHr === "number") {
     const drift = ((raw.lastHalfAvgHr - raw.firstHalfAvgHr) / raw.firstHalfAvgHr * 100).toFixed(1);
     result["hr_drift_first_to_second_half"] = `${drift}% (${Math.round(raw.firstHalfAvgHr)} → ${Math.round(raw.lastHalfAvgHr)} bpm)`;
   }
   if (typeof raw.firstHalfPaceSPerKm === "number" && typeof raw.lastHalfPaceSPerKm === "number") {
-    result["pace_fade_first_to_second_half"] = `${formatPacePerKm(raw.firstHalfPaceSPerKm)} → ${formatPacePerKm(raw.lastHalfPaceSPerKm)}`;
+    const fadePct = ((raw.lastHalfPaceSPerKm - raw.firstHalfPaceSPerKm) / raw.firstHalfPaceSPerKm * 100).toFixed(1);
+    result["pace_fade_first_to_second_half"] = `${formatPacePerKm(raw.firstHalfPaceSPerKm)} → ${formatPacePerKm(raw.lastHalfPaceSPerKm)} (${fadePct}%)`;
+  }
+  if (typeof raw.firstHalfAvgCadence === "number" && typeof raw.lastHalfAvgCadence === "number") {
+    const delta = Math.round(raw.lastHalfAvgCadence - raw.firstHalfAvgCadence);
+    const sign = delta >= 0 ? "+" : "";
+    result["cadence_drift_first_to_second_half"] = `${Math.round(raw.firstHalfAvgCadence)} → ${Math.round(raw.lastHalfAvgCadence)} spm (${sign}${delta})`;
+  }
+  if (typeof raw.firstHalfPacePer100mSec === "number" && typeof raw.lastHalfPacePer100mSec === "number") {
+    const fadePct = ((raw.lastHalfPacePer100mSec - raw.firstHalfPacePer100mSec) / raw.firstHalfPacePer100mSec * 100).toFixed(1);
+    result["swim_pace_fade_first_to_second_half"] = `${formatPace100m(raw.firstHalfPacePer100mSec)} → ${formatPace100m(raw.lastHalfPacePer100mSec)} (${fadePct}%)`;
+  }
+  if (typeof raw.firstHalfStrokeRate === "number" && typeof raw.lastHalfStrokeRate === "number") {
+    const delta = Math.round(raw.lastHalfStrokeRate - raw.firstHalfStrokeRate);
+    const sign = delta >= 0 ? "+" : "";
+    result["stroke_rate_drift_first_to_second_half"] = `${Math.round(raw.firstHalfStrokeRate)} → ${Math.round(raw.lastHalfStrokeRate)} spm (${sign}${delta})`;
+  }
+  if (typeof raw.firstHalfAvgPower === "number" && typeof raw.lastHalfAvgPower === "number") {
+    const deltaPct = ((raw.lastHalfAvgPower - raw.firstHalfAvgPower) / raw.firstHalfAvgPower * 100).toFixed(1);
+    result["power_drift_first_to_second_half"] = `${Math.round(raw.firstHalfAvgPower)} → ${Math.round(raw.lastHalfAvgPower)} W (${deltaPct}%)`;
   }
 
   // Scoring — omit execution_score and execution_score_band from model input;
@@ -830,6 +896,7 @@ function normalizeSessionVerdictUnits(verdict: SessionVerdictOutput): SessionVer
     intended_metrics: n(verdict.intended_metrics),
     execution_summary: n(verdict.execution_summary),
     non_obvious_insight: n(verdict.non_obvious_insight),
+    comparable_reference: verdict.comparable_reference ? n(verdict.comparable_reference) : verdict.comparable_reference,
     adaptation_signal: trimToLastSentence(n(verdict.adaptation_signal)),
     metric_comparisons: verdict.metric_comparisons.map(mc => ({
       ...mc,
@@ -925,10 +992,28 @@ export async function generateSessionVerdict(
     normalizePayload: (raw) => {
       if (!raw || typeof raw !== "object" || Array.isArray(raw)) return raw;
       const record = raw as Record<string, unknown>;
-      if ("teach" in record) return record;
-      return { ...record, teach: null };
+      const patched: Record<string, unknown> = { ...record };
+      if (!("teach" in record)) patched.teach = null;
+      if (!("comparable_reference" in record)) {
+        const camelCase = (record as { comparableReference?: unknown }).comparableReference;
+        patched.comparable_reference = typeof camelCase === "string" && camelCase.length > 0
+          ? camelCase.slice(0, 240)
+          : null;
+      }
+      return patched;
     },
-    postProcess: normalizeSessionVerdictUnits
+    postProcess: (verdict) => {
+      const comparables = ctx.extendedSignals?.historicalComparables ?? [];
+      const expected = comparables.length > 0 ? buildFallbackComparableReference(comparables) : null;
+      if (comparables.length > 0 && !verdict.comparable_reference && expected) {
+        console.warn("[session-verdict] Model omitted comparable_reference despite comparables in context; injecting deterministic reference", {
+          sessionId,
+          comparableCount: comparables.length
+        });
+        verdict = { ...verdict, comparable_reference: expected };
+      }
+      return normalizeSessionVerdictUnits(verdict);
+    }
   });
 
   return {

--- a/lib/ai/prompts/session-verdict.ts
+++ b/lib/ai/prompts/session-verdict.ts
@@ -526,12 +526,21 @@ export function buildFallbackComparableReference(
   if (typeof first.executionScore === "number") metricBits.push(`exec ${first.executionScore}`);
   if (typeof first.avgHr === "number") metricBits.push(`${Math.round(first.avgHr)} bpm`);
   if (typeof first.avgPower === "number") metricBits.push(`${Math.round(first.avgPower)} W`);
+  if (typeof first.avgPaceSPerKm === "number") metricBits.push(formatPacePerKmFromSeconds(first.avgPaceSPerKm));
+  if (typeof first.avgPacePer100mSec === "number") metricBits.push(formatPace100m(first.avgPacePer100mSec));
   const base = metricBits.length > 0
     ? `${first.date}${titleSegment}: ${metricBits.join(", ")}`
     : `${first.date}${titleSegment}`;
   const takeaway = first.takeaway ? ` — ${first.takeaway}` : "";
   const full = `${base}${takeaway}`;
   return full.length > 240 ? `${full.slice(0, 237)}...` : full;
+}
+
+function formatPacePerKmFromSeconds(sec: number): string {
+  const totalSec = Math.round(sec);
+  const mins = Math.floor(totalSec / 60);
+  const secs = totalSec % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}/km`;
 }
 
 export function buildFallbackVerdict(ctx: SessionVerdictContext): SessionVerdictOutput {

--- a/lib/execution-review-examples.test.ts
+++ b/lib/execution-review-examples.test.ts
@@ -21,4 +21,18 @@ describe("COACH_VERDICT_FEW_SHOT", () => {
       expect(example.teach === null || typeof example.teach === "string").toBe(true);
     }
   });
+
+  test("every example declares comparableReference (string or null) and cites a dated prior session", () => {
+    for (const example of COACH_VERDICT_FEW_SHOT) {
+      expect(
+        example.comparableReference === null ||
+          typeof example.comparableReference === "string"
+      ).toBe(true);
+      if (typeof example.comparableReference === "string") {
+        // Comparable references must name at least one prior session by date so
+        // the athlete can anchor the comparison — the whole point of 3.4b.
+        expect(example.comparableReference).toMatch(/\d{4}-\d{2}-\d{2}/);
+      }
+    }
+  });
 });

--- a/lib/execution-review-examples.ts
+++ b/lib/execution-review-examples.ts
@@ -28,6 +28,7 @@ export const COACH_VERDICT_FEW_SHOT: CoachVerdict[] = [
     },
     nonObviousInsight: "Pace-at-138bpm improved 4s/km vs. your 8-week rolling average — the aerobic ceiling is moving up under the same cardiac cost.",
     teach: "HR drift under 2% at steady output over 60 min is the clearest signal that the aerobic system is building capacity: oxygen delivery is keeping pace with demand without creeping effort.",
+    comparableReference: "2026-02-14 Z2 run: 138 bpm at 5:32/km — today 138 bpm at 5:28/km over the same 60 min, 4 s/km faster at the same cardiac cost.",
     uncertainty: {
       label: "confident_read",
       detail: "Full split evidence and HR trace make this a strong read.",
@@ -59,6 +60,7 @@ export const COACH_VERDICT_FEW_SHOT: CoachVerdict[] = [
     },
     nonObviousInsight: "This is the third consecutive long ride where drift spiked after hour two at a similar power — durability, not top-end, is the pattern across the block.",
     teach: "Aerobic decoupling above 5% over a long ride means oxygen supply is outrunning delivery as substrate and thermoregulation load up — volume, fuelling, and pacing are the fixes, not more intensity.",
+    comparableReference: "2026-04-05 long ride: 205 W with 6% drift after hour two; 2026-03-22: 200 W with 5% drift — today's 8% at the same 205 W extends the trend.",
     uncertainty: {
       label: "confident_read",
       detail: "Three prior comparable rides make this a high-confidence trend read.",

--- a/lib/execution-review-types.ts
+++ b/lib/execution-review-types.ts
@@ -184,6 +184,15 @@ export type CoachVerdict = {
    * platitudes. Rotate focus across sessions.
    */
   teach: string | null;
+  /**
+   * Concrete citation of at least one prior same-intent session the reader
+   * can anchor to — date + metric delta (e.g. "2026-04-13 threshold bike:
+   * 172 bpm at 250 W; today 178 bpm at same power"). Required to be non-null
+   * whenever `extendedSignals.historicalComparables` has at least one entry
+   * so the model cannot ignore the comparables that were injected. Null only
+   * when no comparables are available.
+   */
+  comparableReference: string | null;
   uncertainty: {
     label: "confident_read" | "early_read" | "insufficient_data";
     detail: string;
@@ -300,6 +309,7 @@ export const coachVerdictSchema = z.object({
   }),
   nonObviousInsight: z.string().min(1).max(320),
   teach: z.string().min(1).max(200).nullable(),
+  comparableReference: z.string().min(1).max(240).nullable(),
   uncertainty: z.object({
     label: z.enum(["confident_read", "early_read", "insufficient_data"]),
     detail: z.string().min(1).max(500),
@@ -330,6 +340,7 @@ export const COACH_VERDICT_EXAMPLE: CoachVerdict = {
   },
   nonObviousInsight: "HR drifted 7% vs. your last three threshold sessions, which held under 3%. The stimulus still landed, but durability is the next limiter — not top-end power.",
   teach: "HR drift above 5% at steady output flags a durability ceiling: the aerobic system is losing efficiency under load before power drops, so the next gain comes from volume, not intensity.",
+  comparableReference: "2026-04-06 threshold bike: 168 bpm at 245 W with <3% drift — today's 172 bpm at 245 W drifted to 181 bpm by rep 4 at the same target power.",
   uncertainty: {
     label: "early_read",
     detail: "This read is useful, but it is still limited by missing split or interval detail.",

--- a/lib/execution-review.ts
+++ b/lib/execution-review.ts
@@ -7,6 +7,7 @@ import {
   type SessionPriorHeadline,
 } from "@/lib/ai/session-variance-corpus";
 import type { AthleteContextSnapshot } from "@/lib/athlete-context";
+import type { HistoricalComparable } from "@/lib/analytics/historical-comparables";
 import { diagnoseCompletedSession, type SessionDiagnosisInput } from "@/lib/coach/session-diagnosis";
 import {
   type ExecutionEvidence,
@@ -179,6 +180,31 @@ function buildActualEvidence(input: SessionDiagnosisInput): ExecutionEvidence["a
 
 // asObject, asString, asStringArray, clip are now imported from @/lib/openai
 
+/**
+ * Build a deterministic `comparableReference` string from the injected
+ * historical comparables. Used by the fallback verdict and as the sanity-check
+ * replacement when the model forgets the field. Returns null when no
+ * comparables are present — the schema allows null, and fabricating a
+ * reference would violate the "don't invent facts" contract.
+ */
+function buildDeterministicComparableReference(
+  comparables: HistoricalComparable[]
+): string | null {
+  if (!Array.isArray(comparables) || comparables.length === 0) return null;
+  const first = comparables[0];
+  if (!first) return null;
+  const titleSegment = first.title ? ` ${first.title}` : "";
+  const metricBits: string[] = [];
+  if (typeof first.executionScore === "number") metricBits.push(`exec ${first.executionScore}`);
+  if (typeof first.avgHr === "number") metricBits.push(`${Math.round(first.avgHr)} bpm`);
+  if (typeof first.avgPower === "number") metricBits.push(`${Math.round(first.avgPower)} W`);
+  const base = metricBits.length > 0
+    ? `${first.date}${titleSegment}: ${metricBits.join(", ")}`
+    : `${first.date}${titleSegment}`;
+  const takeaway = first.takeaway ? ` — ${first.takeaway}` : "";
+  return clip(`${base}${takeaway}`, 240);
+}
+
 function normalizeNextCall(value: unknown): CoachVerdict["sessionVerdict"]["nextCall"] | null {
   if (typeof value !== "string") return null;
   const normalized = value.trim().toLowerCase().replace(/[\s-]+/g, "_");
@@ -310,6 +336,10 @@ function normalizeCoachVerdictPayload(
           "No comparative history or cross-session signal was strong enough to surface a non-obvious finding for this session.",
         320
       ),
+      comparableReference: (() => {
+        const candidate = asString(root.comparableReference) ?? asString(root.comparable_reference);
+        return candidate ? clip(candidate, 240) : null;
+      })(),
       uncertainty: {
         label: missingEvidence.length > 0 || uncertaintyDetailParts.length > 0 ? "early_read" : "confident_read",
         detail: clip(
@@ -338,7 +368,9 @@ function coerceCoachVerdictPayload(
     nextCall: CoachVerdict["sessionVerdict"]["nextCall"];
   }
 ) {
-  const normalizedPayload = ensureTeachField(normalizeCoachVerdictPayload(payload, defaults));
+  const normalizedPayload = ensureOptionalInsightFields(
+    normalizeCoachVerdictPayload(payload, defaults)
+  );
   const parsed = coachVerdictSchema.safeParse(normalizedPayload);
   return {
     normalizedPayload,
@@ -347,16 +379,23 @@ function coerceCoachVerdictPayload(
 }
 
 /**
- * Inject `teach: null` when the payload does not already carry one. Legacy
- * payloads (DB-stored verdicts pre-teach, hand-written test fixtures, LLM
- * drops) would otherwise fail zod validation now that `teach` is a required
- * nullable field on the schema.
+ * Inject `teach: null` and `comparableReference: null` when the payload does
+ * not already carry them. Legacy payloads (DB-stored verdicts written before
+ * these fields existed, hand-written test fixtures, LLM drops) would
+ * otherwise fail zod validation now that both are required nullable fields.
  */
-function ensureTeachField(payload: unknown): unknown {
+function ensureOptionalInsightFields(payload: unknown): unknown {
   if (!payload || typeof payload !== "object" || Array.isArray(payload)) return payload;
   const record = payload as Record<string, unknown>;
-  if ("teach" in record) return record;
-  return { ...record, teach: null };
+  const patched: Record<string, unknown> = { ...record };
+  if (!("teach" in record)) patched.teach = null;
+  if (!("comparableReference" in record)) {
+    const snakeCase = (record as { comparable_reference?: unknown }).comparable_reference;
+    patched.comparableReference = typeof snakeCase === "string" && snakeCase.length > 0
+      ? clip(snakeCase, 240)
+      : null;
+  }
+  return patched;
 }
 
 function formatSecondsToDuration(sec: number): string {
@@ -410,6 +449,7 @@ function normalizeVerdictUnits(verdict: CoachVerdict): CoachVerdict {
       whatToDoThisWeek: n(verdict.explanation.whatToDoThisWeek)
     },
     nonObviousInsight: n(verdict.nonObviousInsight),
+    comparableReference: verdict.comparableReference ? n(verdict.comparableReference) : verdict.comparableReference,
     uncertainty: {
       ...verdict.uncertainty,
       detail: n(verdict.uncertainty.detail)
@@ -475,6 +515,15 @@ function buildCoachVerdictInstructions() {
     "- If no mechanism is worth teaching on this session, set `teach` to null. Do not manufacture a teach moment to fill the field.",
     "- `teach` is separate from `nonObviousInsight`: insight observes *what* is true; teach explains *why* it matters.",
     "",
+    "comparableReference (≤240 chars):",
+    "- When `extendedSignals.historicalComparables` has ≥1 entry, `comparableReference` MUST be non-null and cite at least one prior session by its date, naming the metric delta (HR, pace, power, execution score, or takeaway). Example: \"2026-04-06 threshold bike: 168 bpm at 245 W; today 172 bpm at 245 W.\"",
+    "- When `historicalComparables` is empty (no prior same-intent session), set `comparableReference` to null. Do not invent a comparable.",
+    "- `comparableReference` is the hard-wired proof that the injected history was actually used; it complements `nonObviousInsight` rather than duplicating it.",
+    "",
+    "Pacing and cadence halves:",
+    "- `actual.splitMetrics` carries first-half vs last-half values for HR, pace, power, cadence, pace-per-100m, and stroke rate. When two halves differ materially (cadence drop ≥3 spm, pace fade ≥3%, power drop ≥5%, stroke-rate drift on swim), cite the split comparison directly in `whatHappened` or `citedEvidence` — this is the cleanest negative-split / durability read available.",
+    "- Do not invent halves that are not present. If `splitMetrics` is null, do not claim a split pattern.",
+    "",
     SESSION_VARIANCE_PROMPT,
     "",
     "Field requirements:",
@@ -491,6 +540,7 @@ function buildCoachVerdictInstructions() {
     "- `explanation.whatToDoThisWeek`: how to handle the rest of this week, max 500 chars.",
     "- `nonObviousInsight`: one finding grounded in an extended signal, max 320 chars. Required.",
     "- `teach`: optional mechanistic explanation, max 200 chars. Null when nothing is worth teaching.",
+    "- `comparableReference`: cite of ≥1 prior session by date + metric delta, max 240 chars. Required non-null when historicalComparables is non-empty; null otherwise.",
     "- `uncertainty.label`: one of `confident_read`, `early_read`, `insufficient_data`.",
     "- `uncertainty.detail`: explain the confidence level plainly, max 500 chars.",
     "- `uncertainty.missingEvidence`: array of missing evidence strings, max 8 items.",
@@ -546,6 +596,7 @@ function buildDeterministicVerdict(evidence: ExecutionEvidence): CoachVerdict {
   const decoupling = evidence.extendedSignals?.aerobicDecoupling ?? null;
   const comparables = evidence.extendedSignals?.historicalComparables ?? [];
   const weatherNotable = evidence.extendedSignals?.weather?.notable ?? [];
+  const comparableReference = buildDeterministicComparableReference(comparables);
   let nonObviousInsight: string;
   if (decoupling && (decoupling.severity === "significant_drift" || decoupling.severity === "poor_durability")) {
     nonObviousInsight = `Cardiac-to-output drift of ${decoupling.percent.toFixed(1)}% from the first half to the second points at aerobic durability, not top-end capacity, as the current limiter.`;
@@ -613,6 +664,7 @@ function buildDeterministicVerdict(evidence: ExecutionEvidence): CoachVerdict {
     },
     nonObviousInsight,
     teach: null,
+    comparableReference,
     uncertainty: {
       label: uncertaintyLabel,
       detail:
@@ -750,6 +802,10 @@ export async function generateCoachVerdict(args: {
 
   const reasoningEffort = reasoningEffortForSession(args.evidence.planned.sessionRole);
 
+  const comparables = args.evidence.extendedSignals?.historicalComparables ?? [];
+  const expectedComparableReference =
+    comparables.length > 0 ? buildDeterministicComparableReference(comparables) : null;
+
   const result = await callOpenAIWithFallback<CoachVerdict>({
     logTag: "session-review-ai",
     fallback: deterministicFallback,
@@ -790,7 +846,23 @@ export async function generateCoachVerdict(args: {
       }
       return undefined;
     },
-    postProcess: normalizeVerdictUnits
+    postProcess: (verdict) => {
+      // Enforce 3.4b: when historicalComparables are present, the verdict must
+      // cite at least one. If the model omitted it, splice in a deterministic
+      // reference rather than discarding the rest of its output — the rest of
+      // the verdict is still higher quality than the full fallback.
+      const patched: CoachVerdict =
+        comparables.length > 0 && !verdict.comparableReference && expectedComparableReference
+          ? { ...verdict, comparableReference: expectedComparableReference }
+          : verdict;
+      if (comparables.length > 0 && !verdict.comparableReference) {
+        console.warn("[session-review-ai] Model omitted comparableReference despite comparables in context; injecting deterministic reference", {
+          sessionId: args.evidence.sessionId,
+          comparableCount: comparables.length
+        });
+      }
+      return normalizeVerdictUnits(patched);
+    }
   });
 
   return { verdict: result.value, source: result.source };

--- a/lib/execution-review.ts
+++ b/lib/execution-review.ts
@@ -198,11 +198,20 @@ function buildDeterministicComparableReference(
   if (typeof first.executionScore === "number") metricBits.push(`exec ${first.executionScore}`);
   if (typeof first.avgHr === "number") metricBits.push(`${Math.round(first.avgHr)} bpm`);
   if (typeof first.avgPower === "number") metricBits.push(`${Math.round(first.avgPower)} W`);
+  if (typeof first.avgPaceSPerKm === "number") metricBits.push(formatSecondsToPacePerKm(first.avgPaceSPerKm));
+  if (typeof first.avgPacePer100mSec === "number") metricBits.push(formatSecondsToPacePer100m(first.avgPacePer100mSec));
   const base = metricBits.length > 0
     ? `${first.date}${titleSegment}: ${metricBits.join(", ")}`
     : `${first.date}${titleSegment}`;
   const takeaway = first.takeaway ? ` — ${first.takeaway}` : "";
   return clip(`${base}${takeaway}`, 240);
+}
+
+function formatSecondsToPacePer100m(sec: number): string {
+  const totalSec = Math.round(sec);
+  const mins = Math.floor(totalSec / 60);
+  const secs = totalSec % 60;
+  return `${mins}:${String(secs).padStart(2, "0")}/100m`;
 }
 
 function normalizeNextCall(value: unknown): CoachVerdict["sessionVerdict"]["nextCall"] | null {

--- a/lib/workouts/session-execution.test.ts
+++ b/lib/workouts/session-execution.test.ts
@@ -527,6 +527,63 @@ describe("shouldRefreshExecutionResultFromActivity", () => {
       }
     )).toBe(false);
   });
+
+  test("returns true when activity has cadence halves but stored result only carries HR halves", () => {
+    // Legacy result from before cadence halves were captured: HR halves
+    // satisfy the aggregate split-metric gate, so without the dedicated
+    // cadence check the prompt context would never see the new signal.
+    expect(shouldRefreshExecutionResultFromActivity(
+      {
+        firstHalfAvgHr: 140,
+        lastHalfAvgHr: 152,
+      },
+      {
+        id: "a1",
+        sport_type: "run",
+        duration_sec: 3600,
+        distance_m: 10000,
+        avg_hr: 148,
+        avg_power: null,
+        parse_summary: {},
+        metrics_v2: {
+          halves: {
+            firstHalfAvgHr: 140,
+            lastHalfAvgHr: 152,
+            firstHalfAvgCadence: 178,
+            lastHalfAvgCadence: 172,
+          }
+        }
+      }
+    )).toBe(true);
+  });
+
+  test("returns false when cadence halves are already in the stored result", () => {
+    expect(shouldRefreshExecutionResultFromActivity(
+      {
+        firstHalfAvgHr: 140,
+        lastHalfAvgHr: 152,
+        firstHalfAvgCadence: 178,
+        lastHalfAvgCadence: 172,
+      },
+      {
+        id: "a1",
+        sport_type: "run",
+        duration_sec: 3600,
+        distance_m: 10000,
+        avg_hr: 148,
+        avg_power: null,
+        parse_summary: {},
+        metrics_v2: {
+          halves: {
+            firstHalfAvgHr: 140,
+            lastHalfAvgHr: 152,
+            firstHalfAvgCadence: 178,
+            lastHalfAvgCadence: 172,
+          }
+        }
+      }
+    )).toBe(false);
+  });
 });
 
 describe("deriveWorkIntervalAvgPower", () => {

--- a/lib/workouts/session-execution.ts
+++ b/lib/workouts/session-execution.ts
@@ -334,6 +334,22 @@ export function shouldRefreshExecutionResultFromActivity(
     ].some((value) => value !== null);
 
     if (!hasSplitMetricsInResult) return true;
+
+    // Cadence halves were added after the original split-metric fields. Legacy
+    // results may already carry HR/pace halves but lack cadence halves, which
+    // means the aggregate check above would short-circuit and the prompt
+    // context would never get the new signal. Trigger a refresh when the
+    // activity has cadence halves but the stored result does not.
+    const extended = splitMetrics as Record<string, number>;
+    const activityHasCadenceHalves =
+      typeof extended.firstHalfAvgCadence === "number" &&
+      typeof extended.lastHalfAvgCadence === "number";
+    if (activityHasCadenceHalves) {
+      const resultHasCadenceHalves =
+        getNumber(current, ["firstHalfAvgCadence", "first_half_avg_cadence"]) !== null &&
+        getNumber(current, ["lastHalfAvgCadence", "last_half_avg_cadence"]) !== null;
+      if (!resultHasCadenceHalves) return true;
+    }
   }
 
   if (activity.sport_type === "swim" && hasLapStructure && getNumber(current, ["lengthCount", "length_count"]) === null) {

--- a/lib/workouts/session-execution.ts
+++ b/lib/workouts/session-execution.ts
@@ -514,6 +514,7 @@ export function buildExecutionResultForSession(session: SessionExecutionSessionR
       nonObviousInsight:
         "Not enough comparative history or extended signals in this preview path to surface a cross-session finding.",
       teach: null,
+      comparableReference: null,
       uncertainty: {
         label: diagnosis.diagnosisConfidence === "high" ? "confident_read" : diagnosis.evidenceCount > 0 ? "early_read" : "insufficient_data",
         detail:


### PR DESCRIPTION
## Summary
- Adds required `comparableReference` / `comparable_reference` field (string | null, ≤240 chars) to `CoachVerdict` and `SessionVerdictOutput`; required non-null whenever `extendedSignals.historicalComparables` has ≥1 entry (Stage 3.4b from the AI content plan).
- Enforcement is `postProcess` splice-in using a deterministic reference when the model omits it — the rest of the model output is retained rather than discarded.
- Surfaces cadence, swim pace, stroke rate, and power halves through `humanizeExecutionResult`; existing HR/pace halves gain % delta. Prompts describe the new fields and when to cite them (Stage 3.7).
- Legacy payloads without the new field remain parseable via the expanded `ensureOptionalInsightFields` tolerance.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run test` — 938 passing, +6 new tests covering halves and the deterministic reference builder
- [ ] Regenerate a session review for a session with ≥2 prior same-intent sessions; confirm `comparableReference` cites a dated prior session
- [ ] Regenerate a session review for a session with no comparable history; confirm `comparableReference` is null
- [ ] Verify a session with cadence drop ≥3 spm surfaces `cadence_drift_first_to_second_half` in the context the model sees

🤖 Generated with [Claude Code](https://claude.com/claude-code)