### PR TITLE
fix: wrap React cache with tsx-safe fallback

### DIFF
--- a/lib/activities/completed-activities.ts
+++ b/lib/activities/completed-activities.ts
@@ -1,4 +1,4 @@
-import { cache } from "react";
+import { cache } from "@/lib/shared/react-cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { getNestedNumber } from "@/lib/workouts/metrics-v2";
 import { classifyActivityStatus } from "@/lib/activities/activity-status";

--- a/lib/athlete-context.ts
+++ b/lib/athlete-context.ts
@@ -1,4 +1,4 @@
-import { cache } from "react";
+import { cache } from "@/lib/shared/react-cache";
 import type { SupabaseClient } from "@supabase/supabase-js";
 import { z } from "zod";
 import { asStringArray } from "@/lib/openai";

--- a/lib/shared/react-cache.ts
+++ b/lib/shared/react-cache.ts
@@ -1,0 +1,10 @@
+import * as React from "react";
+
+type CacheFn = <T extends (...args: any[]) => any>(fn: T) => T;
+
+const reactCache = (React as unknown as { cache?: CacheFn }).cache;
+
+export const cache: CacheFn =
+  typeof reactCache === "function"
+    ? reactCache
+    : (<T extends (...args: any[]) => any>(fn: T) => fn);


### PR DESCRIPTION
## Summary

React 18.3's `cache` is RSC-only — under tsx/Node (e.g. service-role scripts) the import resolves to `undefined` and any call crashes with `TypeError: cache is not a function`.

Route the two callers through a small helper that uses `React.cache` when available and an identity function otherwise. In the Next.js/RSC runtime behaviour is unchanged; in plain Node the wrapped function is just called directly.

## Why

Hit this running `scripts/refresh-ai-content.ts` via tsx:
```
TypeError: (0 , import_react.cache) is not a function
    at getAthleteContextSnapshot (lib/athlete-context.ts:158:42)
```

This unblocks any service-role script that transitively imports `lib/athlete-context` or `lib/activities/completed-activities`.

## Changes

- Add `lib/shared/react-cache.ts` — conditional cache helper
- `lib/athlete-context.ts` — import `cache` from the helper
- `lib/activities/completed-activities.ts` — import `cache` from the helper

## Test plan

- [ ] `npm run typecheck` passes
- [ ] `npm run build` passes (verifies RSC runtime still gets real `React.cache`)
- [ ] `npx tsx --env-file=.env.local scripts/refresh-ai-content.ts --user=<uuid> --scope=sessions,weekly` runs without the cache TypeError

https://claude.ai/code/session_01SQjv4AxLHEGsGNWZvYiAWJ