### PR TITLE
Design system sprint 3 — Session Review rework (F37–F42)

### DIFF
--- a/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
@@ -129,9 +129,9 @@ function FeelSummary({
   if (!option) return null;
 
   return (
-    // F39: clickable summary — primary feel sits large and loud, secondary
-    // signals render as a small chip row below, whole surface opens the
-    // editor on click.
+    // F39 / refinement: clickable summary — kicker labels the row as a
+    // self-report rather than system status. Primary feel sits large and
+    // loud; secondary signals render as a small chip row below.
     <button
       type="button"
       onClick={onEdit}
@@ -142,7 +142,8 @@ function FeelSummary({
         <div className="flex items-center gap-2.5">
           <span className="text-2xl leading-none" aria-hidden="true">{option.icon}</span>
           <div>
-            <p className="text-base font-semibold leading-none" style={{ color: option.color.text }}>
+            <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Your rating</p>
+            <p className="mt-0.5 text-base font-semibold leading-none" style={{ color: option.color.text }}>
               {option.label}
             </p>
             {feel.note ? (

--- a/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
@@ -328,6 +328,18 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
           type="button"
           onClick={() => {
             if (editing) {
+              // Cancel discards the draft — reset every field back to the
+              // persisted server values so a subsequent Edit doesn't
+              // resurrect changes the user just abandoned.
+              setSelectedFeel((existingFeel?.overall_feel ?? null) as FeelLevel | null);
+              setEnergyLevel(existingFeel?.energy_level ?? null);
+              setLegsFeel(existingFeel?.legs_feel ?? null);
+              setMotivation(existingFeel?.motivation ?? null);
+              setSleepQuality(existingFeel?.sleep_quality ?? null);
+              setLifeStress(existingFeel?.life_stress ?? null);
+              setNote(existingFeel?.note ?? "");
+              setShowSecondary(hasExistingFeel);
+              interactionStartRef.current = null;
               setEditing(false);
               setSaveError(null);
             } else {

--- a/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
@@ -92,7 +92,13 @@ function PillSelector({ label, options, value, onChange }: {
 
 type SecondaryItem = { label: string; value: string };
 
-function FeelSummary({ feel }: { feel: NonNullable<FeelCaptureBannerProps["existingFeel"]> }) {
+function FeelSummary({
+  feel,
+  onEdit
+}: {
+  feel: NonNullable<FeelCaptureBannerProps["existingFeel"]>;
+  onEdit: () => void;
+}) {
   // Support both new overall_feel (1-5) and legacy rpe (1-10) rows
   const option = feel.overall_feel
     ? FEEL_OPTIONS.find((o) => o.value === feel.overall_feel)
@@ -108,64 +114,85 @@ function FeelSummary({ feel }: { feel: NonNullable<FeelCaptureBannerProps["exist
   // Legacy RPE-only rows: show RPE value directly
   if (!option && feel.rpe) {
     return (
-      <article className="surface border border-[hsl(var(--border))] p-4">
-        <div className="flex items-center gap-2">
-          <span className="text-sm font-medium text-muted">RPE {feel.rpe}/10</span>
-        </div>
-        {feel.note && <p className="mt-1.5 text-xs text-muted">{feel.note}</p>}
-      </article>
+      <button
+        type="button"
+        onClick={onEdit}
+        className="surface flex w-full items-center justify-between border border-[hsl(var(--border))] px-4 py-3 text-left transition-ui hover:border-[rgba(255,255,255,0.2)]"
+      >
+        <span className="text-sm font-medium text-muted">RPE {feel.rpe}/10</span>
+        {feel.note ? <p className="text-xs italic text-muted">{feel.note}</p> : null}
+        <span className="text-[11px] text-tertiary">Edit →</span>
+      </button>
     );
   }
 
   if (!option) return null;
 
   return (
-    <article className="surface border border-[hsl(var(--border))] px-4 py-2.5">
-      <div className="flex flex-wrap items-center gap-x-4 gap-y-1">
-        {/* Primary feel */}
-        <div className="flex items-center gap-1.5">
-          <span className="text-base" aria-hidden="true">{option.icon}</span>
-          <span className="text-sm font-semibold" style={{ color: option.color.text }}>{option.label}</span>
-        </div>
-
-        {/* Secondary attributes — inline */}
-        {secondaryItems.length > 0 && (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5">
-            {secondaryItems.map((item) => (
-              <span key={item.label} className="text-xs text-tertiary">
-                {item.label} <span className="font-medium text-muted">{item.value}</span>
-              </span>
-            ))}
+    // F39: clickable summary — primary feel sits large and loud, secondary
+    // signals render as a small chip row below, whole surface opens the
+    // editor on click.
+    <button
+      type="button"
+      onClick={onEdit}
+      aria-label="Edit how this session felt"
+      className="surface group flex w-full flex-col gap-2 border border-[hsl(var(--border))] px-4 py-3 text-left transition-ui hover:border-[rgba(255,255,255,0.2)]"
+    >
+      <div className="flex items-start justify-between gap-3">
+        <div className="flex items-center gap-2.5">
+          <span className="text-2xl leading-none" aria-hidden="true">{option.icon}</span>
+          <div>
+            <p className="text-base font-semibold leading-none" style={{ color: option.color.text }}>
+              {option.label}
+            </p>
+            {feel.note ? (
+              <p className="mt-1 max-w-[60ch] truncate text-xs italic text-muted">{feel.note}</p>
+            ) : null}
           </div>
-        )}
-
-        {/* Note — inline after attributes */}
-        {feel.note && (
-          <p className="text-xs text-muted italic">{feel.note}</p>
-        )}
+        </div>
+        <span className="text-[11px] text-tertiary transition-ui group-hover:text-white">Edit →</span>
       </div>
-    </article>
+      {secondaryItems.length > 0 ? (
+        <div className="flex flex-wrap items-center gap-1.5">
+          {secondaryItems.map((item) => (
+            <span
+              key={item.label}
+              className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px]"
+            >
+              <span className="text-tertiary">{item.label}</span>
+              <span className="font-medium text-[rgba(255,255,255,0.78)]">{item.value}</span>
+            </span>
+          ))}
+        </div>
+      ) : null}
+    </button>
   );
 }
 
 export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBannerProps) {
-  const [selectedFeel, setSelectedFeel] = useState<FeelLevel | null>(null);
-  const [showSecondary, setShowSecondary] = useState(false);
-  const [energyLevel, setEnergyLevel] = useState<string | null>(null);
-  const [legsFeel, setLegsFeel] = useState<string | null>(null);
-  const [motivation, setMotivation] = useState<string | null>(null);
-  const [sleepQuality, setSleepQuality] = useState<string | null>(null);
-  const [lifeStress, setLifeStress] = useState<string | null>(null);
-  const [note, setNote] = useState("");
+  const hasExistingFeel = Boolean(existingFeel?.overall_feel || existingFeel?.rpe);
+  const [selectedFeel, setSelectedFeel] = useState<FeelLevel | null>(
+    (existingFeel?.overall_feel ?? null) as FeelLevel | null
+  );
+  const [showSecondary, setShowSecondary] = useState(hasExistingFeel);
+  const [energyLevel, setEnergyLevel] = useState<string | null>(existingFeel?.energy_level ?? null);
+  const [legsFeel, setLegsFeel] = useState<string | null>(existingFeel?.legs_feel ?? null);
+  const [motivation, setMotivation] = useState<string | null>(existingFeel?.motivation ?? null);
+  const [sleepQuality, setSleepQuality] = useState<string | null>(existingFeel?.sleep_quality ?? null);
+  const [lifeStress, setLifeStress] = useState<string | null>(existingFeel?.life_stress ?? null);
+  const [note, setNote] = useState(existingFeel?.note ?? "");
   const [dismissed, setDismissed] = useState(false);
+  const [editing, setEditing] = useState(false);
   const [saving, setSaving] = useState(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const promptShownAt = useRef(new Date().toISOString());
   const interactionStartRef = useRef<number | null>(null);
 
-  // Show summary if feel already captured (either new overall_feel or legacy rpe)
-  if (existingFeel?.overall_feel || existingFeel?.rpe) {
-    return <FeelSummary feel={existingFeel} />;
+  // F39: show the compact summary for already-captured feels; tapping the
+  // summary flips into edit mode so the same capture form re-opens
+  // prefilled with the existing values.
+  if (hasExistingFeel && !editing && existingFeel) {
+    return <FeelSummary feel={existingFeel} onEdit={() => setEditing(true)} />;
   }
 
   if (dismissed) return null;
@@ -203,6 +230,12 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         throw new Error((data as { error?: string }).error || "Failed to save \u2014 please try again.");
+      }
+      // F39: on successful edit, flip back to the summary. Soft reload so
+      // the server-rendered `existingFeel` prop reflects the new values.
+      if (editing) {
+        window.location.reload();
+        return;
       }
       setDismissed(true);
     } catch (err) {
@@ -292,10 +325,17 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
         </button>
         <button
           type="button"
-          onClick={() => setDismissed(true)}
+          onClick={() => {
+            if (editing) {
+              setEditing(false);
+              setSaveError(null);
+            } else {
+              setDismissed(true);
+            }
+          }}
           className="text-sm text-tertiary hover:text-white"
         >
-          Skip
+          {editing ? "Cancel" : "Skip"}
         </button>
       </div>
     </article>

--- a/app/(protected)/sessions/[sessionId]/components/session-comparison-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-comparison-card.tsx
@@ -1,3 +1,6 @@
+"use client";
+
+import { useState } from "react";
 import type { SessionComparison } from "@/lib/training/session-comparison";
 import type { WeeklyTrend } from "@/lib/training/trends";
 import type { StoredComparison } from "@/lib/training/session-comparison-engine";
@@ -38,6 +41,85 @@ function trendBadge(direction: string, confidence?: string) {
   return { label: "Stable", className: "border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.06)] text-tertiary" };
 }
 
+// Refinement: split an AI narrative into a 2-line lead + the remainder so
+// the "Compared to previous" block stops reading like a wall of prose.
+// First sentence is the lead; anything after it lives behind "More detail".
+function splitNarrative(text: string): { lead: string; rest: string | null } {
+  const trimmed = text.trim();
+  // Match the first sentence ending with . ! or ? followed by whitespace.
+  // Falls back to the whole thing if no terminator is found.
+  const match = trimmed.match(/^([^.!?]+[.!?])\s+(.+)$/s);
+  if (!match) return { lead: trimmed, rest: null };
+  const lead = match[1].trim();
+  const rest = match[2].trim();
+  return { lead, rest: rest.length > 0 ? rest : null };
+}
+
+// Refinement: draw an actual sparkline instead of a row of number cells.
+// ~84×20px, points normalised to the trend's value range, flat fallback
+// when all points are identical so we don't render a zero-height line.
+function TrendSparkline({
+  points,
+  direction
+}: {
+  points: Array<{ weekStart: string; value: number; label: string }>;
+  direction: WeeklyTrend["direction"];
+}) {
+  const width = 84;
+  const height = 20;
+  const pad = 2;
+  const validPoints = points.filter((p) => Number.isFinite(p.value));
+  if (validPoints.length < 2) return null;
+  const values = validPoints.map((p) => p.value);
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const range = max - min || 1;
+  const stepX = (width - pad * 2) / (validPoints.length - 1);
+  const coords = validPoints.map((p, i) => {
+    const x = pad + i * stepX;
+    const y = pad + (height - pad * 2) * (1 - (p.value - min) / range);
+    return { x, y };
+  });
+  const path = coords.map((c, i) => `${i === 0 ? "M" : "L"}${c.x.toFixed(1)} ${c.y.toFixed(1)}`).join(" ");
+  const strokeColor = direction === "improving" ? "var(--color-success)" : direction === "declining" ? "var(--color-danger)" : "rgba(255,255,255,0.45)";
+  const last = coords[coords.length - 1];
+  return (
+    <svg
+      width={width}
+      height={height}
+      viewBox={`0 0 ${width} ${height}`}
+      className="shrink-0"
+      aria-hidden="true"
+    >
+      <path d={path} stroke={strokeColor} strokeWidth="1.25" fill="none" strokeLinecap="round" strokeLinejoin="round" />
+      <circle cx={last.x} cy={last.y} r="1.75" fill={strokeColor} />
+    </svg>
+  );
+}
+
+function ComparisonNarrative({ text }: { text: string }) {
+  const { lead, rest } = splitNarrative(text);
+  const [expanded, setExpanded] = useState(false);
+  if (!rest) {
+    return <p className="mt-3 text-sm text-white">{lead}</p>;
+  }
+  return (
+    <div className="mt-3">
+      <p className="text-sm text-white">{lead}</p>
+      {expanded ? (
+        <p className="mt-2 text-sm text-muted">{rest}</p>
+      ) : null}
+      <button
+        type="button"
+        onClick={() => setExpanded((prev) => !prev)}
+        className="mt-2 text-xs text-tertiary hover:text-white"
+      >
+        {expanded ? "Less detail ↑" : "More detail ↓"}
+      </button>
+    </div>
+  );
+}
+
 export function SessionComparisonCard({ comparison, trends = [], aiComparisons = [], sport }: Props) {
   const previousDateLabel = comparisonDateFormatter.format(new Date(`${comparison.previousDate}T00:00:00.000Z`));
 
@@ -63,9 +145,10 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
         <p className="mt-1 text-xs text-tertiary">{previousDateLabel}</p>
       </div>
 
-      {/* AI narrative */}
+      {/* AI narrative — 2-line lead + More detail disclosure so the block
+          doesn't read as a wall of prose. */}
       {bestAiComparison ? (
-        <p className="mt-3 text-sm text-white">{bestAiComparison.comparisonSummary}</p>
+        <ComparisonNarrative text={bestAiComparison.comparisonSummary} />
       ) : null}
 
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -96,31 +179,26 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
         <div className="mt-4 border-t border-[hsl(var(--border))] pt-4">
           <p className="mb-3 text-[10px] uppercase tracking-[0.08em] text-tertiary">Multi-week trend</p>
           <div className="space-y-2.5">
-            {matchedTrends.map((trend) => (
-              <div key={trend.metric} className="flex items-center justify-between gap-3">
-                <span className="text-xs text-muted whitespace-nowrap">{trend.metric}</span>
-                <div className="flex items-center gap-1.5">
-                  {trend.dataPoints.slice(-4).map((pt, idx) => {
-                    const isLatest = idx === trend.dataPoints.slice(-4).length - 1;
-                    return (
-                      <span
-                        key={pt.weekStart}
-                        className={`rounded border px-2 py-1 text-xs tabular-nums ${
-                          isLatest
-                            ? "border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.06)] text-white font-medium"
-                            : "border-[hsl(var(--border))] text-tertiary"
-                        }`}
-                      >
-                        {pt.label}
+            {matchedTrends.map((trend) => {
+              const recent = trend.dataPoints.slice(-5);
+              const latest = recent[recent.length - 1];
+              const directionGlyph = trend.direction === "improving" ? "▲" : trend.direction === "declining" ? "▼" : "—";
+              const directionClass = trend.direction === "improving" ? "text-success" : trend.direction === "declining" ? "text-danger" : "text-tertiary";
+              return (
+                <div key={trend.metric} className="flex items-center justify-between gap-3">
+                  <span className="text-xs text-muted whitespace-nowrap">{trend.metric}</span>
+                  <div className="flex items-center gap-2">
+                    <TrendSparkline points={recent} direction={trend.direction} />
+                    {latest ? (
+                      <span className="rounded border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.06)] px-2 py-1 text-xs font-medium tabular-nums text-white">
+                        {latest.label}
                       </span>
-                    );
-                  })}
-                  <span className={`ml-0.5 text-sm font-medium ${trend.direction === "improving" ? "text-success" : trend.direction === "declining" ? "text-danger" : "text-tertiary"}`}>
-                    {trend.direction === "improving" ? "▲" : trend.direction === "declining" ? "▼" : "—"}
-                  </span>
+                    ) : null}
+                    <span className={`ml-0.5 text-sm font-medium ${directionClass}`}>{directionGlyph}</span>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       ) : null}

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
@@ -391,18 +391,39 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-[hsl(var(--border))]">
-                    {visibleMetrics.map((mc, i) => (
-                      <tr key={i}>
-                        <td className="px-3 py-2 text-muted">{sanitizeText(mc.metric)}</td>
-                        <td className="px-3 py-2 text-right text-tertiary">{sanitizeText(mc.target)}</td>
-                        <td className={`px-3 py-2 text-right font-medium ${
-                          mc.assessment === "on_target" ? "text-success" :
-                          mc.assessment === "missing" ? "text-tertiary" : "text-warning"
-                        }`}>
-                          {sanitizeText(mc.actual)}
-                        </td>
-                      </tr>
-                    ))}
+                    {visibleMetrics.map((mc, i) => {
+                      const rawTarget = sanitizeText(mc.target).trim();
+                      // Em-dash-only target reads as "data failed to load".
+                      // Render "Not set" in muted italic so users parse it as
+                      // "no plan target for this metric" instead.
+                      const targetIsMissing = rawTarget === "" || /^[—–-]+\s*$/.test(rawTarget);
+                      const targetIsMissingWithNote = /^[—–-]+\s*\(.+\)\s*$/.test(rawTarget);
+                      const targetNote = targetIsMissingWithNote
+                        ? rawTarget.replace(/^[—–-]+\s*\((.+)\)\s*$/, "$1")
+                        : null;
+                      return (
+                        <tr key={i}>
+                          <td className="px-3 py-2 text-muted">{sanitizeText(mc.metric)}</td>
+                          <td className="px-3 py-2 text-right text-tertiary">
+                            {targetIsMissing ? (
+                              <span className="italic text-muted">Not set</span>
+                            ) : targetIsMissingWithNote ? (
+                              <span className="italic text-muted">
+                                Not set <span className="text-[11px] not-italic text-tertiary">({targetNote})</span>
+                              </span>
+                            ) : (
+                              rawTarget
+                            )}
+                          </td>
+                          <td className={`px-3 py-2 text-right font-medium ${
+                            mc.assessment === "on_target" ? "text-success" :
+                            mc.assessment === "missing" ? "text-tertiary" : "text-warning"
+                          }`}>
+                            {sanitizeText(mc.actual)}
+                          </td>
+                        </tr>
+                      );
+                    })}
                   </tbody>
                 </table>
               </div>
@@ -412,7 +433,9 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
                   onClick={() => setShowAllMetrics(!showAllMetrics)}
                   className="mt-2 text-xs text-tertiary hover:text-white"
                 >
-                  {showAllMetrics ? "Show fewer" : `Show all ${verdict.metric_comparisons.length} metrics`}
+                  {showAllMetrics
+                    ? "Show fewer ↑"
+                    : `Show ${verdict.metric_comparisons.length - 3} more metric${verdict.metric_comparisons.length - 3 === 1 ? "" : "s"} ↓`}
                 </button>
               )}
             </div>

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import Link from "next/link";
 
 /** Sanitize raw camelCase field names that may exist in stored verdict text. */
 function sanitizeText(text: string): string {
@@ -185,6 +186,27 @@ const ADAPTATION_LABELS: Record<string, string> = {
   modify: "Modification suggested",
   redistribute: "Redistribution suggested"
 };
+
+// F42: builds a specific coach prompt pre-loaded with the session's
+// discipline, verdict status, and key deviations — so the Explain link
+// opens a conversation grounded in *this* session instead of a blank
+// "what should I ask?" state.
+function buildCoachPrompt(
+  discipline: string | null | undefined,
+  verdictStatus: VerdictStatus,
+  deviations: Deviation[] | null
+): string {
+  const sport = discipline?.trim() || "this";
+  const statusWord = verdictStatus === "achieved" ? "hit"
+    : verdictStatus === "partial" ? "partially hit"
+    : verdictStatus === "missed" ? "missed"
+    : "drifted off";
+  const topDeviations = deviations?.slice(0, 2).map((d) => d.metric).filter(Boolean) ?? [];
+  if (topDeviations.length > 0) {
+    return `My ${sport} session ${statusWord} its target. Walk me through what ${topDeviations.join(" and ")} is telling me and what to adjust next time.`;
+  }
+  return `My ${sport} session ${statusWord} its target. Walk me through what the numbers are telling me and what to adjust next time.`;
+}
 
 function getContextualExplanation(verdictStatus: VerdictStatus, discipline: string | null | undefined, deviations: Deviation[] | null): string {
   const statusExplanation: Record<VerdictStatus, string> = {
@@ -408,19 +430,30 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
             </div>
           )}
 
-          {/* Expandable explanation */}
+          {/* F42: inline contextual explanation + coach hand-off. Label
+              specifies what will be explained (not the vague "this"), and
+              the expanded panel ends with a specific coach prompt pre-
+              loaded with the session's deviation context. */}
           <button
             type="button"
             onClick={() => setShowExplanation(!showExplanation)}
             className="mt-3 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
           >
-            {showExplanation ? "Hide explanation" : "What does this mean?"}
+            {showExplanation ? "Hide explanation" : "Explain these metrics"}
           </button>
           {showExplanation && (
             <div className="mt-2 rounded-lg bg-[rgba(0,0,0,0.2)] p-3">
               <p className="text-sm text-muted leading-relaxed">
                 {getContextualExplanation(verdict.verdict_status, discipline, verdict.key_deviations)}
               </p>
+              <Link
+                href={`/coach?prompt=${encodeURIComponent(
+                  buildCoachPrompt(discipline, verdict.verdict_status, verdict.key_deviations)
+                )}`}
+                className="mt-2 inline-flex items-center text-[11px] text-[var(--color-accent)] transition-ui hover:text-white"
+              >
+                Dig in with coach →
+              </Link>
             </div>
           )}
         </div>

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -482,9 +482,14 @@ export default async function SessionReviewPage({ params, searchParams }: { para
   // orders by date then created_at so double-session days resolve correctly.
   type NextSessionInfo = { id: string; session_name: string | null; type: string; date: string } | null;
   let nextSession: NextSessionInfo = null as NextSessionInfo;
+  // F41: mirror query for the previous session in the same week so the
+  // footer can offer a "← Prev" alongside "Next →", letting users walk
+  // the week without jumping back to the calendar between sessions.
+  let prevSession: NextSessionInfo = null as NextSessionInfo;
   if (!activityId) {
     try {
       const weekEndIso = new Date(sessionMonday.getTime() + 6 * 86400000).toISOString().slice(0, 10);
+      const weekStartIsoForNav = sessionMonday.toISOString().slice(0, 10);
       const { data: nextCandidates } = await supabase
         .from("sessions")
         .select("id,session_name,type,date,created_at")
@@ -499,6 +504,19 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       // The query already excludes the current session (neq) and orders by date + created_at,
       // so the first candidate is the correct next session, even for same-day doubles.
       nextSession = (nextCandidates?.[0] ?? null) as typeof nextSession;
+
+      const { data: prevCandidates } = await supabase
+        .from("sessions")
+        .select("id,session_name,type,date,created_at")
+        .eq("user_id", user.id)
+        .gte("date", weekStartIsoForNav)
+        .lte("date", session.date)
+        .in("status", ["planned", "completed"])
+        .neq("id", session.id)
+        .order("date", { ascending: false })
+        .order("created_at", { ascending: false })
+        .limit(5);
+      prevSession = (prevCandidates?.[0] ?? null) as typeof prevSession;
     } catch {
       // Agent preview mock client may not support .neq() — degrade gracefully
     }
@@ -596,12 +614,16 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         <span className="truncate text-[rgba(255,255,255,0.6)]">{sessionTitle}</span>
       </nav>
 
-      {/* ── Section 1: Header ── */}
+      {/* ── Section 1: Header + score hero ──
+          F38: score is the page's title — render it at 72px tabular-nums
+          with an inline verdict label. The first 2-3 usefulMetrics sit
+          beside the score so the user gets the headline stats without
+          opening any accordion. */}
       <article className="surface p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
-            <h1 className="text-2xl font-semibold">{sessionTitle}</h1>
-            <p className="mt-1.5 text-sm text-muted">
+            <h1 className="text-xl font-semibold text-[rgba(255,255,255,0.92)] sm:text-2xl">{sessionTitle}</h1>
+            <p className="mt-1 text-sm text-muted">
               {disciplineLabel} · {sessionDateLabel} · {actualDurationLabel}
             </p>
             {blockContext ? (
@@ -613,7 +635,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           </div>
         </div>
 
-        <div className="mt-4 flex flex-wrap items-center gap-2">
+        <div className="mt-3 flex flex-wrap items-center gap-2">
           <span className={sessionStatusBadgeClass}>{reviewVm.sessionStatusLabel}</span>
           <span className={intentBadgeClass}>{reviewVm.intent.label}</span>
           {reviewVm.isReviewable ? (
@@ -624,17 +646,34 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         </div>
 
         {reviewVm.isReviewable && reviewVm.score !== null ? (
-          <div className="mt-4 flex items-baseline gap-3">
-            <span className={`font-mono text-3xl font-semibold ${toneToTextClass(reviewVm.scoreTone)}`}>
-              {reviewVm.score}
-            </span>
-            <span className={`text-base font-medium ${toneToTextClass(reviewVm.scoreTone)}`}>
-              {reviewVm.scoreBand}
-            </span>
-            {confidenceQualifier ? (
-              <span className="rounded-full border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.06)] px-2 py-0.5 text-[10px] text-tertiary">
-                {confidenceQualifier}
+          <div className="mt-5 flex flex-col gap-4 border-t border-[hsl(var(--border))] pt-5 sm:flex-row sm:items-center sm:gap-6">
+            <div className="flex items-baseline gap-3">
+              <span
+                className={`font-mono text-6xl font-semibold leading-none tabular-nums tracking-[-0.02em] sm:text-7xl ${toneToTextClass(reviewVm.scoreTone)}`}
+              >
+                {reviewVm.score}
               </span>
+              <div className="min-w-0">
+                <p className={`text-lg font-medium ${toneToTextClass(reviewVm.scoreTone)}`}>
+                  {reviewVm.scoreBand}
+                </p>
+                {confidenceQualifier ? (
+                  <p className="text-[11px] text-tertiary">{confidenceQualifier}</p>
+                ) : null}
+              </div>
+            </div>
+            {reviewVm.usefulMetrics.length > 0 ? (
+              <div className="grid flex-1 grid-cols-3 gap-2">
+                {reviewVm.usefulMetrics.slice(0, 3).map((metric) => (
+                  <div
+                    key={metric.label}
+                    className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2"
+                  >
+                    <p className="text-[10px] uppercase tracking-[0.08em] text-tertiary">{metric.label}</p>
+                    <p className="mt-1 text-sm font-medium tabular-nums text-white">{metric.value}</p>
+                  </div>
+                ))}
+              </div>
             ) : null}
           </div>
         ) : null}
@@ -642,14 +681,43 @@ export default async function SessionReviewPage({ params, searchParams }: { para
 
       {showFeelCapture ? <FeelCaptureBanner sessionId={session.id} existingFeel={existingFeelData} /> : null}
 
-      {/* ── Section 2: The Numbers (promoted to hero position) ── */}
-      {session.status === "completed" && !activityId ? (
-        <SessionVerdictCard
-          sessionId={session.id}
-          existingVerdict={existingVerdictData as Parameters<typeof SessionVerdictCard>[0]["existingVerdict"]}
-          sessionCompleted={true}
-          discipline={session.discipline ?? session.sport}
-        />
+      {/* ── Section 2: "One thing" hero ──
+          F37: promote this out of the old Coach's Take stack so the
+          single most actionable takeaway gets its own emphasised card.
+          The long-form analysis (purpose, execution assessment, metric
+          table, why-it-matters, etc.) moves into the accordion below. */}
+      {reviewVm.isReviewable && reviewVm.oneThingToChange ? (
+        <article
+          className={`rounded-2xl border-l-[3px] p-5 ${
+            isKeepDoingAdvice
+              ? "border-l-[var(--color-success)] bg-[rgba(52,211,153,0.05)]"
+              : "border-l-[var(--color-accent)] bg-[rgba(190,255,0,0.04)]"
+          } border-y border-r border-[hsl(var(--border))]`}
+        >
+          <p className={`text-[11px] font-medium uppercase tracking-[0.14em] ${isKeepDoingAdvice ? "text-success" : "text-[var(--color-accent)]"}`}>
+            {oneThingLabel}
+          </p>
+          <p className="mt-2 text-base font-medium leading-snug text-white">{reviewVm.oneThingToChange}</p>
+          {reviewVm.whyItMatters ? (
+            <p className="mt-2 text-sm text-[rgba(255,255,255,0.68)]">{reviewVm.whyItMatters}</p>
+          ) : null}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <Link
+              href={`/coach?prompt=${encodeURIComponent(`${sessionTitle}: how do I apply "${reviewVm.oneThingToChange}" to my next session?`)}`}
+              className="btn-primary px-3 text-xs"
+            >
+              Apply to next session
+            </Link>
+            {nextSession ? (
+              <Link
+                href={`/sessions/${nextSession.id}`}
+                className="inline-flex items-center rounded-lg border border-[hsl(var(--border))] px-3 py-1.5 text-xs text-tertiary transition-ui hover:border-[rgba(255,255,255,0.2)] hover:text-white"
+              >
+                Next: {nextSession.session_name ?? nextSession.type} →
+              </Link>
+            ) : null}
+          </div>
+        </article>
       ) : null}
 
       {/* Extras verdict card — reads from the CoachVerdict stored in execution_result */}
@@ -686,46 +754,41 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         </article>
       ) : null}
 
-      {/* ── Section 3: Coach's Take (consolidated narrative) ── */}
-      <section className="surface p-4 md:p-5">
-        {reviewVm.isReviewable ? (
+      {/* ── Section 3: Read full analysis (accordion) ──
+          F37: everything long-form that used to live between the score
+          and the sub-score breakdown now collapses here. Default closed.
+          The SessionVerdictCard is rendered inside so its fetch still
+          runs on mount, just behind a disclosure. */}
+      {reviewVm.isReviewable ? (
+        <DetailsAccordion
+          title="Read full analysis"
+          summaryDetail={
+            <span className="text-[11px] text-muted">
+              Verdict · purpose · metric deltas · plan impact
+            </span>
+          }
+        >
           <div className="space-y-4">
-            {/* Execution diagnosis — shown for reviewable sessions without a verdict card (skipped, planned-sync) */}
-            {session.status !== "completed" ? (
-              <>
-                {reviewVm.actualExecutionSummary ? (
-                  <div>
-                    <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Execution quality</p>
-                    <p className="mt-2 text-sm">{reviewVm.actualExecutionSummary}</p>
-                  </div>
-                ) : null}
-                {reviewVm.mainGap ? (
-                  <div className="border-t border-[hsl(var(--border))] pt-4">
-                    <p className="text-xs uppercase tracking-[0.14em] text-tertiary">{reviewVm.mainGapLabel}</p>
-                    <p className="mt-2 text-sm">{reviewVm.mainGap}</p>
-                  </div>
-                ) : null}
-              </>
+            {session.status === "completed" && !activityId ? (
+              <SessionVerdictCard
+                sessionId={session.id}
+                existingVerdict={existingVerdictData as Parameters<typeof SessionVerdictCard>[0]["existingVerdict"]}
+                sessionCompleted={true}
+                discipline={session.discipline ?? session.sport}
+              />
             ) : null}
 
-            {/* One thing to change / Keep doing */}
-            {reviewVm.oneThingToChange ? (
-              <div className={`rounded-xl border p-4 ${isKeepDoingAdvice
-                ? "border-[rgba(52,211,153,0.3)] bg-[rgba(52,211,153,0.06)]"
-                : "border-[hsl(var(--accent)/0.3)] bg-[hsl(var(--accent)/0.06)]"
-              }`}>
-                <p className={`text-xs uppercase tracking-[0.14em] ${isKeepDoingAdvice ? "text-success" : "text-[hsl(var(--accent))]"}`}>
-                  {oneThingLabel}
-                </p>
-                <p className="mt-2 text-sm font-medium text-white">{reviewVm.oneThingToChange}</p>
+            {/* Execution diagnosis — shown for reviewable sessions without a verdict card (skipped, planned-sync) */}
+            {session.status !== "completed" && reviewVm.actualExecutionSummary ? (
+              <div>
+                <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Execution quality</p>
+                <p className="mt-2 text-sm">{reviewVm.actualExecutionSummary}</p>
               </div>
             ) : null}
-
-            {/* Why it matters */}
-            {reviewVm.whyItMatters ? (
-              <div>
-                <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Why it matters</p>
-                <p className="mt-2 text-sm text-muted">{reviewVm.whyItMatters}</p>
+            {session.status !== "completed" && reviewVm.mainGap ? (
+              <div className="border-t border-[hsl(var(--border))] pt-4">
+                <p className="text-xs uppercase tracking-[0.14em] text-tertiary">{reviewVm.mainGapLabel}</p>
+                <p className="mt-2 text-sm">{reviewVm.mainGap}</p>
               </div>
             ) : null}
 
@@ -743,12 +806,14 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               ) : null}
             </div>
 
-            {/* Metrics grid — pulled from right sidebar to be inline */}
-            {reviewVm.usefulMetrics.length > 0 ? (
+            {/* Full metrics grid — 3 are already shown inline with the score,
+                this exposes the rest (plus the first 3 for a consolidated view). */}
+            {reviewVm.usefulMetrics.length > 3 ? (
               <div className="border-t border-[hsl(var(--border))] pt-4">
+                <p className="mb-2 text-xs uppercase tracking-[0.14em] text-tertiary">All metrics</p>
                 <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
                   {reviewVm.usefulMetrics.map((metric) => (
-                    <div key={metric.label} className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
+                    <div key={metric.label} className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
                       <p className="text-xs text-muted">{metric.label}</p>
                       <p className="mt-1 text-base font-semibold text-white">{metric.value}</p>
                     </div>
@@ -757,7 +822,9 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               </div>
             ) : null}
           </div>
-        ) : (
+        </DetailsAccordion>
+      ) : (
+        <section className="surface p-4 md:p-5">
           <div className="grid gap-3 md:grid-cols-[0.9fr_1.1fr]">
             <div>
               <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Planned intent</p>
@@ -768,8 +835,8 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               <p className="mt-2 text-sm">{reviewVm.unlockDetail}</p>
             </div>
           </div>
-        )}
-      </section>
+        </section>
+      )}
 
       {/* ── Section 4: Score Breakdown (visible by default) ── */}
       {reviewVm.isReviewable && reviewVm.score !== null && reviewVm.componentScores ? (
@@ -789,7 +856,10 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               ) : null}
             </div>
           </div>
-          <div className="mt-3 space-y-3">
+          {/* F40: 2-column layout at md+, faint 50 tick at each bar to
+              anchor "halfway" so the user has a scale reference. 100 is
+              implicit at the right edge. */}
+          <div className="mt-3 grid gap-3 sm:grid-cols-2 sm:gap-x-5 sm:gap-y-4">
             {[
               { label: "Intent match", weightLabel: "40%", component: reviewVm.componentScores.intentMatch },
               { label: "Pacing & execution", weightLabel: "25%", component: reviewVm.componentScores.pacingExecution },
@@ -815,21 +885,28 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                     </div>
                     <span className="text-xs font-mono font-medium text-white">{component.score}</span>
                   </div>
-                  <div className="mt-1.5 flex h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                    <div className={`h-full ${barColor} transition-all`} style={{ width: `${component.score}%` }} />
-                    {cappedUpperPct > 0 ? (
-                      <div
-                        className="h-full border-l border-warning/40"
-                        style={{
-                          width: `${cappedUpperPct}%`,
-                          backgroundImage:
-                            "repeating-linear-gradient(45deg, hsl(var(--warning) / 0.25) 0 4px, transparent 4px 8px)"
-                        }}
-                        aria-label="uncertainty band"
-                      />
-                    ) : null}
+                  <div className="relative mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                    {/* 50-point tick mark so the bar has a legible scale anchor */}
+                    <span
+                      aria-hidden="true"
+                      className="absolute inset-y-0 left-1/2 w-px bg-[rgba(255,255,255,0.25)]"
+                    />
+                    <div className="flex h-full w-full">
+                      <div className={`h-full ${barColor} transition-all`} style={{ width: `${component.score}%` }} />
+                      {cappedUpperPct > 0 ? (
+                        <div
+                          className="h-full border-l border-warning/40"
+                          style={{
+                            width: `${cappedUpperPct}%`,
+                            backgroundImage:
+                              "repeating-linear-gradient(45deg, hsl(var(--warning) / 0.25) 0 4px, transparent 4px 8px)"
+                          }}
+                          aria-label="uncertainty band"
+                        />
+                      ) : null}
+                    </div>
                   </div>
-                  <p className="mt-1 text-[11px] text-muted">{component.detail}</p>
+                  <p className="mt-1 text-[11px] leading-snug text-muted">{component.detail}</p>
                 </div>
               );
             })}
@@ -889,10 +966,16 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         </div>
       </section>
 
-      {/* Navigation footer */}
-      <nav className="flex flex-wrap items-center gap-3 border-t border-[hsl(var(--border))] pt-4">
+      {/* F41: footer walks the week — prev on the left, next on the right.
+          Breadcrumb at the top of the page handles back-to-calendar, and
+          the Ask-coach section above already has the primary coach CTA,
+          so no "Back to Calendar" or "Ask Coach about this" here. The
+          post-upload flow keeps its dedicated Dashboard + Calendar pair
+          because the user just arrived from a fresh upload and hasn't
+          seen either yet. */}
+      <nav className="flex flex-wrap items-center justify-between gap-3 border-t border-[hsl(var(--border))] pt-4">
         {isPostUpload ? (
-          <>
+          <div className="flex flex-wrap items-center gap-3">
             <Link
               href="/dashboard"
               className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-medium text-white hover:bg-[rgba(255,255,255,0.14)] lg:min-h-0"
@@ -905,31 +988,27 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             >
               View Calendar
             </Link>
-          </>
+          </div>
         ) : (
           <>
-            <Link
-              href={`/calendar?weekStart=${weekStartIso}`}
-              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-medium text-white hover:bg-[rgba(255,255,255,0.14)] lg:min-h-0"
-            >
-              ← Back to Calendar
-            </Link>
+            {prevSession ? (
+              <Link
+                href={`/sessions/${prevSession.id}`}
+                className="inline-flex min-h-[44px] items-center gap-1.5 text-sm text-tertiary transition-ui hover:text-white lg:min-h-0"
+              >
+                ← Prev: {prevSession.session_name ?? prevSession.type}
+              </Link>
+            ) : <span />}
             {nextSession ? (
               <Link
                 href={`/sessions/${nextSession.id}`}
-                className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.12)] px-4 py-2 text-sm text-[rgba(255,255,255,0.7)] hover:border-[rgba(255,255,255,0.2)] hover:text-white lg:min-h-0"
+                className="inline-flex min-h-[44px] items-center gap-1.5 text-sm text-tertiary transition-ui hover:text-white lg:min-h-0"
               >
                 Next: {nextSession.session_name ?? nextSession.type} →
               </Link>
-            ) : null}
+            ) : <span />}
           </>
         )}
-        <Link
-          href={`/coach?prompt=${encodeURIComponent(`${sessionTitle}: What should I focus on for my next session?`)}`}
-          className="inline-flex min-h-[44px] items-center gap-1.5 text-sm text-cyan-400 hover:text-cyan-300 lg:min-h-0"
-        >
-          Ask Coach about this
-        </Link>
       </nav>
     </section>
   );

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -477,48 +477,36 @@ export default async function SessionReviewPage({ params, searchParams }: { para
   const sessionMonday = getMonday(new Date(`${session.date}T00:00:00.000Z`));
   const weekStartIso = sessionMonday.toISOString().slice(0, 10);
 
-  // Query for next session in the same week for forward navigation
-  // Uses gte + neq to include same-day sessions, filters out skipped, and
-  // orders by date then created_at so double-session days resolve correctly.
+  // F41: fetch the ordered week in one query, then pick the siblings by
+  // index. This makes same-day doubles resolve correctly — `gte`/`lte` on
+  // date alone loses the ordering for rows that share `session.date`, so
+  // the old prev/next pair would disagree about which same-day session
+  // comes first. Indexing a single ordered list can't disagree.
   type NextSessionInfo = { id: string; session_name: string | null; type: string; date: string } | null;
   let nextSession: NextSessionInfo = null as NextSessionInfo;
-  // F41: mirror query for the previous session in the same week so the
-  // footer can offer a "← Prev" alongside "Next →", letting users walk
-  // the week without jumping back to the calendar between sessions.
   let prevSession: NextSessionInfo = null as NextSessionInfo;
   if (!activityId) {
     try {
       const weekEndIso = new Date(sessionMonday.getTime() + 6 * 86400000).toISOString().slice(0, 10);
       const weekStartIsoForNav = sessionMonday.toISOString().slice(0, 10);
-      const { data: nextCandidates } = await supabase
-        .from("sessions")
-        .select("id,session_name,type,date,created_at")
-        .eq("user_id", user.id)
-        .gte("date", session.date)
-        .lte("date", weekEndIso)
-        .in("status", ["planned", "completed"])
-        .neq("id", session.id)
-        .order("date", { ascending: true })
-        .order("created_at", { ascending: true })
-        .limit(5);
-      // The query already excludes the current session (neq) and orders by date + created_at,
-      // so the first candidate is the correct next session, even for same-day doubles.
-      nextSession = (nextCandidates?.[0] ?? null) as typeof nextSession;
-
-      const { data: prevCandidates } = await supabase
+      const { data: weekRows } = await supabase
         .from("sessions")
         .select("id,session_name,type,date,created_at")
         .eq("user_id", user.id)
         .gte("date", weekStartIsoForNav)
-        .lte("date", session.date)
+        .lte("date", weekEndIso)
         .in("status", ["planned", "completed"])
-        .neq("id", session.id)
-        .order("date", { ascending: false })
-        .order("created_at", { ascending: false })
-        .limit(5);
-      prevSession = (prevCandidates?.[0] ?? null) as typeof prevSession;
+        .order("date", { ascending: true })
+        .order("created_at", { ascending: true });
+      if (Array.isArray(weekRows)) {
+        const idx = weekRows.findIndex((row) => row.id === session.id);
+        if (idx >= 0) {
+          prevSession = (weekRows[idx - 1] ?? null) as typeof prevSession;
+          nextSession = (weekRows[idx + 1] ?? null) as typeof nextSession;
+        }
+      }
     } catch {
-      // Agent preview mock client may not support .neq() — degrade gracefully
+      // Agent preview mock client may not support this shape — degrade gracefully
     }
   }
 

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -626,9 +626,6 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             <p className="mt-1 text-sm text-muted">
               {disciplineLabel} · {sessionDateLabel} · {actualDurationLabel}
             </p>
-            {blockContext ? (
-              <p className="mt-1 text-xs text-tertiary">{blockContext}</p>
-            ) : null}
           </div>
           <div className="flex flex-row flex-wrap items-center gap-2 sm:flex-col sm:items-end">
             {hasLinkedActivity ? <RegenerateReviewButton sessionId={session.id} /> : null}
@@ -641,6 +638,14 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           {reviewVm.isReviewable ? (
             <span className={narrativeSourcePillClass(reviewVm.narrativeSource)}>
               {narrativeSourceLabel(reviewVm.narrativeSource)}
+            </span>
+          ) : null}
+          {blockContext ? (
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-[11px] text-[rgba(255,255,255,0.78)]">
+              <svg width="10" height="10" viewBox="0 0 12 12" fill="none" className="text-tertiary" aria-hidden="true">
+                <path d="M6 1L10.5 3.5V8.5L6 11L1.5 8.5V3.5L6 1Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
+              </svg>
+              {blockContext}
             </span>
           ) : null}
         </div>
@@ -839,89 +844,112 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       )}
 
       {/* ── Section 4: Score Breakdown (visible by default) ── */}
-      {reviewVm.isReviewable && reviewVm.score !== null && reviewVm.componentScores ? (
-        <article className="surface p-4 md:p-5">
-          <div className="flex items-center justify-between">
-            <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Score breakdown</p>
-            <div className="flex flex-wrap items-center gap-2">
-              {reviewVm.scoreBand ? (
-                <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
-                  {reviewVm.scoreBand}
-                </span>
-              ) : null}
-              {reviewVm.executionCostLabel ? (
-                <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
-                  Execution cost: {reviewVm.executionCostLabel}
-                </span>
-              ) : null}
+      {reviewVm.isReviewable && reviewVm.score !== null && reviewVm.componentScores ? (() => {
+        const breakdownRows = [
+          { key: "intentMatch", label: "Intent match", component: reviewVm.componentScores.intentMatch },
+          { key: "pacingExecution", label: "Pacing & execution", component: reviewVm.componentScores.pacingExecution },
+          { key: "completion", label: "Completion", component: reviewVm.componentScores.completion },
+          { key: "recoveryCompliance", label: "Recovery compliance", component: reviewVm.componentScores.recoveryCompliance }
+        ];
+        // Refinement: flag the single lowest sub-score so the user's eye
+        // lands on the metric pulling the headline down. Only highlight
+        // when the lowest is actually weak (< 85) and genuinely trails the
+        // rest (≥ 5 pts below the next-lowest) — otherwise a pack of
+        // similar 90s would still render one as "bad".
+        const sortedByScore = [...breakdownRows].sort((a, b) => a.component.score - b.component.score);
+        const lowest = sortedByScore[0];
+        const nextLowest = sortedByScore[1];
+        const lowestKey =
+          lowest && lowest.component.score < 85 && nextLowest && nextLowest.component.score - lowest.component.score >= 5
+            ? lowest.key
+            : null;
+        return (
+          <article className="surface p-4 md:p-5">
+            <div className="flex items-center justify-between">
+              <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Score breakdown</p>
+              <div className="flex flex-wrap items-center gap-2">
+                {reviewVm.scoreBand ? (
+                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
+                    {reviewVm.scoreBand}
+                  </span>
+                ) : null}
+                {reviewVm.executionCostLabel ? (
+                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
+                    Execution cost: {reviewVm.executionCostLabel}
+                  </span>
+                ) : null}
+              </div>
             </div>
-          </div>
-          {/* F40: 2-column layout at md+, faint 50 tick at each bar to
-              anchor "halfway" so the user has a scale reference. 100 is
-              implicit at the right edge. */}
-          <div className="mt-3 grid gap-3 sm:grid-cols-2 sm:gap-x-5 sm:gap-y-4">
-            {[
-              { label: "Intent match", weightLabel: "40%", component: reviewVm.componentScores.intentMatch },
-              { label: "Pacing & execution", weightLabel: "25%", component: reviewVm.componentScores.pacingExecution },
-              { label: "Completion", weightLabel: "20%", component: reviewVm.componentScores.completion },
-              { label: "Recovery compliance", weightLabel: "15%", component: reviewVm.componentScores.recoveryCompliance }
-            ].map(({ label, weightLabel, component }) => {
-              const barColor = component.score >= 80 ? "bg-[hsl(var(--success))]"
-                : component.score >= 60 ? "bg-[hsl(var(--warning))]"
-                : component.score >= 40 ? "bg-[hsl(35,100%,50%)]"
-                : "bg-[hsl(var(--signal-risk))]";
-              const cappedUpperPct = component.capped && typeof component.uncappedScore === "number"
-                ? Math.max(0, Math.min(100, component.uncappedScore) - component.score)
-                : 0;
-              return (
-                <div key={label}>
-                  <div className="flex items-center justify-between gap-2">
-                    <div className="flex items-center gap-2">
-                      <span className="text-xs font-medium text-white">{label}</span>
-                      <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1.5 py-0.5 text-[9px] text-tertiary">{weightLabel}</span>
-                      {component.capped ? (
-                        <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Capped</span>
-                      ) : null}
-                    </div>
-                    <span className="text-xs font-mono font-medium text-white">{component.score}</span>
-                  </div>
-                  <div className="relative mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
-                    {/* 50-point tick mark so the bar has a legible scale anchor */}
-                    <span
-                      aria-hidden="true"
-                      className="absolute inset-y-0 left-1/2 w-px bg-[rgba(255,255,255,0.25)]"
-                    />
-                    <div className="flex h-full w-full">
-                      <div className={`h-full ${barColor} transition-all`} style={{ width: `${component.score}%` }} />
-                      {cappedUpperPct > 0 ? (
-                        <div
-                          className="h-full border-l border-warning/40"
-                          style={{
-                            width: `${cappedUpperPct}%`,
-                            backgroundImage:
-                              "repeating-linear-gradient(45deg, hsl(var(--warning) / 0.25) 0 4px, transparent 4px 8px)"
-                          }}
-                          aria-label="uncertainty band"
-                        />
-                      ) : null}
-                    </div>
-                  </div>
-                  <p className="mt-1 text-[11px] leading-snug text-muted">{component.detail}</p>
-                </div>
-              );
-            })}
-          </div>
-          {cappedDominantMetric ? (
-            <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
-              {cappedDominantMetric} data missing — Intent Match is capped because the primary effort signal for this session isn&apos;t there to confirm.
+            {/* Refinement: weights collapse to a single explainer line so
+                they stop fighting the sub-score numbers for attention. */}
+            <p className="mt-1 text-[11px] text-tertiary">
+              Weighted: Intent 40 · Pacing 25 · Completion 20 · Recovery 15
             </p>
-          ) : missingCriticalData.length > 0 ? (
-            <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
-              {missingCriticalData[0]} missing — pair the right sensor next time to unlock a confirmed read.
-            </p>
-          ) : null}
-        </article>
-      ) : null}
+            {/* F40: 2-column layout at md+, faint 50 tick at each bar to
+                anchor "halfway" so the user has a scale reference. 100 is
+                implicit at the right edge. */}
+            <div className="mt-3 grid gap-3 sm:grid-cols-2 sm:gap-x-5 sm:gap-y-4">
+              {breakdownRows.map(({ key, label, component }) => {
+                const isLowest = key === lowestKey;
+                const barColor = component.score >= 80 ? "bg-[hsl(var(--success))]"
+                  : component.score >= 60 ? "bg-[hsl(var(--warning))]"
+                  : component.score >= 40 ? "bg-[hsl(35,100%,50%)]"
+                  : "bg-[hsl(var(--signal-risk))]";
+                const cappedUpperPct = component.capped && typeof component.uncappedScore === "number"
+                  ? Math.max(0, Math.min(100, component.uncappedScore) - component.score)
+                  : 0;
+                return (
+                  <div key={label}>
+                    <div className="flex items-center justify-between gap-2">
+                      <div className="flex items-center gap-2">
+                        <span className={`text-xs font-medium ${isLowest ? "text-warning" : "text-white"}`}>{label}</span>
+                        {isLowest ? (
+                          <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Lowest</span>
+                        ) : null}
+                        {component.capped ? (
+                          <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Capped</span>
+                        ) : null}
+                      </div>
+                      <span className={`font-mono tabular-nums ${isLowest ? "text-sm font-semibold text-warning" : "text-xs font-medium text-white"}`}>{component.score}</span>
+                    </div>
+                    <div className="relative mt-1.5 h-1.5 w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.08)]">
+                      {/* 50-point tick mark so the bar has a legible scale anchor */}
+                      <span
+                        aria-hidden="true"
+                        className="absolute inset-y-0 left-1/2 w-px bg-[rgba(255,255,255,0.25)]"
+                      />
+                      <div className="flex h-full w-full">
+                        <div className={`h-full ${barColor} transition-all`} style={{ width: `${component.score}%` }} />
+                        {cappedUpperPct > 0 ? (
+                          <div
+                            className="h-full border-l border-warning/40"
+                            style={{
+                              width: `${cappedUpperPct}%`,
+                              backgroundImage:
+                                "repeating-linear-gradient(45deg, hsl(var(--warning) / 0.25) 0 4px, transparent 4px 8px)"
+                            }}
+                            aria-label="uncertainty band"
+                          />
+                        ) : null}
+                      </div>
+                    </div>
+                    <p className="mt-1 text-[11px] leading-snug text-muted">{component.detail}</p>
+                  </div>
+                );
+              })}
+            </div>
+            {cappedDominantMetric ? (
+              <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+                {cappedDominantMetric} data missing — Intent Match is capped because the primary effort signal for this session isn&apos;t there to confirm.
+              </p>
+            ) : missingCriticalData.length > 0 ? (
+              <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+                {missingCriticalData[0]} missing — pair the right sensor next time to unlock a confirmed read.
+              </p>
+            ) : null}
+          </article>
+        );
+      })() : null}
 
       {/* ── Section 5: Compared to Previous ── */}
       {sessionComparison ? <SessionComparisonCard comparison={sessionComparison} trends={sessionTrends ?? []} aiComparisons={storedComparisons} sport={session.sport} /> : null}

--- a/app/(protected)/sessions/[sessionId]/regenerate-review-button.tsx
+++ b/app/(protected)/sessions/[sessionId]/regenerate-review-button.tsx
@@ -39,7 +39,12 @@ export function RegenerateReviewButton({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="flex flex-wrap items-center gap-2">
-      <button type="button" onClick={handleRegenerate} disabled={isPending} className="btn-secondary px-3 py-1.5 text-xs disabled:opacity-60">
+      <button
+        type="button"
+        onClick={handleRegenerate}
+        disabled={isPending}
+        className="text-xs text-tertiary underline-offset-2 transition-ui hover:text-white hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+      >
         {isPending ? "Regenerating..." : "Regenerate review"}
       </button>
       {message ? <p className="text-xs text-muted">{message}</p> : null}


### PR DESCRIPTION
## Summary
Addresses all 6 Session Review findings (F37–F42) from the April 2026 desktop UX audit. The critical overhaul users hit on every upload.

### Findings addressed
- **F37 (Critical)** · Six stacked prose blocks collapse into 3: score hero + "one thing to change" hero + "Read full analysis" accordion (SessionVerdictCard + Coach's Take narrative + full metrics grid).
- **F38 (High)** · Score is now the page's title. Renders at 72px tabular-nums with 3 inline metric tiles (duration / key reps / NP).
- **F39 (High)** · Feel-capture summary: large emoji + coloured primary feel as the hero, compact signal chips on a second row, whole surface is a button that flips into edit mode (form prefills with existing values).
- **F40 (Medium)** · Score Breakdown: 2-column layout at sm+ with a 50-point tick line on each bar for scale anchor.
- **F41 (Medium)** · Footer walks the week. Drops redundant "Back to Calendar" and duplicate "Ask Coach about this". Adds a prev-session query so users can navigate forward and back.
- **F42 (Low)** · Verdict card's "What does this mean?" → "Explain these metrics". Expanded panel gets a "Dig in with coach →" link that pre-loads the Coach with the session's discipline, verdict status, and top deviations.

## Test plan
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 969/972 pass (3 pre-existing `ambient-signals` date-fixture drift failures unrelated to Sprint 3)
- [x] Headless Chrome screenshot confirms score hero, feel row, one-thing hero, and score-breakdown ticks
- [ ] Real-browser sanity check for feel-edit flow (prefill + save reload)
- [ ] Verify prev/next footer renders on a session with siblings in the same week (preview seed has a single session)

## Known follow-ups
- Sport-specific guidance on the Coach prompt in F42 is currently template-based. A richer "include ride metrics in the prompt" version would need a server-side fetch before redirect.
- Score Breakdown's "delta vs last similar session" (F40's full ask) not yet implemented — requires a backend query for the prior similar session's component scores. Added ticks now; deltas deferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)