### PR TITLE
feat(plan|calendar|coach): sprint 4 design audit F21–F36 (re-open)

### DIFF
--- a/app/(protected)/calendar/components/coach-note-card.tsx
+++ b/app/(protected)/calendar/components/coach-note-card.tsx
@@ -63,9 +63,9 @@ const TRIGGER_COLORS: Partial<Record<TriggerType, TriggerColors>> = {
 };
 
 /**
- * Summarize a multi-sentence rationale into a single coach-note headline:
- * - First sentence, capped at 140 characters
- * - If no sentence break, first 140 chars with ellipsis
+ * Summarize a multi-sentence rationale into a single coach-note headline.
+ * First sentence, capped at 140 characters; falls back to a 140-char
+ * ellipsis when no sentence terminator lands inside that budget.
  */
 function summarizeRationale(text: string): { summary: string; hasMore: boolean } {
   const cleaned = text.trim();
@@ -81,8 +81,12 @@ function summarizeRationale(text: string): { summary: string; hasMore: boolean }
   return { summary: `${cleaned.slice(0, 137).trimEnd()}…`, hasMore: true };
 }
 
-function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: AdaptationRationale; defaultCollapsed?: boolean }) {
-  const [expanded, setExpanded] = useState(!defaultCollapsed);
+// F27: single note renders as a 1-line banner by default. Clicking the
+// banner expands into the full card (rationale prose + changes table +
+// preserved elements + Got-it/Discuss actions). This stops the block
+// from crowding the calendar grid below the fold.
+function CoachNoteRow({ rationale, startExpanded = false }: { rationale: AdaptationRationale; startExpanded?: boolean }) {
+  const [expanded, setExpanded] = useState(startExpanded);
   const [acknowledging, setAcknowledging] = useState(false);
   const [dismissed, setDismissed] = useState(false);
 
@@ -93,8 +97,7 @@ function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: Ad
   const colors = TRIGGER_COLORS[triggerType] ?? DEFAULT_TRIGGER_COLORS;
   const changes = Array.isArray(rationale.changes_summary) ? rationale.changes_summary : [];
   const preserved = rationale.preserved_elements ?? [];
-  const { summary: summaryLine, hasMore } = summarizeRationale(rationale.rationale_text);
-  const canCollapse = hasMore || changes.length > 0 || preserved.length > 0;
+  const { summary: summaryLine } = summarizeRationale(rationale.rationale_text);
 
   async function handleAcknowledge() {
     setAcknowledging(true);
@@ -108,6 +111,24 @@ function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: Ad
     } finally {
       setAcknowledging(false);
     }
+  }
+
+  if (!expanded) {
+    return (
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        aria-expanded="false"
+        className="group flex w-full items-center gap-2.5 rounded-lg border px-3 py-2 text-left transition hover:border-[rgba(255,255,255,0.2)]"
+        style={{ borderColor: colors.border, backgroundColor: colors.bg }}
+      >
+        <span className="flex-shrink-0 rounded-full border px-2 py-0.5 text-[10px] uppercase tracking-wider" style={{ borderColor: colors.border, color: colors.text }}>
+          {triggerLabel}
+        </span>
+        <span className="truncate text-xs text-white">{summaryLine}</span>
+        <span className="ml-auto flex-shrink-0 text-[11px] text-tertiary transition-colors group-hover:text-white">Read →</span>
+      </button>
+    );
   }
 
   return (
@@ -124,23 +145,19 @@ function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: Ad
             {triggerLabel}
           </span>
         </div>
-      </div>
-
-      <p className="mt-2 text-sm text-white">
-        {expanded ? rationale.rationale_text : summaryLine}
-      </p>
-
-      {canCollapse ? (
         <button
           type="button"
-          onClick={() => setExpanded(!expanded)}
-          className="mt-2 text-xs text-tertiary hover:text-white"
+          onClick={() => setExpanded(false)}
+          aria-label="Collapse coach note"
+          className="text-[11px] text-tertiary hover:text-white"
         >
-          {expanded ? "Show less" : "Show full reasoning"}
+          Collapse ↑
         </button>
-      ) : null}
+      </div>
 
-      {expanded && (changes.length > 0 || preserved.length > 0) && (
+      <p className="mt-2 text-sm text-white">{rationale.rationale_text}</p>
+
+      {(changes.length > 0 || preserved.length > 0) && (
         <div className="mt-3 space-y-3 rounded-lg bg-[rgba(0,0,0,0.2)] p-3">
           {changes.length > 0 && (
             <div>
@@ -171,7 +188,6 @@ function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: Ad
         </div>
       )}
 
-      {/* Actions */}
       <div className="mt-3 flex items-center gap-3">
         <button
           type="button"
@@ -193,34 +209,23 @@ function SingleCoachNote({ rationale, defaultCollapsed = true }: { rationale: Ad
 }
 
 export function CoachNoteCards({ rationales }: Props) {
-  const [showAll, setShowAll] = useState(false);
-
   if (rationales.length === 0) return null;
 
-  const firstNote = rationales[0];
-  const restNotes = rationales.slice(1);
-
+  // F27: count header — the user's mental model is "this week's coach
+  // notes", not "the first note is special and the rest are buried".
   return (
-    <div className="space-y-3">
-      <SingleCoachNote key={firstNote.id} rationale={firstNote} />
-
-      {restNotes.length > 0 && (
-        <button
-          type="button"
-          onClick={() => setShowAll((prev) => !prev)}
-          className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-xs text-tertiary transition hover:border-[rgba(255,255,255,0.16)] hover:text-white"
-        >
-          {showAll
-            ? "Hide older notes"
-            : `${restNotes.length} more coach note${restNotes.length > 1 ? "s" : ""}`}
-          <span className="text-[10px]">{showAll ? "\u25B2" : "\u25BC"}</span>
-        </button>
-      )}
-
-      {showAll &&
-        restNotes.map((r) => (
-          <SingleCoachNote key={r.id} rationale={r} />
+    <section className="space-y-2" aria-label="Coach notes for this week">
+      <div className="flex items-center gap-2">
+        <p className="text-[10px] uppercase tracking-[0.12em] text-tertiary">Coach notes</p>
+        <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1.5 py-0.5 text-[10px] tabular-nums text-muted">
+          {rationales.length}
+        </span>
+      </div>
+      <div className="space-y-1.5">
+        {rationales.map((rationale) => (
+          <CoachNoteRow key={rationale.id} rationale={rationale} />
         ))}
-    </div>
+      </div>
+    </section>
   );
 }

--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -566,37 +566,49 @@ export function WeekCalendar({
 
   return (
     <section className="space-y-3">
-      <header className="surface-subtle flex flex-wrap items-center justify-between gap-2 px-3 py-2">
-        <div className="flex items-center gap-2 text-xs">
+      {/* F31: three logical groups — range nav, filters, action — split
+          by vertical dividers so the eye doesn't have to parse a flat
+          pile of controls. Completion counts move down into the per-day
+          headers (F29) where they already sit next to the load numbers. */}
+      <header className="surface-subtle flex flex-wrap items-center justify-between gap-x-4 gap-y-2 px-3 py-2">
+        <div
+          role="group"
+          aria-label="Week range"
+          className="flex flex-wrap items-center gap-2 text-xs"
+        >
           <p className="text-sm font-semibold">{dayFormatter.format(new Date(`${weekDays[0].iso}T00:00:00.000Z`))} – {dayFormatter.format(new Date(`${weekDays[6].iso}T00:00:00.000Z`))}</p>
-          <Link href={withWeek(addDays(activeWeekStart, -7))} className="rounded-md border border-[rgba(255,255,255,0.12)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[rgba(255,255,255,0.6)]">Prev</Link>
-          <Link
-            href={withWeek(currentWeekStart)}
-            className={`rounded-md border bg-[var(--color-surface-raised)] px-2 py-1 text-xs ${
-              activeWeekStart === currentWeekStart
-                ? "border-[rgba(190,255,0,0.40)] text-[var(--color-accent)]"
-                : "border-[rgba(255,255,255,0.12)] text-[rgba(255,255,255,0.6)]"
-            }`}
-          >
-            This week
-          </Link>
-          <Link href={withWeek(addDays(activeWeekStart, 7))} className="rounded-md border border-[rgba(255,255,255,0.12)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[rgba(255,255,255,0.6)]">Next</Link>
+          <div className="flex items-center gap-1.5 border-l border-[hsl(var(--border)/0.6)] pl-3">
+            <Link href={withWeek(addDays(activeWeekStart, -7))} aria-label="Previous week" className="rounded-md border border-[rgba(255,255,255,0.12)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[rgba(255,255,255,0.6)] hover:text-white">Prev</Link>
+            <Link
+              href={withWeek(currentWeekStart)}
+              className={`rounded-md border bg-[var(--color-surface-raised)] px-2 py-1 text-xs ${
+                activeWeekStart === currentWeekStart
+                  ? "border-[rgba(190,255,0,0.40)] text-[var(--color-accent)]"
+                  : "border-[rgba(255,255,255,0.12)] text-[rgba(255,255,255,0.6)] hover:text-white"
+              }`}
+            >
+              This week
+            </Link>
+            <Link href={withWeek(addDays(activeWeekStart, 7))} aria-label="Next week" className="rounded-md border border-[rgba(255,255,255,0.12)] bg-[var(--color-surface-raised)] px-2 py-1 text-xs text-[rgba(255,255,255,0.6)] hover:text-white">Next</Link>
+          </div>
         </div>
-        <div className="flex flex-col gap-2 text-xs sm:flex-row sm:flex-wrap sm:items-center">
-          <div className="flex items-center gap-2">
+        <div className="flex flex-wrap items-center gap-x-4 gap-y-2">
+          <div
+            role="group"
+            aria-label="Filters"
+            className="flex items-center gap-2 text-xs"
+          >
             <label className="sr-only" htmlFor="sport-filter">Discipline filter</label>
-            <select id="sport-filter" value={sportFilter} onChange={(e) => setSportFilter(e.target.value as SportFilter)} className="flex-1 rounded-md border border-[hsl(var(--border))] bg-transparent px-2 py-1.5 sm:flex-none sm:py-1">
+            <select id="sport-filter" value={sportFilter} onChange={(e) => setSportFilter(e.target.value as SportFilter)} className="rounded-md border border-[hsl(var(--border))] bg-transparent px-2 py-1.5 sm:py-1">
               <option value="all">All disciplines</option><option value="swim">Swim</option><option value="bike">Bike</option><option value="run">Run</option><option value="strength">Strength</option>
             </select>
             <label className="sr-only" htmlFor="status-filter">Status filter</label>
-            <select id="status-filter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as FilterStatus)} className="flex-1 rounded-md border border-[hsl(var(--border))] bg-transparent px-2 py-1.5 sm:flex-none sm:py-1">
+            <select id="status-filter" value={statusFilter} onChange={(e) => setStatusFilter(e.target.value as FilterStatus)} className="rounded-md border border-[hsl(var(--border))] bg-transparent px-2 py-1.5 sm:py-1">
               <option value="all">All statuses</option><option value="planned">Planned</option><option value="completed">Completed</option><option value="skipped">Skipped</option><option value="moved">Moved</option><option value="extra">Extra</option>
             </select>
           </div>
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 border-l border-[hsl(var(--border)/0.6)] pl-4">
             <button onClick={() => setQuickAddDate(weekDays[0]?.iso)} className="btn-primary px-3 text-xs">Add session</button>
-            <span className="hidden sm:inline rounded-full border border-[hsl(var(--border)/0.8)] bg-[hsl(var(--surface-subtle)/0.45)] px-2 py-0.5 text-[11px] text-muted">{completedCount} done · {plannedRemainingCount} remaining · {skippedCount} skipped · {extraSessionCount} extra</span>
-            <span className="sm:hidden rounded-full border border-[hsl(var(--border)/0.8)] bg-[hsl(var(--surface-subtle)/0.45)] px-2 py-0.5 text-[11px] text-muted">{completedCount} done · {skippedCount} skipped</span>
           </div>
         </div>
       </header>
@@ -828,32 +840,43 @@ export function WeekCalendar({
               ? `${metrics.skipped} session${metrics.skipped > 1 ? "s" : ""} skipped`
               : `${metrics.remainingPlanned} min not done`
             : null;
-          const dayLabel = isToday
-            ? getDayStateLabel("today")
-            : needsAttention
-              ? getDayStateLabel("needs_attention")
-              : metrics?.fullyDone
-                ? getDayStateLabel("complete")
-                : metrics?.isRest
-                  ? getDayStateLabel("rest_day")
-                  : metrics?.availableDay
-                    ? getDayStateLabel("available")
-                    : metrics?.openCapacity
-                      ? getDayStateLabel("open_capacity")
-                      : isFuture && metrics?.hasPlanned
-                        ? getDayStateLabel("planned")
-                        : getDayStateLabel("planned");
-          const dayTone = needsAttention ? "text-[hsl(var(--signal-risk))]" : isToday ? "text-accent" : "text-muted";
-
-          // Day context note — single-line contextual hint per the spec
+          // F29: condense day state into a single colored dot. Dot does
+          // the state-at-a-glance work; text underneath carries the
+          // "this many minutes planned / done" reading in tabular-nums.
           const hasKeySession = daySessions.some((s) => s.is_key || s.role === "key");
           const allRecovery = daySessions.length > 0 && daySessions.every((s) => s.role === "recovery" || s.role === "optional");
+          const dotState =
+            needsAttention ? "risk"
+            : isToday ? "today"
+            : metrics?.fullyDone ? "complete"
+            : metrics?.isRest ? "rest"
+            : metrics?.hasPlanned ? "planned"
+            : "open";
+          const dotClass: Record<typeof dotState, string> = {
+            risk: "bg-[hsl(var(--signal-risk))]",
+            today: "bg-[var(--color-accent)]",
+            complete: "bg-success",
+            planned: "bg-[rgba(255,255,255,0.3)]",
+            rest: "bg-transparent border border-[rgba(255,255,255,0.2)]",
+            open: "bg-transparent border border-dashed border-[rgba(255,255,255,0.18)]"
+          };
+          const dotTitle: Record<typeof dotState, string> = {
+            risk: attentionReason ?? "Needs attention",
+            today: "Today",
+            complete: "Fully done",
+            planned: "Planned",
+            rest: "Rest day",
+            open: "Open capacity"
+          };
+          // F30: future-day planned-only load stays muted — red means
+          // "missed" only, and a planned-not-yet-done Saturday is neither.
+          const loadClass = needsAttention ? "text-[hsl(var(--signal-risk))]" : "text-muted";
           const dayContextNote = hasKeySession
-            ? "Key session today"
+            ? "Key session"
             : daySessions.length === 0 && !needsAttention
               ? "Rest day"
               : allRecovery
-                ? "Recovery day"
+                ? "Recovery"
                 : null;
 
           return (
@@ -866,18 +889,30 @@ export function WeekCalendar({
                 borderTopWidth: isToday ? "2px" : "1px"
               }}
             >
-              <div className="mb-2 min-h-[86px] border-b border-[hsl(var(--border))] pb-2">
-                <p className="text-xs uppercase tracking-[0.14em] text-muted">{day.weekday}</p>
-                <div className="flex items-center justify-between">
-                  <p className="font-semibold">{day.label}</p>
-                  {isToday ? <span className="rounded-full bg-[hsl(var(--accent-performance)/0.2)] px-2 py-0.5 text-[11px] text-accent">Today</span> : null}
+              <div className="mb-2 border-b border-[hsl(var(--border))] pb-2">
+                <div className="flex items-center gap-1.5">
+                  <span
+                    aria-hidden="true"
+                    title={dotTitle[dotState]}
+                    className={`h-2 w-2 flex-shrink-0 rounded-full ${dotClass[dotState]}`}
+                  />
+                  <p className="text-xs uppercase tracking-[0.14em] text-muted">{day.weekday}</p>
+                  <span className="text-xs text-tertiary">·</span>
+                  <p className="text-xs font-medium text-white">{day.label}</p>
+                  {isToday ? (
+                    <span className="ml-auto rounded-full bg-[hsl(var(--accent-performance)/0.2)] px-1.5 py-0.5 text-[10px] text-accent">Today</span>
+                  ) : null}
                 </div>
-                <p className="mt-1 text-xs text-muted">{metrics?.completedMin ?? 0}/{metrics?.plannedMin ?? 0} min</p>
-                <p className={`mt-1 text-[11px] ${dayTone}`}>{dayLabel}</p>
-                {dayContextNote ? (
-                  <p className={`text-[11px] ${hasKeySession ? "font-medium text-accent" : "text-tertiary"}`}>{dayContextNote}</p>
+                {(metrics?.plannedMin ?? 0) > 0 || (metrics?.completedMin ?? 0) > 0 ? (
+                  <p className={`mt-1.5 text-[11px] tabular-nums ${loadClass}`}>
+                    {metrics?.plannedMin ?? 0}m planned
+                    {(metrics?.completedMin ?? 0) > 0 ? ` · ${metrics?.completedMin ?? 0}m done` : ""}
+                  </p>
                 ) : null}
-                {attentionReason ? <p className="text-[11px] text-muted">{attentionReason}</p> : null}
+                {dayContextNote ? (
+                  <p className={`mt-0.5 text-[11px] ${hasKeySession ? "font-medium text-accent" : "text-tertiary"}`}>{dayContextNote}</p>
+                ) : null}
+                {attentionReason ? <p className="mt-0.5 text-[11px] text-[hsl(var(--signal-risk))]">{attentionReason}</p> : null}
               </div>
 
               <div className="space-y-1.5 pt-0.5">
@@ -896,12 +931,35 @@ export function WeekCalendar({
                   const cardBackground = isNeedsAttentionCard ? "rgba(255,90,40,0.04)" : "#18181C";
                   const leftBorderColor = isNeedsAttentionCard ? "#FF5A28" : calendarDisciplineBorderColor(session.sport);
 
+                  // F28: completed sessions surface their execution score
+                  // as the state badge so the card communicates "how did
+                  // it go" at a glance. Falls back to the neutral status
+                  // chip when the score hasn't been computed yet.
+                  const cardScoreRaw =
+                    session.executionResult?.executionScore ??
+                    session.executionResult?.execution_score;
+                  const cardScore = typeof cardScoreRaw === "number" ? Math.round(cardScoreRaw) : null;
+                  const cardScoreClass =
+                    cardScore !== null
+                      ? cardScore >= 85
+                        ? "border-[rgba(52,211,153,0.35)] bg-[rgba(52,211,153,0.12)] text-success"
+                        : cardScore >= 70
+                          ? "border-[rgba(251,191,36,0.35)] bg-[rgba(251,191,36,0.12)] text-warning"
+                          : "border-[rgba(248,113,113,0.35)] bg-[rgba(248,113,113,0.12)] text-danger"
+                      : "";
                   const stateBadge =
                     state === "extra" ? null
                     : state === "unmatched_upload" ? (
                       <span className="rounded-full border border-[hsl(var(--accent-performance)/0.45)] bg-[hsl(var(--accent-performance)/0.14)] px-1.5 py-0.5 text-[10px] text-accent">Needs review</span>
                     ) : state === "moved" ? (
                       <span className="rounded-full border border-[hsl(var(--signal-load)/0.4)] px-1.5 py-0.5 text-[10px] text-[hsl(var(--signal-load))]">Moved{movedMeta ? ` · from ${weekDays.find((day) => day.iso === movedMeta.fromDate)?.weekday ?? movedMeta.fromDate}` : ""}</span>
+                    ) : session.status === "completed" && cardScore !== null ? (
+                      <span
+                        className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 font-mono text-[10px] font-medium tabular-nums ${cardScoreClass}`}
+                        title={session.executionResult?.executionScoreBand ?? "Execution score"}
+                      >
+                        {cardScore}
+                      </span>
                     ) : (
                       <SessionStatusChip status={session.status} compact />
                     );
@@ -994,12 +1052,28 @@ export function WeekCalendar({
                         </div>
                       ) : null}
                       {showCompletedFooter ? (
-                        <div className="mt-1 flex items-center border-t border-[rgba(255,255,255,0.06)] pt-1 text-[10px]">
-                          <span className="inline-flex w-full items-center justify-center gap-1 rounded-full border border-[rgba(52,211,153,0.25)] bg-[rgba(52,211,153,0.12)] px-[10px] py-[3px] text-[11px] font-medium text-success">
-                            <span aria-hidden="true">✓</span>
-                            {state === "extra" ? "Extra" : "Completed"}
-                          </span>
-                        </div>
+                        // F28: when the completed session has an execution
+                        // score, promote it into the footer chip. "Completed"
+                        // alone told the user nothing they didn't already see
+                        // from the green check; the score band ("On target",
+                        // "Partial match"…) is the actionable signal.
+                        state !== "extra" && cardScore !== null ? (
+                          <div className={`mt-1 flex items-center border-t border-[rgba(255,255,255,0.06)] pt-1 text-[10px]`}>
+                            <span className={`inline-flex w-full items-center justify-center gap-1.5 rounded-full border px-[10px] py-[3px] text-[11px] font-medium ${cardScoreClass}`}>
+                              <span className="font-mono tabular-nums">{cardScore}</span>
+                              <span>
+                                {session.executionResult?.executionScoreBand ?? "Completed"}
+                              </span>
+                            </span>
+                          </div>
+                        ) : (
+                          <div className="mt-1 flex items-center border-t border-[rgba(255,255,255,0.06)] pt-1 text-[10px]">
+                            <span className="inline-flex w-full items-center justify-center gap-1 rounded-full border border-[rgba(52,211,153,0.25)] bg-[rgba(52,211,153,0.12)] px-[10px] py-[3px] text-[11px] font-medium text-success">
+                              <span aria-hidden="true">✓</span>
+                              {state === "extra" ? "Extra" : "Completed"}
+                            </span>
+                          </div>
+                        )
                       ) : state === "unmatched_upload" ? (
                         <div className="mt-2 border-t border-[hsl(var(--accent-performance)/0.18)] pt-1.5">
                           <button

--- a/app/(protected)/coach/CoachBriefingCard.tsx
+++ b/app/(protected)/coach/CoachBriefingCard.tsx
@@ -7,27 +7,46 @@ type Props = {
   brief: WeeklyExecutionBrief;
   athleteContext: AthleteContextSnapshot | null;
   briefingContext: CoachBriefingContext;
+  /**
+   * F36: when this card renders inside the outer "This week at a glance"
+   * disclosure, the disclosure already owns the headline — suppress the
+   * internal one to avoid "Execution is on track" appearing twice.
+   */
+  suppressHeader?: boolean;
 };
 
-export function CoachBriefingCard({ brief, athleteContext, briefingContext }: Props) {
+export function CoachBriefingCard({ brief, athleteContext, briefingContext, suppressHeader = false }: Props) {
   const recurringPattern = athleteContext?.observed.recurringPatterns[0]?.detail ?? null;
 
   return (
     <article className="surface p-4 md:p-5">
-      {/* Header */}
-      <div className="flex flex-wrap items-start justify-between gap-3">
-        <div className="min-w-0 flex-1">
-          <p className="label">Coach Briefing</p>
-          <h2 className="mt-1 text-xl font-semibold sm:text-2xl">{brief.weekHeadline}</h2>
-          {brief.trend.reviewedCount === 0 ? <p className="mt-1.5 text-sm text-muted">{brief.weekSummary}</p> : null}
+      {suppressHeader ? (
+        brief.trend.reviewedCount === 0 ? (
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <p className="text-sm text-muted">{brief.weekSummary}</p>
+            <Link
+              href="/settings/athlete-context"
+              className="shrink-0 inline-flex min-h-[44px] items-center rounded-full border border-[hsl(var(--border))] px-3 text-xs text-muted transition hover:border-[hsl(var(--accent)/0.5)] hover:text-foreground lg:min-h-0 lg:py-1.5"
+            >
+              Edit athlete context
+            </Link>
+          </div>
+        ) : null
+      ) : (
+        <div className="flex flex-wrap items-start justify-between gap-3">
+          <div className="min-w-0 flex-1">
+            <p className="label">Coach Briefing</p>
+            <h2 className="mt-1 text-xl font-semibold sm:text-2xl">{brief.weekHeadline}</h2>
+            {brief.trend.reviewedCount === 0 ? <p className="mt-1.5 text-sm text-muted">{brief.weekSummary}</p> : null}
+          </div>
+          <Link
+            href="/settings/athlete-context"
+            className="shrink-0 inline-flex min-h-[44px] items-center rounded-full border border-[hsl(var(--border))] px-3 text-xs text-muted transition hover:border-[hsl(var(--accent)/0.5)] hover:text-foreground lg:min-h-0 lg:py-1.5"
+          >
+            Edit athlete context
+          </Link>
         </div>
-        <Link
-          href="/settings/athlete-context"
-          className="shrink-0 inline-flex min-h-[44px] items-center rounded-full border border-[hsl(var(--border))] px-3 text-xs text-muted transition hover:border-[hsl(var(--accent)/0.5)] hover:text-foreground lg:min-h-0 lg:py-1.5"
-        >
-          Edit athlete context
-        </Link>
-      </div>
+      )}
 
       {/* Trend strip — compact metadata row, only when there's data */}
       {brief.trend.reviewedCount > 0 ? (

--- a/app/(protected)/coach/coach-chat.tsx
+++ b/app/(protected)/coach/coach-chat.tsx
@@ -1124,18 +1124,25 @@ export function CoachChat({
               <label htmlFor="coach-input" className="sr-only">
                 Ask your triathlon coach
               </label>
-              <div className="-mx-4 mb-1.5 flex gap-1 overflow-x-auto px-4 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0">
-                {quickPrompts.map((prompt) => (
-                  <button
-                    key={prompt}
-                    type="button"
-                    onClick={() => setInput(prompt)}
-                    className="shrink-0 whitespace-nowrap rounded-full border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1 text-[12px] font-medium text-[rgba(255,255,255,0.55)] transition hover:border-[rgba(255,255,255,0.16)] hover:text-[rgba(255,255,255,0.75)]"
-                  >
-                    {prompt}
-                  </button>
-                ))}
-              </div>
+              {/* F33: suggestion chips compete with the input cursor if
+                  they stay visible after the thread starts. Show them
+                  only while the thread is empty (opener only, no user
+                  turn yet). Dynamic follow-ups belong to a future
+                  iteration once the last-response parser exists. */}
+              {messages.filter((m) => m.role === "user").length === 0 ? (
+                <div className="-mx-4 mb-1.5 flex gap-1 overflow-x-auto px-4 sm:mx-0 sm:flex-wrap sm:overflow-visible sm:px-0">
+                  {quickPrompts.map((prompt) => (
+                    <button
+                      key={prompt}
+                      type="button"
+                      onClick={() => setInput(prompt)}
+                      className="shrink-0 whitespace-nowrap rounded-full border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1 text-[12px] font-medium text-[rgba(255,255,255,0.55)] transition hover:border-[rgba(255,255,255,0.16)] hover:text-[rgba(255,255,255,0.75)]"
+                    >
+                      {prompt}
+                    </button>
+                  ))}
+                </div>
+              ) : null}
               <div className="flex gap-2">
                 <input
                   id="coach-input"
@@ -1160,6 +1167,12 @@ export function CoachChat({
                   </button>
                 ) : null}
               </div>
+              {/* F33: keyboard hint — single-line input takes Enter to
+                  send by default, so the hint calls that out and gives
+                  users a nudge toward the send button otherwise. */}
+              <p className="mt-1.5 hidden text-right text-[10px] text-tertiary sm:block">
+                <kbd className="rounded border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-1 py-0.5 text-[10px] font-mono">⏎</kbd> to send
+              </p>
               {error ? <p className="mt-2 text-sm text-rose-400">{error}</p> : null}
             </form>
           </div>

--- a/app/(protected)/coach/page.tsx
+++ b/app/(protected)/coach/page.tsx
@@ -306,17 +306,26 @@ export default async function CoachPage({ searchParams }: { searchParams?: { pro
     (transitionBriefing && !transitionBriefing.dismissedAt) || weeklyBrief || Boolean(athleteContext);
 
   return (
-    <section className="space-y-4">
-      {/* ── Chat-first layout: chat renders above the briefing ──── */}
-      <CoachChat diagnosisSessions={diagnosisSessions} briefingContext={briefingContext} initialPrompt={searchParams?.prompt} showBriefingPanel={false} />
+    // F32: chat-first layout. Chat takes the main column; briefing,
+    // check-in, and profile fold into a right-rail "Context" panel at
+    // desktop widths, stacking below the chat on narrower viewports.
+    // The rail remains a collapsible disclosure so the chat always has
+    // breathing room even when a user wants the briefing visible.
+    <section className="grid gap-4 lg:grid-cols-[minmax(0,1.6fr)_minmax(0,1fr)]">
+      <div className="min-w-0">
+        <CoachChat diagnosisSessions={diagnosisSessions} briefingContext={briefingContext} initialPrompt={searchParams?.prompt} showBriefingPanel={false} />
+      </div>
 
-      {/* ── Briefing bundle (collapsed by default) ──────────────── */}
+      {/* F36: Coach Briefing owns its own collapsible headline — the
+          old "This week at a glance" kicker duplicated the briefing's
+          headline verbatim on the expanded view. One headline now. */}
+      <aside className="min-w-0 lg:sticky lg:top-20 lg:self-start">
       {hasBriefingContent ? (
         <details className="surface group rounded-xl">
           <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3">
             <div className="min-w-0">
-              <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">This week at a glance</p>
-              <p className="mt-0.5 truncate text-sm text-white">
+              <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Coach briefing</p>
+              <p className="mt-0.5 truncate text-sm font-medium text-white">
                 {weeklyBrief?.weekHeadline
                   ?? (athleteContext?.goals.priorityEventName
                     ? `Priority: ${athleteContext.goals.priorityEventName}`
@@ -336,51 +345,69 @@ export default async function CoachPage({ searchParams }: { searchParams?: { pro
                 brief={weeklyBrief}
                 athleteContext={athleteContext}
                 briefingContext={briefingContext}
+                suppressHeader
               />
             ) : null}
 
             {athleteContext ? (
-              <div className="grid gap-4 md:grid-cols-2">
+              <div className="space-y-4">
                 <WeeklyCheckinCard weekStart={weekStart} snapshot={athleteContext} />
 
                 <article className="surface p-4">
                   <div className="flex flex-wrap items-start justify-between gap-3">
-                    <div>
+                    <div className="min-w-0 flex-1">
                       <p className="label">Coaching profile</p>
                       <h2 className="mt-1 text-lg font-semibold">{contextIncomplete ? "Profile needs a few details" : "Profile is ready"}</h2>
-                      <p className="mt-1 text-sm text-muted">
-                        {contextIncomplete
-                          ? "Finish a few fields so Coach can personalize advice."
-                          : "Coach has your baseline context for briefing, reviews, and chat."}
-                      </p>
+                      {/* F35: prose summary reads as "Coach understands
+                          you". The old pill row read as tags, which
+                          invited "why don't these link anywhere?" */}
+                      {contextIncomplete ? (
+                        <p className="mt-1 text-sm text-muted">
+                          Finish a few fields so Coach can personalize advice.
+                        </p>
+                      ) : (
+                        <p className="mt-1 text-sm text-[rgba(255,255,255,0.78)] leading-relaxed">
+                          {(() => {
+                            const parts: string[] = [];
+                            const experience = athleteContext.declared.experienceLevel.value;
+                            const event = athleteContext.goals.priorityEventName;
+                            const goal = athleteContext.goals.goalType;
+                            const limiters = athleteContext.declared.limiters.slice(0, 2).map((l) => l.value);
+                            if (event && experience) {
+                              parts.push(`Training for ${event} as a${/^[aeiou]/i.test(experience) ? "n" : ""} ${experience.toLowerCase()} athlete.`);
+                            } else if (event) {
+                              parts.push(`Training for ${event}.`);
+                            } else if (experience) {
+                              parts.push(`${experience[0].toUpperCase()}${experience.slice(1)} athlete.`);
+                            }
+                            if (goal) parts.push(`Goal: ${goal.toLowerCase()}.`);
+                            if (limiters.length > 0) {
+                              parts.push(`Current focus — ${limiters.join(" and ").toLowerCase()}.`);
+                            }
+                            return parts.join(" ") || "Coach has your baseline context for briefing, reviews, and chat.";
+                          })()}
+                        </p>
+                      )}
                     </div>
                     <Link href="/settings/athlete-context" className={contextIncomplete ? "btn-primary px-3 py-1.5 text-xs" : "border border-[rgba(255,255,255,0.20)] bg-transparent px-3 py-1.5 text-xs text-[rgba(255,255,255,0.7)] rounded-md"}>
                       {contextIncomplete ? "Complete profile" : "Edit profile"}
                     </Link>
                   </div>
 
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    {contextIncomplete
-                      ? missingContextLabels.map((label) => (
+                  {contextIncomplete ? (
+                    <div className="mt-3 flex flex-wrap gap-2">
+                      {missingContextLabels.map((label) => (
                         <span key={label} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{label}</span>
-                      ))
-                      : (
-                        <>
-                          {athleteContext.goals.priorityEventName ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.goals.priorityEventName}</span> : null}
-                          {athleteContext.goals.goalType ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.goals.goalType}</span> : null}
-                          {athleteContext.declared.experienceLevel.value ? <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{athleteContext.declared.experienceLevel.value}</span> : null}
-                          {athleteContext.declared.limiters.slice(0, 2).map((limiter) => (
-                            <span key={limiter.value} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">{limiter.value}</span>
-                          ))}
-                        </>
-                      )}
-                  </div>
+                      ))}
+                    </div>
+                  ) : null}
                 </article>
               </div>
             ) : null}
           </div>
         </details>
       ) : null}
+      </aside>
     </section>
   );
 }

--- a/app/(protected)/coach/weekly-checkin-card.tsx
+++ b/app/(protected)/coach/weekly-checkin-card.tsx
@@ -154,13 +154,16 @@ export function WeeklyCheckinCard({ weekStart, snapshot }: Props) {
 
   const completionLabel = completedCount === METRICS.length ? "Ready" : `${completedCount}/${METRICS.length} set`;
 
-  const summaryChips = useMemo(
+  // F34: only the metrics with a value surface as chips. Unset metrics
+  // collapse into an aggregate progress indicator so the card doesn't
+  // open with "Not set" repeated five times.
+  const setChips = useMemo(
     () =>
-      METRICS.map((metric) => ({
-        key: metric.key,
-        label: metric.label,
-        value: metric.choices.find((choice) => choice.value === values[metric.key])?.label ?? "Not set"
-      })),
+      METRICS.flatMap((metric) => {
+        const selection = metric.choices.find((choice) => choice.value === values[metric.key]);
+        if (!selection) return [];
+        return [{ key: metric.key, label: metric.label, value: selection.label }];
+      }),
     [values]
   );
 
@@ -244,18 +247,45 @@ export function WeeklyCheckinCard({ weekStart, snapshot }: Props) {
         </div>
 
         <div className="mt-3 rounded-[22px] border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3.5">
-          <div className="flex flex-wrap gap-2">
-            {summaryChips.map((chip) => (
-              <span key={chip.key} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.7)]">
-                <span className="text-[rgba(255,255,255,0.35)]">{chip.label}:</span> <span className="text-[rgba(255,255,255,0.8)]">{chip.value}</span>
-              </span>
-            ))}
-            {note.trim() ? (
-              <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">
-                Note added
-              </span>
-            ) : null}
+          {/* F34: aggregate progress row — one dot per signal, filled
+              when captured. A 2/5 row reads as "made progress", not
+              "three things failed". */}
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="flex items-center gap-1" aria-label={`${completedCount} of ${METRICS.length} signals captured`}>
+              {METRICS.map((metric) => {
+                const isSet = values[metric.key] !== null;
+                return (
+                  <span
+                    key={metric.key}
+                    title={metric.label}
+                    className={`h-2 w-2 rounded-full ${isSet ? "bg-success" : "border border-[rgba(255,255,255,0.18)]"}`}
+                  />
+                );
+              })}
+            </div>
+            <p className="text-xs text-muted">
+              {completedCount === 0
+                ? `0 of ${METRICS.length} signals captured — takes under a minute.`
+                : completedCount === METRICS.length
+                  ? "All signals captured for this week."
+                  : `${completedCount} of ${METRICS.length} signals captured.`}
+            </p>
           </div>
+
+          {setChips.length > 0 ? (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {setChips.map((chip) => (
+                <span key={chip.key} className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.7)]">
+                  <span className="text-[rgba(255,255,255,0.35)]">{chip.label}:</span> <span className="text-[rgba(255,255,255,0.8)]">{chip.value}</span>
+                </span>
+              ))}
+              {note.trim() ? (
+                <span className="rounded-md border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-1.5 text-xs text-[rgba(255,255,255,0.6)]">
+                  Note added
+                </span>
+              ) : null}
+            </div>
+          ) : null}
 
           <div className="mt-3 flex flex-wrap items-center justify-end gap-3">
             <div className="flex items-center gap-3">

--- a/app/(protected)/plan/components/weekly-intensity-header.tsx
+++ b/app/(protected)/plan/components/weekly-intensity-header.tsx
@@ -39,6 +39,39 @@ function formatDelta(pct: number | null): string | null {
   return pct > 0 ? `+${pct}%` : `${pct}%`;
 }
 
+// F23: classify the week's intensity shape so the distribution bar gets
+// a verdict instead of just four percentages. Polarized = ≥65% easy
+// (Z1-2) + ≥10% hard (Z4+Z5) with little Z3 glue. Pyramidal = lots of
+// easy + significant Z3 with moderate Z4+. Threshold-heavy = Z3+Z4
+// dominates. Everything else is "mixed".
+function classifyDistribution(dist: Record<ZoneKey, number>): { label: string; tone: "success" | "warning" | "info" | "muted" } {
+  const easy = (dist.z1 ?? 0) + (dist.z2 ?? 0);
+  const tempo = dist.z3 ?? 0;
+  const hard = (dist.z4 ?? 0) + (dist.z5 ?? 0);
+  const threshold = (dist.z3 ?? 0) + (dist.z4 ?? 0);
+
+  if (easy >= 0.65 && hard >= 0.1 && tempo < 0.2) {
+    return { label: "Polarized", tone: "success" };
+  }
+  if (easy >= 0.5 && tempo >= 0.15 && hard >= 0.05 && tempo >= hard) {
+    return { label: "Pyramidal", tone: "info" };
+  }
+  if (threshold >= 0.35 && easy < 0.55) {
+    return { label: "Threshold-heavy", tone: "warning" };
+  }
+  if (easy >= 0.8) {
+    return { label: "Aerobic-dominant", tone: "success" };
+  }
+  return { label: "Mixed", tone: "muted" };
+}
+
+const VERDICT_TONE_CLASS: Record<"success" | "warning" | "info" | "muted", string> = {
+  success: "border-[rgba(52,211,153,0.3)] bg-[rgba(52,211,153,0.08)] text-success",
+  warning: "border-[rgba(251,191,36,0.3)] bg-[rgba(251,191,36,0.08)] text-warning",
+  info: "border-[rgba(96,165,250,0.3)] bg-[rgba(96,165,250,0.08)] text-[rgb(147,197,253)]",
+  muted: "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] text-tertiary"
+};
+
 export function WeeklyIntensityHeader({ summary }: Props) {
   const zones = DISPLAY_ZONES
     .map((zone) => ({
@@ -49,78 +82,60 @@ export function WeeklyIntensityHeader({ summary }: Props) {
     }))
     .filter((z) => z.fraction > 0.02);
 
-  // Merge z1 and z2 for display
   const endurancePct = Math.round(
     ((summary.zoneDistribution.z1 ?? 0) + (summary.zoneDistribution.z2 ?? 0)) * 100
   );
-  const tempoPct = Math.round((summary.zoneDistribution.z3 ?? 0) * 100);
-  const thresholdPct = Math.round((summary.zoneDistribution.z4 ?? 0) * 100);
-  const vo2Pct = Math.round((summary.zoneDistribution.z5 ?? 0) * 100);
+  const hardPct = Math.round(
+    ((summary.zoneDistribution.z4 ?? 0) + (summary.zoneDistribution.z5 ?? 0)) * 100
+  );
+
+  const verdict = classifyDistribution(summary.zoneDistribution);
 
   const hoursDelta = formatDelta(summary.hoursDeltaPct);
-  const stressDelta = formatDelta(summary.stressDeltaPct);
 
   return (
-    <div className="space-y-2">
-      {/* Stacked zone bar */}
-      <div className="flex h-2 overflow-hidden rounded-full">
-        {zones.map((z) => (
-          <div
-            key={z.zone}
-            title={`${z.label}: ${Math.round(z.fraction * 100)}%`}
-            style={{
-              width: `${Math.round(z.fraction * 100)}%`,
-              backgroundColor: z.colour
-            }}
-          />
-        ))}
-      </div>
-
-      {/* Zone breakdown text */}
-      <div className="flex flex-wrap gap-3 text-[10px] text-tertiary">
-        {endurancePct > 0 ? (
-          <span className="flex items-center gap-1">
-            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: ZONE_COLOURS.z2 }} />
-            Z1-2: {endurancePct}%
-          </span>
-        ) : null}
-        {tempoPct > 0 ? (
-          <span className="flex items-center gap-1">
-            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: ZONE_COLOURS.z3 }} />
-            Z3: {tempoPct}%
-          </span>
-        ) : null}
-        {thresholdPct > 0 ? (
-          <span className="flex items-center gap-1">
-            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: ZONE_COLOURS.z4 }} />
-            Z4: {thresholdPct}%
-          </span>
-        ) : null}
-        {vo2Pct > 0 ? (
-          <span className="flex items-center gap-1">
-            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: ZONE_COLOURS.z5 }} />
-            Z5: {vo2Pct}%
-          </span>
-        ) : null}
-      </div>
-
-      {/* Totals */}
-      <div className="flex flex-wrap gap-4 text-xs text-muted">
-        <span>
-          {formatHours(summary.totalPlannedHours)}
-          {hoursDelta ? (
-            <span className={`ml-1 ${(summary.hoursDeltaPct ?? 0) > 0 ? "text-tertiary" : "text-tertiary"}`}>
-              ({hoursDelta} vs last week)
-            </span>
-          ) : null}
+    <div className="space-y-2.5">
+      {/* F23: distribution verdict — the pedagogically interesting number */}
+      <div className="flex flex-wrap items-center gap-2">
+        <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium ${VERDICT_TONE_CLASS[verdict.tone]}`}>
+          {verdict.label} this week
         </span>
-        {summary.totalStressScore ? (
-          <span>
-            Stress: {summary.totalStressScore}
-            {stressDelta ? <span className="ml-1 text-tertiary">({stressDelta})</span> : null}
-          </span>
-        ) : null}
+        <p className="text-[11px] text-tertiary">
+          {endurancePct}% easy · {hardPct}% hard
+        </p>
       </div>
+
+      {/* F23: 20px stacked zone bar with inline labels on any segment
+          wide enough to read. Anything <10% gets only its colour. */}
+      <div className="flex h-5 overflow-hidden rounded-md">
+        {zones.map((z) => {
+          const pct = Math.round(z.fraction * 100);
+          const showLabel = pct >= 10;
+          return (
+            <div
+              key={z.zone}
+              title={`${z.label}: ${pct}%`}
+              className="flex items-center justify-center text-[10px] font-medium leading-none"
+              style={{
+                width: `${pct}%`,
+                backgroundColor: z.colour,
+                color: "rgba(0,0,0,0.78)"
+              }}
+            >
+              {showLabel ? `${z.label} ${pct}%` : null}
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Totals — kept lean; stress moves into the Daily Load Shape
+          subtitle where it belongs with the TSS per-day chart. */}
+      {summary.totalPlannedHours > 0 || hoursDelta ? (
+        <p className="text-[11px] text-tertiary">
+          {formatHours(summary.totalPlannedHours)} planned
+          {hoursDelta ? ` · ${hoursDelta} vs last week` : ""}
+        </p>
+      ) : null}
     </div>
   );
 }

--- a/app/(protected)/plan/plan-editor.tsx
+++ b/app/(protected)/plan/plan-editor.tsx
@@ -567,32 +567,52 @@ export function PlanEditor({
             <h2 className="text-lg font-semibold">Week {selectedWeek.week_index} · {weekDraft.focus}</h2>
             <p className="text-sm text-muted">{weekRangeLabel(selectedWeek.week_start_date)} · Planned {totalMinutes} min</p>
           </div>
-          <div className="flex flex-wrap items-center gap-2">
-            <button
-              type="button"
-              aria-label="Previous week"
-              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.06)] px-3 text-xs text-[rgba(255,255,255,0.7)] disabled:opacity-40 lg:min-h-0 lg:min-w-0 lg:px-2 lg:py-1"
-              onClick={() => previousWeek && setSelectedWeekId(previousWeek.id)}
-              disabled={!previousWeek}
+          {/* F25: week pager (prev / select / next) is one group, Save
+              and Actions are week-scoped commands. A visual gap keeps
+              Tab from overshooting from "→" straight onto "Actions". */}
+          <div className="flex flex-wrap items-center gap-4">
+            <div
+              role="group"
+              aria-label="Week pager"
+              className="flex flex-wrap items-center gap-2"
             >
-              ←
-            </button>
-            <select value={selectedWeek.id} onChange={(event) => setSelectedWeekId(event.target.value)} className="input-base flex-1 py-1.5 text-xs sm:flex-none sm:w-auto" aria-label="Select plan week">
-              {planWeeks.map((week) => (
-                <option key={week.id} value={week.id}>Week {week.week_index} ({weekRangeLabel(week.week_start_date)})</option>
-              ))}
-            </select>
-            <button
-              type="button"
-              aria-label="Next week"
-              className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.06)] px-3 text-xs text-[rgba(255,255,255,0.7)] disabled:opacity-40 lg:min-h-0 lg:min-w-0 lg:px-2 lg:py-1"
-              onClick={() => nextWeek && setSelectedWeekId(nextWeek.id)}
-              disabled={!nextWeek}
-            >
-              →
-            </button>
-            {isWeekDirty ? <button form="week-details-form" className="btn-primary px-3 text-xs">Save</button> : null}
-            <button type="button" onClick={() => setWeekActionOpen((v) => !v)} className="inline-flex min-h-[44px] items-center rounded-md border border-[rgba(255,255,255,0.20)] bg-transparent px-3 text-xs text-[rgba(255,255,255,0.7)] lg:min-h-0 lg:py-1.5">Actions</button>
+              <button
+                type="button"
+                aria-label="Previous week"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.06)] px-3 text-xs text-[rgba(255,255,255,0.7)] disabled:opacity-40 lg:min-h-0 lg:min-w-0 lg:px-2 lg:py-1"
+                onClick={() => previousWeek && setSelectedWeekId(previousWeek.id)}
+                disabled={!previousWeek}
+              >
+                ←
+              </button>
+              <select value={selectedWeek.id} onChange={(event) => setSelectedWeekId(event.target.value)} className="input-base flex-1 py-1.5 text-xs sm:flex-none sm:w-auto" aria-label="Select plan week">
+                {planWeeks.map((week) => (
+                  <option key={week.id} value={week.id}>Week {week.week_index} ({weekRangeLabel(week.week_start_date)})</option>
+                ))}
+              </select>
+              <button
+                type="button"
+                aria-label="Next week"
+                className="inline-flex min-h-[44px] min-w-[44px] items-center justify-center rounded-md border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.06)] px-3 text-xs text-[rgba(255,255,255,0.7)] disabled:opacity-40 lg:min-h-0 lg:min-w-0 lg:px-2 lg:py-1"
+                onClick={() => nextWeek && setSelectedWeekId(nextWeek.id)}
+                disabled={!nextWeek}
+              >
+                →
+              </button>
+            </div>
+            <div className="flex flex-wrap items-center gap-2">
+              {isWeekDirty ? <button form="week-details-form" className="btn-primary px-3 text-xs">Save</button> : null}
+              <button
+                type="button"
+                onClick={() => setWeekActionOpen((v) => !v)}
+                aria-haspopup="menu"
+                aria-expanded={weekActionOpen}
+                className="inline-flex min-h-[44px] items-center gap-1.5 rounded-md border border-[rgba(255,255,255,0.20)] bg-transparent px-3 text-xs text-[rgba(255,255,255,0.7)] lg:min-h-0 lg:py-1.5"
+              >
+                Actions
+                <span aria-hidden="true" className={`text-[10px] transition-transform ${weekActionOpen ? "rotate-180" : ""}`}>▾</span>
+              </button>
+            </div>
           </div>
         </div>
       </header>
@@ -669,42 +689,72 @@ export function PlanEditor({
         <BlockOverview weeks={blockOverviewWeeks} currentWeekStart={selectedWeek?.week_start_date} />
       ) : null}
 
+      {/* F24: provenance moves to a tooltip — the user doesn't need to
+          know whether the focus was planner-set or derived, they need
+          to know *what the focus is*. Rest / Key counts fold into a
+          compact inline line so the big-label treatment is reserved for
+          the focus itself. */}
       <section className="surface-subtle px-4 py-3">
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <div className="grid gap-3 md:grid-cols-[1fr_1.6fr]">
           <div>
             <p className="card-kicker">Block</p>
             <p className="mt-1 text-sm font-medium text-white">{weekDraft.focus}</p>
           </div>
           {displayWeekFocus ? (
-            <div className="md:col-span-2">
-              <p className="card-kicker">Week focus{weekFocusSource ? ` · ${weekFocusSource}` : ""}</p>
+            <div>
+              <p className="card-kicker inline-flex items-center gap-1.5">
+                Week focus
+                {weekFocusSource === "Derived focus" ? (
+                  <span
+                    title="AI-derived from this week's session mix — not an explicit planner setting."
+                    aria-label="AI-derived"
+                    className="inline-flex h-3.5 w-3.5 items-center justify-center rounded-full border border-[rgba(190,255,0,0.35)] text-[9px] leading-none text-[var(--color-accent)]"
+                  >
+                    ✦
+                  </span>
+                ) : null}
+              </p>
               <p className="mt-1 text-sm font-medium text-white">{displayWeekFocus}</p>
             </div>
           ) : null}
-          <div>
-            <p className="card-kicker">Rest days</p>
-            <p className="mt-1 text-sm font-medium text-white">{restDays}</p>
-          </div>
-          {keySessions > 0 ? (
-            <div>
-              <p className="card-kicker">Key sessions</p>
-              <p className="mt-1 text-sm font-medium text-white">{keySessions}</p>
-            </div>
-          ) : null}
         </div>
+        <p className="mt-2 text-[11px] text-tertiary">
+          {restDays} rest day{restDays === 1 ? "" : "s"}
+          {keySessions > 0 ? ` · ${keySessions} key session${keySessions === 1 ? "" : "s"}` : ""}
+        </p>
         {notePreview ? <p className="mt-3 text-xs text-muted">Week notes: {notePreview}</p> : null}
       </section>
 
       {weekDays.some((d) => d.totalMinutes > 0) ? (
         <section className="surface-subtle px-4 py-3">
-          <div className="mb-2.5 flex items-center justify-between">
+          <div className="mb-1 flex flex-wrap items-baseline justify-between gap-x-3 gap-y-1">
             <p className="card-kicker">Daily load shape</p>
-            {volumeDelta !== null ? (
-              <p className={`text-[11px] font-medium ${volumeDelta > 0 ? "text-emerald-300" : volumeDelta < 0 ? "text-rose-300" : "text-muted"}`}>
-                {volumeDelta > 0 ? `+${volumeDelta}` : volumeDelta} min vs last week
-              </p>
-            ) : null}
+            {/* F22: inline sport legend — bar segments encode sport, so
+                the reader needs a key to decode "mostly blue Monday". */}
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[10px] text-tertiary">
+              {(["swim", "bike", "run", "strength"] as const).map((sport) => (
+                <span key={sport} className="inline-flex items-center gap-1">
+                  <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: `var(--color-${sport})` }} aria-hidden="true" />
+                  {getDisciplineMeta(sport).label}
+                </span>
+              ))}
+            </div>
           </div>
+          {/* F26: week total + delta as the chart's subtitle — the
+              "+150 min vs last week" figure was the most interesting
+              takeaway on the chart and it was floating unattached. */}
+          <p className="mb-2.5 text-[11px] text-muted">
+            <span className="tabular-nums text-[rgba(255,255,255,0.78)]">{Math.floor(totalMinutes / 60)}h {totalMinutes % 60}m total</span>
+            {volumeDelta !== null ? (
+              <>
+                {" · "}
+                <span className={`tabular-nums ${volumeDelta > 0 ? "text-emerald-300" : volumeDelta < 0 ? "text-rose-300" : "text-muted"}`}>
+                  {volumeDelta > 0 ? "▲ " : volumeDelta < 0 ? "▼ " : ""}
+                  {volumeDelta > 0 ? `+${volumeDelta}` : volumeDelta}m vs last week
+                </span>
+              </>
+            ) : null}
+          </p>
           <div className="flex items-end gap-1.5">
             {(() => {
               // Estimate per-session stress using the duration+intent heuristic so
@@ -755,7 +805,7 @@ export function PlanEditor({
               });
             })()}
           </div>
-          <p className="mt-1 text-[10px] text-tertiary">Bar height reflects estimated training stress (TSS) per day, not duration.</p>
+          <p className="mt-1 text-[10px] text-tertiary">Bar height = estimated training stress (TSS) · color = sport.</p>
         </section>
       ) : null}
 
@@ -789,158 +839,11 @@ export function PlanEditor({
         <input type="hidden" name="notes" value={weekDraft.notes} />
       </form>
 
-      <article className="surface p-4">
-        <div className="mb-3 flex items-center justify-between">
-          <h3 className="text-sm font-medium text-[rgba(255,255,255,0.5)]">Week board (Mon–Sun)</h3>
-          <p className="text-xs text-tertiary">For scheduling changes, use Calendar.</p>
-        </div>
-
-        <div className="hidden gap-3 lg:grid lg:grid-cols-7">
-          {weekDays.map((day) => (
-            <section key={day.iso} className={`group/day flex min-h-[236px] min-w-0 flex-col p-2.5 ${day.isRest ? "surface-subtle opacity-80" : "surface-subtle"}`}>
-              <div className="mb-1.5 flex items-start justify-between border-b border-[hsl(var(--border))] pb-1.5">
-                <div><p className="text-xs uppercase tracking-wide text-muted">{day.label}</p><p className="text-sm font-medium">{day.date}</p></div>
-                <div className="text-right">
-                  <p className="text-xs text-muted">{day.totalMinutes} min</p>
-                  {day.isRest ? <p className="text-[11px] text-muted/90">Rest</p> : null}
-                  {!day.isRest && day.roleCounts.key > 0 ? <p className="text-[11px] text-accent">Key day</p> : null}
-                  {!day.isRest && day.roleCounts.key === 0 && day.roleCounts.recovery > 0 ? <p className="text-[11px] text-emerald-200">Recovery-biased</p> : null}
-                </div>
-              </div>
-              <div className="flex-1 space-y-1.5">
-                {day.sessions.map((session) => {
-                  const meta = getDisciplineMeta(session.sport);
-                  const role = getOptionalSessionRoleLabel(session);
-                  const roleCue = getSessionRoleCue(role);
-                  const intentCue = getSessionIntentCue(session.intent_category);
-
-                  const sessionProfile = sessionProfileMap.get(session.id);
-                  return (
-                    <button
-                      key={session.id}
-                      type="button"
-                      onClick={() => setActiveSessionId(session.id)}
-                      className="w-full rounded-lg border bg-[#18181C] px-2 py-2 text-left"
-                      style={{
-                        borderColor: "rgba(255,255,255,0.06)",
-                        borderLeftWidth: "3px",
-                        borderLeftColor: disciplineBorderColor(session.sport)
-                      }}
-                    >
-                      <div className="flex items-center justify-between gap-1">
-                        <span
-                          className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium"
-                          style={{
-                            backgroundColor: disciplineChipTone(session.sport).bg,
-                            color: disciplineChipTone(session.sport).text
-                          }}
-                        >
-                          <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: disciplineChipTone(session.sport).dot }} />
-                          <span>{meta.label}</span>
-                        </span>
-                        <div className="flex items-center gap-1.5">
-                          {session.is_key ? (
-                            <span className="inline-flex items-center gap-1 rounded-full border border-[rgba(190,255,0,0.35)] bg-[rgba(190,255,0,0.12)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-accent)]">
-                              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)]" />
-                              Key
-                            </span>
-                          ) : null}
-                          {roleCue ? (
-                            <span title={role ?? undefined} className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium tracking-wide ${roleCue.className}`}><span aria-hidden="true">{roleCue.marker}</span><span>{role}</span></span>
-                          ) : null}
-                        </div>
-                      </div>
-                      <p className="mt-1 line-clamp-2 text-xs font-semibold leading-snug">{getSessionDisplayName({ sessionName: session.session_name ?? session.type, discipline: session.discipline ?? session.sport, subtype: session.subtype ?? session.target, workoutType: session.workout_type, intentCategory: session.intent_category, source: session.source_metadata, executionResult: session.execution_result })}</p>
-                      {intentCue ? (
-                        <p className="text-[11px] text-muted">
-                          Intent: {intentCue}
-                        </p>
-                      ) : null}
-                      <p className="text-[11px] text-muted">{session.duration_minutes} min{session.target ? ` · ${session.target}` : ""}{role === "Optional" ? " · Optional" : ""}</p>
-                      {(() => {
-                        const profile = sessionProfileMap.get(session.id);
-                        return profile ? <IntensityBar zoneDistribution={profile.zoneDistribution} height={4} className="mt-1" /> : null;
-                      })()}
-                    </button>
-                  );
-                })}
-                {day.sessions.length === 0 ? <p className="py-4 text-center text-xs text-muted">Rest day · planned recovery window</p> : null}
-              </div>
-              <button type="button" onClick={() => setQuickAddDay(day.iso)} className="mt-2 w-fit text-left text-xs text-[rgba(255,255,255,0.25)] transition hover:text-[rgba(255,255,255,0.6)] focus-visible:text-[rgba(255,255,255,0.6)]">＋ Add</button>
-            </section>
-          ))}
-        </div>
-
-        <div className="space-y-3 lg:hidden">
-          {weekDays.map((day) => (
-            <section key={day.iso} className={`group/day p-2.5 ${day.isRest ? "surface-subtle opacity-80" : "surface-subtle"}`}>
-              <div className="mb-1.5 flex items-center justify-between border-b border-[hsl(var(--border))] pb-1.5">
-                <p className="text-sm font-semibold">{day.label} · {day.date}</p>
-                <p className="text-xs text-muted">{day.totalMinutes} min{day.isRest ? " · Rest" : day.roleCounts.key > 0 ? " · Key day" : day.roleCounts.recovery > 0 ? " · Recovery-biased" : ""}</p>
-              </div>
-              <div className="space-y-1.5">
-                {day.sessions.map((session) => {
-                  const role = getOptionalSessionRoleLabel(session);
-                  const roleCue = getSessionRoleCue(role);
-                  const intentCue = getSessionIntentCue(session.intent_category);
-
-                  const mobileProfile = sessionProfileMap.get(session.id);
-                  return (
-                    <button
-                      key={session.id}
-                      type="button"
-                      onClick={() => setActiveSessionId(session.id)}
-                      className="w-full rounded-lg border bg-[#18181C] px-2 py-2 text-left text-xs"
-                      style={{
-                        borderColor: "rgba(255,255,255,0.06)",
-                        borderLeftWidth: "3px",
-                        borderLeftColor: disciplineBorderColor(session.sport)
-                      }}
-                    >
-                      <div className="flex items-center justify-between gap-2">
-                        <span
-                          className="inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[11px] font-medium"
-                          style={{
-                            backgroundColor: disciplineChipTone(session.sport).bg,
-                            color: disciplineChipTone(session.sport).text
-                          }}
-                        >
-                          <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: disciplineChipTone(session.sport).dot }} />
-                          <span>{getDisciplineMeta(session.sport).label}</span>
-                        </span>
-                        <div className="flex items-center gap-1.5">
-                          {session.is_key ? (
-                            <span className="inline-flex items-center gap-1 rounded-full border border-[rgba(190,255,0,0.35)] bg-[rgba(190,255,0,0.12)] px-1.5 py-0.5 text-[10px] font-medium text-[var(--color-accent)]">
-                              <span aria-hidden="true" className="h-1.5 w-1.5 rounded-full bg-[var(--color-accent)]" />
-                              Key
-                            </span>
-                          ) : null}
-                          {roleCue ? (
-                            <span title={role ?? undefined} className={`inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px] font-medium tracking-wide ${roleCue.className}`}><span aria-hidden="true">{roleCue.marker}</span><span>{role}</span></span>
-                          ) : null}
-                        </div>
-                      </div>
-                      <p className="mt-1 line-clamp-2 font-semibold leading-snug">{getSessionDisplayName({ sessionName: session.session_name ?? session.type, discipline: session.discipline ?? session.sport, subtype: session.subtype ?? session.target, workoutType: session.workout_type, intentCategory: session.intent_category, source: session.source_metadata, executionResult: session.execution_result })}</p>
-                      {intentCue ? (
-                        <p className="text-[11px] text-muted">
-                          Intent: {intentCue}
-                        </p>
-                      ) : null}
-                      <p className="text-muted">{session.duration_minutes} min{session.target ? ` · ${session.target}` : ""}{role === "Optional" ? " · Optional" : ""}</p>
-                      {(() => {
-                        const profile = sessionProfileMap.get(session.id);
-                        return profile ? <IntensityBar zoneDistribution={profile.zoneDistribution} height={4} className="mt-1" /> : null;
-                      })()}
-                    </button>
-                  );
-                })}
-                {day.sessions.length === 0 ? <p className="py-2 text-xs text-muted">Rest day · planned recovery window.</p> : null}
-              </div>
-              <button type="button" onClick={() => setQuickAddDay(day.iso)} className="mt-1.5 inline-flex min-h-[44px] items-center text-xs text-[rgba(255,255,255,0.25)] transition hover:text-[rgba(255,255,255,0.6)] focus-visible:text-[rgba(255,255,255,0.6)] lg:min-h-0">＋ Add</button>
-            </section>
-          ))}
-        </div>
-      </article>
+      {/* F21: Week board removed. It duplicated Calendar's week grid while
+          explicitly saying "use Calendar for scheduling" — so it was a
+          lookup surface at best. Daily Load Shape (above) already shows
+          the 7-column duration-by-sport summary in one row, which is
+          the only thing Plan-view adds over Calendar. */}
 
       <details className="surface-subtle p-3">
         <summary className="flex min-h-[44px] cursor-pointer items-center text-sm font-medium lg:min-h-0">Week notes & settings</summary>


### PR DESCRIPTION
Reopens the Sprint 4 changes after the revert (#293). Exact same diff as #292 — 8 files, plan/calendar/coach polish for F21–F36. Leaving as draft / unmerged so the design direction can be revisited before landing again.

## Summary

**Plan (F21–F26):**
- Delete the Week board; Daily Load Shape gets a sport legend + total/delta subtitle.
- Intensity Distribution goes from a 4 px sliver to a 20 px bar with a classification verdict pill.
- Drop "DERIVED FOCUS" provenance label; fold rest/key counts inline.
- Actions button gets its own group and chevron, separated from the week pager.

**Calendar (F27–F31):**
- Coach Notes collapse to one-line banners with a count badge; expansion restores the full card.
- Completed session cards surface their execution score + band in the footer chip.
- Day headers condense to a colored state dot + weekday + tabular-nums load line; future-day planned load no longer renders in red.
- Filter row splits into three groups with border dividers.

**Coach (F32–F36):**
- Chat-first: chat takes the main column, briefing + check-in + profile fold into a sticky right-rail Context aside at lg+.
- Suggestion chips hide once a user turn exists; "⏎ to send" keyboard hint below the input.
- Weekly Check-in replaces five "Not set" chips with a 5-dot progress row + aggregate line.
- Coaching Profile becomes a prose summary instead of four floating tags.
- Duplicate "Execution is on track" headlines merged.

## Test plan
- [ ] `npm run typecheck` — clean (verified locally)
- [ ] `npm run test` — 75/76 suites pass (3 pre-existing `ambient-signals` date-fixture failures unrelated)
- [ ] Visual revisit before merging

🤖 Generated with [Claude Code](https://claude.com/claude-code)