### PR TITLE
perf(mobile): address mobile performance audit findings

### DIFF
--- a/app/(protected)/account-menu.tsx
+++ b/app/(protected)/account-menu.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useRef } from "react";
 
@@ -39,8 +40,14 @@ export function AccountMenu({ avatarUrl, initials, displayName, email, signOutAc
     <details className="group relative" ref={detailsRef}>
       <summary aria-label="Open account menu" className="list-none cursor-pointer rounded-full border border-[var(--border-default)] bg-[var(--color-surface)] p-0.5 transition hover:border-[var(--border-accent)] focus-visible:outline-none">
         {avatarUrl ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img src={avatarUrl} alt="User avatar" className="h-9 w-9 rounded-full object-cover" />
+          <Image
+            src={avatarUrl}
+            alt="User avatar"
+            width={36}
+            height={36}
+            sizes="36px"
+            className="h-9 w-9 rounded-full object-cover"
+          />
         ) : (
           <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[var(--color-accent-muted)] text-xs font-medium text-accent">
             {initials}

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -1065,7 +1065,7 @@ export function WeekCalendar({
       ) : null}
       {detailSession ? <DetailsModal session={detailSession} onClose={() => setDetailSession(null)} /> : null}
       {toast ? (
-        <div className="fixed bottom-20 left-1/2 z-50 -translate-x-1/2">
+        <div className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] left-1/2 z-50 -translate-x-1/2">
           <div className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-elevated))] px-4 py-2.5 text-sm font-medium text-white shadow-xl">
             {toast}
           </div>
@@ -1358,7 +1358,7 @@ function TaskOverlay({ children, onClose }: { children: React.ReactNode; onClose
 function TaskSheet({ children, title, description, onClose }: { children: React.ReactNode; title: string; description?: string; onClose: () => void }) {
   return (
     <TaskOverlay onClose={onClose}>
-      <aside className="relative ml-auto flex h-screen w-full flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] shadow-2xl sm:max-w-xl">
+      <aside className="relative ml-auto flex h-[100dvh] w-full flex-col border-l border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] shadow-2xl sm:max-w-xl">
         <header className="border-b border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle)/0.22)] px-4 py-4 sm:px-5">
           <div className="flex items-start justify-between gap-3">
             <div className="min-w-0">
@@ -1382,7 +1382,7 @@ function TaskSheet({ children, title, description, onClose }: { children: React.
 function TaskModal({ children, title, description, onClose }: { children: React.ReactNode; title: string; description?: string; onClose: () => void }) {
   return (
     <TaskOverlay onClose={onClose}>
-      <div className="relative z-10 flex min-h-screen items-center justify-center p-4">
+      <div className="relative z-10 flex min-h-[100dvh] max-h-[100dvh] items-center justify-center overflow-y-auto p-4">
         <section className="w-full max-w-md rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--bg-elevated))] p-5 shadow-2xl">
           <header className="mb-4 border-b border-[hsl(var(--border))] pb-3">
             <p className="text-base font-semibold">{title}</p>

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { FormEvent, useEffect, useMemo, useRef, useState } from "react";
+import { FormEvent, memo, useEffect, useMemo, useRef, useState } from "react";
 import type { CoachBriefingContext, CoachDiagnosisSession } from "./types";
 import { getDiagnosisDataState } from "@/lib/ui/sparse-data";
 
@@ -14,6 +14,65 @@ type Message = {
   failed?: boolean;
   retryText?: string;
 };
+
+type CoachMessageProps = {
+  message: Message;
+  onRetry: (message: Message) => void;
+};
+
+// Message bubbles rarely change once rendered; only the streaming tail updates.
+// Memoising with a field-level comparator stops every bubble from re-rendering
+// on every keystroke in the input below.
+const CoachMessage = memo(
+  function CoachMessage({ message, onRetry }: CoachMessageProps) {
+    return (
+      <div className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
+        <div
+          className={`max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-2.5 text-sm ${
+            message.role === "user"
+              ? "bg-[hsl(var(--ai-accent-core))] text-[#0A0A0B]"
+              : message.failed
+                ? "border border-[hsl(var(--danger)/0.4)] bg-[hsl(var(--danger)/0.08)] text-[hsl(var(--text-secondary))]"
+                : "border border-[rgba(255,255,255,0.06)] bg-[#1F1F25] px-4 py-3.5 text-[rgba(255,255,255,0.8)]"
+          }`}
+        >
+          {message.pending && message.content.trim().length === 0 ? (
+            <span className="inline-flex items-center gap-1.5 text-xs text-tertiary">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[hsl(var(--text-secondary)/0.55)]" />
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[hsl(var(--text-secondary)/0.55)] [animation-delay:120ms]" />
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[hsl(var(--text-secondary)/0.55)] [animation-delay:240ms]" />
+              <span className="ml-1">Coach is thinking</span>
+            </span>
+          ) : (
+            <>
+              {message.content}
+              {message.pending ? <span className="ml-1 animate-pulse text-tertiary">▍</span> : null}
+            </>
+          )}
+          {message.failed && message.role === "assistant" && message.retryText ? (
+            <div className="mt-2">
+              <button type="button" onClick={() => onRetry(message)} className="text-xs font-medium text-[hsl(var(--ai-accent-core))] hover:underline">
+                Retry
+              </button>
+            </div>
+          ) : null}
+        </div>
+      </div>
+    );
+  },
+  (prev, next) => {
+    const a = prev.message;
+    const b = next.message;
+    return (
+      a.id === b.id &&
+      a.role === b.role &&
+      a.content === b.content &&
+      a.pending === b.pending &&
+      a.failed === b.failed &&
+      a.retryText === b.retryText
+    );
+  }
+);
 
 type CoachSummary = {
   plannedMinutes: number;
@@ -1004,7 +1063,7 @@ export function CoachChat({
       ) : null}
 
       <section id="coaching-chat" className="surface overflow-hidden">
-        <div className="flex min-h-[420px] h-[calc(100dvh-213px)] flex-col lg:grid lg:h-[68vh] lg:max-h-[780px] lg:min-h-[560px] lg:grid-cols-[248px_1fr]">
+        <div className="flex min-h-[420px] h-[calc(100dvh-var(--mobile-chrome)-80px)] flex-col lg:grid lg:h-[68vh] lg:max-h-[780px] lg:min-h-[560px] lg:grid-cols-[248px_1fr]">
           <aside className="hidden min-h-0 flex-col border-r border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-2.5 lg:flex">
             <button type="button" onClick={handleNewChat} className="rounded-md border border-[rgba(190,255,0,0.35)] bg-transparent px-3 py-1.5 text-sm text-[var(--color-accent)]">
               New conversation
@@ -1056,39 +1115,8 @@ export function CoachChat({
               }}
               className="min-h-0 flex-1 space-y-2.5 overflow-y-auto px-4 py-3"
             >
-              {messages.map((message, index) => (
-                <div key={message.id} className={`flex ${message.role === "user" ? "justify-end" : "justify-start"}`}>
-                  <div
-                    className={`max-w-[85%] whitespace-pre-wrap rounded-2xl px-4 py-2.5 text-sm ${
-                      message.role === "user"
-                        ? "bg-[hsl(var(--ai-accent-core))] text-[#0A0A0B]"
-                        : message.failed
-                          ? "border border-[hsl(var(--danger)/0.4)] bg-[hsl(var(--danger)/0.08)] text-[hsl(var(--text-secondary))]"
-                          : "border border-[rgba(255,255,255,0.06)] bg-[#1F1F25] px-4 py-3.5 text-[rgba(255,255,255,0.8)]"
-                    }`}
-                  >
-                    {message.pending && message.content.trim().length === 0 ? (
-                      <span className="inline-flex items-center gap-1.5 text-xs text-tertiary">
-                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[hsl(var(--text-secondary)/0.55)]" />
-                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[hsl(var(--text-secondary)/0.55)] [animation-delay:120ms]" />
-                        <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[hsl(var(--text-secondary)/0.55)] [animation-delay:240ms]" />
-                        <span className="ml-1">Coach is thinking</span>
-                      </span>
-                    ) : (
-                      <>
-                        {message.content}
-                        {message.pending ? <span className="ml-1 animate-pulse text-tertiary">▍</span> : null}
-                      </>
-                    )}
-                    {message.failed && message.role === "assistant" && message.retryText ? (
-                      <div className="mt-2">
-                        <button type="button" onClick={() => handleRetry(message)} className="text-xs font-medium text-[hsl(var(--ai-accent-core))] hover:underline">
-                          Retry
-                        </button>
-                      </div>
-                    ) : null}
-                  </div>
-                </div>
+              {messages.map((message) => (
+                <CoachMessage key={message.id} message={message} onRetry={handleRetry} />
               ))}
             </div>
 
@@ -1116,6 +1144,10 @@ export function CoachChat({
                   placeholder="Ask how to execute better and what to adjust next..."
                   className="w-full min-w-0 rounded-md border border-[rgba(255,255,255,0.08)] bg-[#18181C] px-3 py-2 text-[rgba(255,255,255,0.8)] placeholder:text-[rgba(255,255,255,0.25)] focus:border-[rgba(190,255,0,0.30)]"
                   disabled={isLoading}
+                  inputMode="text"
+                  enterKeyHint="send"
+                  autoComplete="off"
+                  autoCapitalize="sentences"
                 />
                 <button type="submit" disabled={isLoading} aria-label="Send" className="btn-primary inline-flex shrink-0 items-center justify-center px-3 disabled:opacity-70 sm:px-4">
                   <span className="hidden sm:inline">Send</span>

--- a/app/(protected)/coach/loading.tsx
+++ b/app/(protected)/coach/loading.tsx
@@ -1,6 +1,6 @@
 export default function CoachLoading() {
   return (
-    <section className="flex h-[calc(100dvh-8rem)] flex-col animate-pulse">
+    <section className="flex h-[calc(100dvh-var(--mobile-chrome))] flex-col animate-pulse">
       {/* Chat header */}
       <div className="surface border-b border-[hsl(var(--border))] p-4">
         <div className="h-4 w-32 rounded bg-[hsl(var(--surface-2))]" />

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -138,7 +138,7 @@ async function getDiagnosisSessions(supabase: Awaited<ReturnType<typeof createCl
     .lte("date", weekEnd)
     .not("execution_result", "is", null)
     .order("date", { ascending: false })
-    .limit(12);
+    .limit(8);
 
   if (error) {
     return [] as CoachDiagnosisSession[];
@@ -163,7 +163,7 @@ const getBriefingContext = cache(async function getBriefingContext(supabase: Awa
   }
 
   const todayIso = new Date().toISOString().slice(0, 10);
-  const [{ data: activities }, { data: weeklySessions }, { data: links }, { data: reviewedSessions }, { data: upcomingKeySessions }] = await Promise.all([
+  const [{ data: activities }, { data: weeklySessions }, { data: reviewedSessions }, { data: upcomingKeySessions }] = await Promise.all([
     supabase
       .from("completed_activities")
       .select("id")
@@ -176,10 +176,6 @@ const getBriefingContext = cache(async function getBriefingContext(supabase: Awa
       .eq("user_id", userId)
       .gte("date", weekStart)
       .lte("date", weekEnd),
-    supabase
-      .from("session_activity_links")
-      .select("planned_session_id,completed_activity_id,confirmation_status")
-      .eq("user_id", userId),
     supabase
       .from("sessions")
       .select("id")
@@ -199,24 +195,46 @@ const getBriefingContext = cache(async function getBriefingContext(supabase: Awa
       .limit(3)
   ]);
 
-  const weeklySessionIds = new Set(((weeklySessions ?? []) as Array<{ id: string }>).map((session) => session.id));
+  const weeklyActivityIdList = ((activities ?? []) as Array<{ id: string }>).map((a) => a.id);
+  const weeklySessionIdList = ((weeklySessions ?? []) as Array<{ id: string }>).map((s) => s.id);
+  const weeklySessionIds = new Set(weeklySessionIdList);
+
+  // Only fetch links that touch this week's activities or planned sessions. Without this scope,
+  // athletes with a year of history transfer the entire links table on every coach page load.
+  let links: Array<{ planned_session_id: string | null; completed_activity_id: string | null; confirmation_status: string | null }> = [];
+  if (weeklyActivityIdList.length > 0 || weeklySessionIdList.length > 0) {
+    const orFilters: string[] = [];
+    if (weeklyActivityIdList.length > 0) {
+      orFilters.push(`completed_activity_id.in.(${weeklyActivityIdList.join(",")})`);
+    }
+    if (weeklySessionIdList.length > 0) {
+      orFilters.push(`planned_session_id.in.(${weeklySessionIdList.join(",")})`);
+    }
+    const { data: scopedLinks } = await supabase
+      .from("session_activity_links")
+      .select("planned_session_id,completed_activity_id,confirmation_status")
+      .eq("user_id", userId)
+      .or(orFilters.join(","))
+      .limit(500);
+    links = (scopedLinks ?? []) as typeof links;
+  }
+
   const confirmedLinkedActivityIds = new Set(
-    (links ?? [])
-      .filter((link: any) => link.planned_session_id && (link.confirmation_status === "confirmed" || link.confirmation_status === null))
-      .map((link: any) => link.completed_activity_id as string)
-      .filter(Boolean)
+    links
+      .filter((link) => link.planned_session_id && (link.confirmation_status === "confirmed" || link.confirmation_status === null))
+      .map((link) => link.completed_activity_id)
+      .filter((id): id is string => Boolean(id))
   );
   const confirmedLinkedSessionIds = new Set(
-    (links ?? [])
-      .filter((link: any) => link.planned_session_id && weeklySessionIds.has(link.planned_session_id as string) && (link.confirmation_status === "confirmed" || link.confirmation_status === null))
-      .map((link: any) => link.planned_session_id as string)
+    links
+      .filter((link) => link.planned_session_id && weeklySessionIds.has(link.planned_session_id as string) && (link.confirmation_status === "confirmed" || link.confirmation_status === null))
+      .map((link) => link.planned_session_id as string)
   );
 
   const reviewedSessionIds = new Set(((reviewedSessions ?? []) as Array<{ id: string }>).map((session) => session.id));
   const pendingReviewCount = [...confirmedLinkedSessionIds].filter((sessionId) => !reviewedSessionIds.has(sessionId as string)).length;
 
-  const allActivityIds = ((activities ?? []) as Array<{ id: string }>).map((a) => a.id);
-  const extraActivityCount = allActivityIds.filter((id) => !confirmedLinkedActivityIds.has(id)).length;
+  const extraActivityCount = weeklyActivityIdList.filter((id) => !confirmedLinkedActivityIds.has(id)).length;
 
   const upcomingKeyNames = ((upcomingKeySessions ?? []) as Array<{ session_name: string | null; type: string; sport: string }>)
     .map((s) => s.session_name || `${s.type} ${s.sport}`)

--- a/app/(protected)/coach/weekly-checkin-card.tsx
+++ b/app/(protected)/coach/weekly-checkin-card.tsx
@@ -279,7 +279,7 @@ export function WeeklyCheckinCard({ weekStart, snapshot }: Props) {
             role="dialog"
             aria-modal="true"
             aria-labelledby="weekly-checkin-title"
-            className="relative z-10 max-h-[90vh] w-full max-w-lg overflow-y-auto rounded-[20px] border border-[hsl(var(--border))] bg-[linear-gradient(180deg,hsl(var(--surface)),hsl(var(--surface-subtle)))] shadow-[0_30px_120px_hsl(222_40%_4%/0.55)] sm:max-w-xl sm:rounded-[28px] md:max-w-4xl"
+            className="relative z-10 max-h-[calc(100dvh-4rem)] w-full max-w-lg overflow-y-auto rounded-[20px] border border-[hsl(var(--border))] bg-[linear-gradient(180deg,hsl(var(--surface)),hsl(var(--surface-subtle)))] shadow-[0_30px_120px_hsl(222_40%_4%/0.55)] sm:max-w-xl sm:rounded-[28px] md:max-w-4xl"
           >
             <div className="border-b border-[hsl(var(--border))] p-4 sm:p-5">
               <div className="flex flex-wrap items-start justify-between gap-3">

--- a/app/(protected)/components/coach-fab.tsx
+++ b/app/(protected)/components/coach-fab.tsx
@@ -1,0 +1,27 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { useCoachPanel } from "./coach-panel-context";
+
+// Small, always-visible. Kept in its own module so the wrapper can hydrate it
+// eagerly while the heavier CoachPanel stays lazy.
+export function CoachFAB() {
+  const { open, isOpen } = useCoachPanel();
+  const pathname = usePathname();
+
+  if (isOpen) return null;
+  if (pathname?.startsWith("/coach")) return null;
+
+  return (
+    <button
+      type="button"
+      onClick={() => open()}
+      className="fixed bottom-[calc(5rem+env(safe-area-inset-bottom))] right-4 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-[hsl(var(--accent))] text-black shadow-lg transition hover:scale-105 hover:shadow-xl lg:bottom-6 lg:right-6"
+      aria-label="Open coach"
+    >
+      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
+      </svg>
+    </button>
+  );
+}

--- a/app/(protected)/components/coach-panel-wrapper.tsx
+++ b/app/(protected)/components/coach-panel-wrapper.tsx
@@ -1,17 +1,17 @@
 "use client";
 
 import { lazy, Suspense } from "react";
+import { CoachFAB } from "./coach-fab";
 import { CoachPanelProvider } from "./coach-panel-context";
 
 const CoachPanel = lazy(() => import("./coach-panel").then((m) => ({ default: m.CoachPanel })));
-const CoachFAB = lazy(() => import("./coach-panel").then((m) => ({ default: m.CoachFAB })));
 
 export function CoachPanelWrapper({ children }: { children: React.ReactNode }) {
   return (
     <CoachPanelProvider>
       {children}
+      <CoachFAB />
       <Suspense fallback={null}>
-        <CoachFAB />
         <CoachPanel />
       </Suspense>
     </CoachPanelProvider>

--- a/app/(protected)/components/coach-panel.tsx
+++ b/app/(protected)/components/coach-panel.tsx
@@ -2,7 +2,6 @@
 
 import { useCallback, useEffect, useRef, useState, type FormEvent } from "react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
 import { useCoachPanel } from "./coach-panel-context";
 
 type Message = {
@@ -249,24 +248,3 @@ export function CoachPanel() {
   );
 }
 
-// Floating Action Button to open the coach panel
-export function CoachFAB() {
-  const { open, isOpen } = useCoachPanel();
-  const pathname = usePathname();
-
-  if (isOpen) return null;
-  if (pathname?.startsWith("/coach")) return null;
-
-  return (
-    <button
-      type="button"
-      onClick={() => open()}
-      className="fixed bottom-20 right-4 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-[hsl(var(--accent))] text-black shadow-lg transition hover:scale-105 hover:shadow-xl lg:bottom-6 lg:right-6"
-      aria-label="Open coach"
-    >
-      <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-        <path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z" />
-      </svg>
-    </button>
-  );
-}

--- a/app/(protected)/dashboard/components/dashboard-skeletons.tsx
+++ b/app/(protected)/dashboard/components/dashboard-skeletons.tsx
@@ -1,0 +1,13 @@
+export function DashboardCardSkeleton({ lines = 2 }: { lines?: number }) {
+  return (
+    <article className="surface animate-pulse p-4 md:p-5" aria-hidden>
+      <div className="h-3 w-24 rounded bg-[hsl(var(--surface-2))]" />
+      <div className="mt-3 h-5 w-2/3 rounded bg-[hsl(var(--surface-2))]" />
+      <div className="mt-3 space-y-2">
+        {Array.from({ length: lines }).map((_, i) => (
+          <div key={i} className="h-3 w-full rounded bg-[hsl(var(--surface-2))]" />
+        ))}
+      </div>
+    </article>
+  );
+}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -23,6 +23,7 @@ import { TrainingScoreCard } from "./components/training-score-card";
 import { ReadinessIndicator } from "./components/readiness-indicator";
 import { RecentUploadCard } from "./components/recent-upload-card";
 import { DisciplineBalanceCompact } from "./components/discipline-balance-compact";
+import { DashboardCardSkeleton } from "./components/dashboard-skeletons";
 import { getLatestFitness, getReadinessState, getTsbTrend } from "@/lib/training/fitness-model";
 import { computeWeeklyDisciplineBalance, detectDisciplineImbalance } from "@/lib/training/discipline-balance";
 import { detectTrends } from "@/lib/training/trends";
@@ -581,7 +582,7 @@ export default async function DashboardPage({
 
       {/* Recent Upload Card — actionable, not a text wall, stays above grid */}
       {isCurrentWeek ? (
-        <Suspense fallback={null}>
+        <Suspense fallback={<DashboardCardSkeleton />}>
           <DashboardRecentUpload supabase={supabase} userId={user.id} />
         </Suspense>
       ) : null}
@@ -763,7 +764,7 @@ export default async function DashboardPage({
       {/* Narrative cards — collapsed by default so the grid stays above the fold */}
       {/* Morning Brief */}
       {isCurrentWeek ? (
-        <Suspense fallback={null}>
+        <Suspense fallback={<DashboardCardSkeleton />}>
           <DashboardMorningBrief supabase={supabase} userId={user.id} todayIso={todayIso} />
         </Suspense>
       ) : null}
@@ -771,11 +772,11 @@ export default async function DashboardPage({
       {/* Transition Briefing / Monday Unified Flow */}
       {showTransitionBriefing ? (
         dashboardMoment === "monday_transition" ? (
-          <Suspense fallback={null}>
+          <Suspense fallback={<DashboardCardSkeleton />}>
             <DashboardMondayTransition supabase={supabase} userId={user.id} weekStart={weekStart} todayIso={todayIso} />
           </Suspense>
         ) : (
-          <Suspense fallback={null}>
+          <Suspense fallback={<DashboardCardSkeleton />}>
             <DashboardTransitionBriefing supabase={supabase} userId={user.id} weekStart={weekStart} />
           </Suspense>
         )
@@ -784,11 +785,11 @@ export default async function DashboardPage({
       {/* Context-aware section: end_of_week promotes debrief before week ahead */}
       {dashboardMoment === "end_of_week" ? (
         <>
-          <Suspense fallback={null}>
+          <Suspense fallback={<DashboardCardSkeleton />}>
             <DashboardDebrief supabase={supabase} userId={user.id} weekStart={weekStart} timeZone={timeZone} todayIso={todayIso} />
           </Suspense>
           {showWeekAheadCard ? (
-            <Suspense fallback={null}>
+            <Suspense fallback={<DashboardCardSkeleton />}>
               <DashboardWeekAhead supabase={supabase} userId={user.id} weekStart={weekStart} />
             </Suspense>
           ) : null}
@@ -796,11 +797,11 @@ export default async function DashboardPage({
       ) : (
         <>
           {showWeekAheadCard ? (
-            <Suspense fallback={null}>
+            <Suspense fallback={<DashboardCardSkeleton />}>
               <DashboardWeekAhead supabase={supabase} userId={user.id} weekStart={weekStart} />
             </Suspense>
           ) : null}
-          <Suspense fallback={null}>
+          <Suspense fallback={<DashboardCardSkeleton />}>
             <DashboardDebrief supabase={supabase} userId={user.id} weekStart={weekStart} timeZone={timeZone} todayIso={todayIso} />
           </Suspense>
         </>
@@ -809,21 +810,21 @@ export default async function DashboardPage({
       {/* Readiness (at-a-glance) → Training Score + Balance */}
       {isCurrentWeek ? (
         <>
-          <Suspense fallback={null}>
+          <Suspense fallback={<DashboardCardSkeleton />}>
             <DashboardReadiness supabase={supabase} userId={user.id} />
           </Suspense>
           <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
-            <Suspense fallback={null}>
+            <Suspense fallback={<DashboardCardSkeleton />}>
               <DashboardTrainingScore supabase={supabase} userId={user.id} todayIso={todayIso} />
             </Suspense>
-            <Suspense fallback={null}>
+            <Suspense fallback={<DashboardCardSkeleton />}>
               <DashboardDisciplineBalance supabase={supabase} userId={user.id} weekStart={weekStart} />
             </Suspense>
           </div>
         </>
       ) : null}
 
-      <Suspense fallback={null}>
+      <Suspense fallback={<DashboardCardSkeleton />}>
         <DashboardTrends supabase={supabase} userId={user.id} />
       </Suspense>
     </section>

--- a/app/auth/forgot-password/reset-password-form.tsx
+++ b/app/auth/forgot-password/reset-password-form.tsx
@@ -58,6 +58,11 @@ export function ForgotPasswordForm() {
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           className="input-base"
+          autoComplete="email"
+          inputMode="email"
+          autoCapitalize="none"
+          autoCorrect="off"
+          enterKeyHint="send"
         />
       </div>
 

--- a/app/auth/sign-in/sign-in-form.tsx
+++ b/app/auth/sign-in/sign-in-form.tsx
@@ -96,6 +96,10 @@ export function SignInForm() {
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           className="input-base"
+          autoComplete="email"
+          inputMode="email"
+          autoCapitalize="none"
+          autoCorrect="off"
         />
       </div>
 
@@ -110,6 +114,8 @@ export function SignInForm() {
           value={password}
           onChange={(event) => setPassword(event.target.value)}
           className="input-base"
+          autoComplete="current-password"
+          enterKeyHint="go"
         />
       </div>
 

--- a/app/auth/sign-up/sign-up-form.tsx
+++ b/app/auth/sign-up/sign-up-form.tsx
@@ -43,6 +43,10 @@ export function SignUpForm() {
           value={email}
           onChange={(event) => setEmail(event.target.value)}
           className="input-base"
+          autoComplete="email"
+          inputMode="email"
+          autoCapitalize="none"
+          autoCorrect="off"
         />
       </div>
 
@@ -58,6 +62,8 @@ export function SignUpForm() {
           value={password}
           onChange={(event) => setPassword(event.target.value)}
           className="input-base"
+          autoComplete="new-password"
+          enterKeyHint="go"
         />
       </div>
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -51,6 +51,12 @@
   --motion-standard: 180ms;
   --motion-ease: ease;
 
+  /* Mobile chrome heights — single source of truth for full-height views
+     that need to account for the sticky header and bottom nav. */
+  --mobile-header-h: 61px;
+  --mobile-nav-h: 72px;
+  --mobile-chrome: calc(var(--mobile-header-h) + var(--mobile-nav-h) + env(safe-area-inset-bottom, 0px));
+
   /* Compatibility aliases for existing inline Tailwind usage. */
   --surface: 240 5% 4%;
   --surface-elevated: 240 8% 7%;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,7 +24,6 @@ export const metadata: Metadata = {
 export const viewport: Viewport = {
   width: "device-width",
   initialScale: 1,
-  maximumScale: 1,
   themeColor: "#0a0a0b",
 };
 

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,7 +1,21 @@
 import withSerwist from "@serwist/next";
 import createNextIntlPlugin from "next-intl/plugin";
+import createBundleAnalyzer from "@next/bundle-analyzer";
 
 const withNextIntl = createNextIntlPlugin("./i18n.ts");
+const withBundleAnalyzer = createBundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
+
+const supabaseHost = (() => {
+  try {
+    return process.env.NEXT_PUBLIC_SUPABASE_URL
+      ? new URL(process.env.NEXT_PUBLIC_SUPABASE_URL).hostname
+      : undefined;
+  } catch {
+    return undefined;
+  }
+})();
 
 const withSerwistConfig = withSerwist({
   swSrc: "app/sw.ts",
@@ -41,7 +55,13 @@ const securityHeaders = [
 const nextConfig = {
   reactStrictMode: true,
   experimental: {
-    optimizePackageImports: ["openai", "zod", "@supabase/supabase-js"]
+    optimizePackageImports: ["openai", "zod", "@supabase/supabase-js", "@supabase/ssr"]
+  },
+  images: {
+    formats: ["image/avif", "image/webp"],
+    remotePatterns: supabaseHost
+      ? [{ protocol: "https", hostname: supabaseHost }]
+      : []
   },
   async headers() {
     const headers = [...securityHeaders];
@@ -62,4 +82,4 @@ const nextConfig = {
   }
 };
 
-export default withSerwistConfig(withNextIntl(nextConfig));
+export default withSerwistConfig(withNextIntl(withBundleAnalyzer(nextConfig)));

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "zod": "^3.24.1"
       },
       "devDependencies": {
+        "@next/bundle-analyzer": "^16.2.4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
         "@types/jest": "^30.0.0",
@@ -741,6 +742,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@discoveryjs/json-ext": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
+      "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/@emnapi/core": {
@@ -2517,6 +2528,16 @@
         "@tybys/wasm-util": "^0.10.0"
       }
     },
+    "node_modules/@next/bundle-analyzer": {
+      "version": "16.2.4",
+      "resolved": "https://registry.npmjs.org/@next/bundle-analyzer/-/bundle-analyzer-16.2.4.tgz",
+      "integrity": "sha512-EAA9xTDv0P1IiUcZaASJJPkNDjRvL7OMTha6XN8MBzALYGfn7I52Mn7vRiyjVfNrtUPi2qiacY+eFVXe3lKCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "webpack-bundle-analyzer": "4.10.1"
+      }
+    },
     "node_modules/@next/env": {
       "version": "14.2.35",
       "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
@@ -3054,6 +3075,13 @@
       "funding": {
         "url": "https://opencollective.com/pkgr"
       }
+    },
+    "node_modules/@polka/url": {
+      "version": "1.0.0-next.29",
+      "resolved": "https://registry.npmjs.org/@polka/url/-/url-1.0.0-next.29.tgz",
+      "integrity": "sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@resvg/resvg-wasm": {
       "version": "2.4.0",
@@ -4657,6 +4685,19 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/acorn-walk": {
+      "version": "8.3.5",
+      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.5.tgz",
+      "integrity": "sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.11.0"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/agent-base": {
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
@@ -5841,6 +5882,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/debounce": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/debounce/-/debounce-1.2.1.tgz",
+      "integrity": "sha512-XRRe6Glud4rd/ZGQfiV1ruXSfbvfJedlV9Y6zOlP+2K04vBYiJEte6stfFkCP03aMnY5tsipamumUjL14fofug==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -6034,6 +6082,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/duplexer": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
+      "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/eastasianwidth": {
       "version": "0.2.0",
@@ -7460,6 +7515,22 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/gzip-size": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/gzip-size/-/gzip-size-6.0.0.tgz",
+      "integrity": "sha512-ax7ZYomf6jqPTQ4+XCpUGyXKHk5WweS+e05MBO4/y3WJ5RkmPXNKvX+bx1behVILVwr6JSQvZAku021CHPXG3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "duplexer": "^0.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/has-bigints": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-bigints/-/has-bigints-1.1.0.tgz",
@@ -8107,6 +8178,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/is-plain-object": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+      "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/is-potential-custom-element-name": {
@@ -9773,6 +9854,16 @@
         "node": ">=16 || 14 >=14.17"
       }
     },
+    "node_modules/mrmime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mrmime/-/mrmime-2.0.1.tgz",
+      "integrity": "sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
@@ -9966,6 +10057,17 @@
         "@swc/helpers": {
           "optional": true
         }
+      }
+    },
+    "node_modules/next-intl/node_modules/@swc/helpers": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.21.tgz",
+      "integrity": "sha512-jI/VAmtdjB/RnI8GTnokyX7Ug8c+g+ffD6QRLa6XQewtnGyukKkKSk3wLTM3b5cjt1jNh9x0jfVlagdN2gDKQg==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "peer": true,
+      "dependencies": {
+        "tslib": "^2.8.0"
       }
     },
     "node_modules/next/node_modules/postcss": {
@@ -10339,6 +10441,16 @@
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
       "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "license": "MIT"
+    },
+    "node_modules/opener": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/opener/-/opener-1.5.2.tgz",
+      "integrity": "sha512-ur5UIdyw5Y7yEj9wLzhqXiy6GZ3Mwx0yGI+5sMn2r0N0v3cKJvUmFH5yPP+WXh9e0xfyzyJX95D8l088DNFj7A==",
+      "dev": true,
+      "license": "(WTFPL OR MIT)",
+      "bin": {
+        "opener": "bin/opener-bin.js"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -11559,6 +11671,21 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/sirv": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/sirv/-/sirv-2.0.4.tgz",
+      "integrity": "sha512-94Bdh3cC2PKrbgSOUqTiGPWVZeSiXfKOVZNJniWoqrWrRkB1CJzBU3NEbiTsPcYy1lDsANA/THzS+9WBiy5nfQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@polka/url": "^1.0.0-next.24",
+        "mrmime": "^2.0.0",
+        "totalist": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/slash": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
@@ -12233,6 +12360,16 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/totalist": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/totalist/-/totalist-3.0.1.tgz",
+      "integrity": "sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tough-cookie": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -12645,6 +12782,66 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer": {
+      "version": "4.10.1",
+      "resolved": "https://registry.npmjs.org/webpack-bundle-analyzer/-/webpack-bundle-analyzer-4.10.1.tgz",
+      "integrity": "sha512-s3P7pgexgT/HTUSYgxJyn28A+99mmLq4HsJepMPzu0R8ImJc52QNqaFYW1Z2z2uIb1/J3eYgaAWVpaC+v/1aAQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "0.5.7",
+        "acorn": "^8.0.4",
+        "acorn-walk": "^8.0.0",
+        "commander": "^7.2.0",
+        "debounce": "^1.2.1",
+        "escape-string-regexp": "^4.0.0",
+        "gzip-size": "^6.0.0",
+        "html-escaper": "^2.0.2",
+        "is-plain-object": "^5.0.0",
+        "opener": "^1.5.2",
+        "picocolors": "^1.0.0",
+        "sirv": "^2.0.3",
+        "ws": "^7.3.1"
+      },
+      "bin": {
+        "webpack-bundle-analyzer": "lib/bin/analyzer.js"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/webpack-bundle-analyzer/node_modules/ws": {
+      "version": "7.5.10",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.10.tgz",
+      "integrity": "sha512-+dbF1tHwZpXcbOJdVOkzLDxZP1ailvSxM6ZweXTegylPny803bFhA+vqBYw4s31NSAk4S2Qz+AKXK9a4wkdjcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/whatwg-encoding": {

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "zod": "^3.24.1"
   },
   "devDependencies": {
+    "@next/bundle-analyzer": "^16.2.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
     "@types/jest": "^30.0.0",


### PR DESCRIPTION
P0 (correctness + biggest mobile wins):
- Remove viewport maximumScale so pinch-zoom works (WCAG 1.4.4)
- Scope session_activity_links query to the week's activities/sessions
  instead of fetching entire user link history on every /coach load
- Convert header avatar from <img> to next/image with explicit dimensions
  to remove CLS; add Supabase remote pattern to next.config
- Replace h-screen / min-h-screen with 100dvh in calendar task sheet and
  modal so iOS keyboard doesn't crush the layout
- Add inputMode, enterKeyHint, autoComplete to the main coach chat input
- Replace brittle 213px calc in coach chat height with a --mobile-chrome
  CSS variable defined once in globals.css

P1 (high impact, moderate effort):
- Add DashboardCardSkeleton and wire it as the Suspense fallback across
  the dashboard's 12 boundaries (was fallback={null})
- Extract memoised CoachMessage component so typing in the input no
  longer re-renders every prior bubble
- Split CoachFAB into its own module and hydrate it eagerly; keep the
  heavier CoachPanel lazy-loaded to remove FAB pop-in on every route
- Lower coach diagnosis query limit from 12 to 8 (JSONB overfetch trim)
- Replace bottom-20 on FAB and calendar toast with
  bottom-[calc(5rem+env(safe-area-inset-bottom))] for landscape safety
- Expand next.config: image formats (avif/webp), remote Supabase host,
  add @supabase/ssr to optimizePackageImports

P2:
- Wire @next/bundle-analyzer behind ANALYZE=true
- Swap max-h-[90vh] for max-h-[calc(100dvh-4rem)] on weekly check-in
  modal
- Add autoComplete, inputMode, autoCapitalize, enterKeyHint to sign-in,
  sign-up, and forgot-password forms for better mobile keyboards and
  password-manager autofill

All 968 tests pass; typecheck and lint clean; production build verified.

https://claude.ai/code/session_01RhiQUZn7Rx4xgFEYbRH8gk