### PR TITLE
feat(design-system): F02 stage 2 — session review on canonical type scale

### DIFF
--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
@@ -111,13 +111,13 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
     <article className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]">
       {/* Header */}
       <div className="flex items-center justify-between px-5 pt-4 pb-0">
-        <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Extra session verdict</p>
+        <p className="text-kicker text-tertiary">Extra session verdict</p>
         {narrativeSource === "ai" ? (
-          <span className="rounded-full border border-[rgba(190,255,0,0.2)] bg-[rgba(190,255,0,0.06)] px-2 py-0.5 text-[10px] text-[var(--color-accent)]">
+          <span className="rounded-full border border-[rgba(190,255,0,0.2)] bg-[rgba(190,255,0,0.06)] px-2 py-0.5 text-ui-label text-[var(--color-accent)]">
             AI review
           </span>
         ) : (
-          <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-tertiary">
+          <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-ui-label text-tertiary">
             Directional
           </span>
         )}
@@ -127,7 +127,7 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
         {/* Part 1: What this session was */}
         <div className="px-5 py-4">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-0.5 text-[11px] font-medium text-muted">
+            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-0.5 text-ui-label font-medium text-muted">
               {intentLabel}
             </span>
             {sessionId && sport ? (
@@ -139,7 +139,7 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
             ) : null}
           </div>
           {verdict.explanation.sessionIntent ? (
-            <p className="mt-2 text-sm text-muted">{sanitizeText(verdict.explanation.sessionIntent)}</p>
+            <p className="mt-2 text-body text-muted">{sanitizeText(verdict.explanation.sessionIntent)}</p>
           ) : null}
         </div>
 
@@ -156,19 +156,19 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
               >
                 <IntentMatchIcon match={verdict.sessionVerdict.intentMatch} />
               </span>
-              <p className="text-sm font-medium" style={{ color: match.color }}>
+              <p className="text-body font-medium" style={{ color: match.color }}>
                 {match.label}
               </p>
             </div>
-            <p className="mt-2 text-xs font-medium" style={{ color: match.color }}>
+            <p className="mt-2 text-ui-label font-medium" style={{ color: match.color }}>
               {sanitizeText(verdict.sessionVerdict.headline)}
             </p>
-            <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.sessionVerdict.summary)}</p>
+            <p className="mt-2 text-body text-white leading-relaxed">{sanitizeText(verdict.sessionVerdict.summary)}</p>
           </div>
 
           {/* What happened — expanded detail below the status box */}
           {verdict.explanation.whatHappened ? (
-            <p className="mt-3 text-sm text-muted leading-relaxed">{sanitizeText(verdict.explanation.whatHappened)}</p>
+            <p className="mt-3 text-body text-muted leading-relaxed">{sanitizeText(verdict.explanation.whatHappened)}</p>
           ) : null}
 
           {/* Cited evidence — progressive disclosure */}
@@ -177,7 +177,7 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
               <button
                 type="button"
                 onClick={() => setShowEvidence(!showEvidence)}
-                className="mt-3 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
+                className="mt-3 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-ui-label text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
               >
                 {showEvidence ? "Hide evidence" : "Show evidence"}
               </button>
@@ -185,10 +185,10 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
                 <div className="mt-2 space-y-2 rounded-lg bg-[rgba(0,0,0,0.2)] p-3">
                   {verdict.citedEvidence.map((item, i) => (
                     <div key={i}>
-                      <p className="text-xs font-medium text-white">{sanitizeText(item.claim)}</p>
+                      <p className="text-ui-label font-medium text-white">{sanitizeText(item.claim)}</p>
                       <ul className="mt-1 space-y-0.5">
                         {item.support.map((s, j) => (
-                          <li key={j} className="text-xs text-muted pl-3 relative before:absolute before:left-0 before:top-[7px] before:h-1 before:w-1 before:rounded-full before:bg-[rgba(255,255,255,0.2)]">
+                          <li key={j} className="text-ui-label text-muted pl-3 relative before:absolute before:left-0 before:top-[7px] before:h-1 before:w-1 before:rounded-full before:bg-[rgba(255,255,255,0.2)]">
                             {sanitizeText(s)}
                           </li>
                         ))}
@@ -206,14 +206,14 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
           <div className="px-5 py-4">
             {verdict.nonObviousInsight ? (
               <>
-                <p className="text-xs uppercase tracking-[0.14em] text-[var(--color-accent)]">Coach insight</p>
-                <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.nonObviousInsight)}</p>
+                <p className="text-kicker text-[var(--color-accent)]">Coach insight</p>
+                <p className="mt-2 text-body text-white leading-relaxed">{sanitizeText(verdict.nonObviousInsight)}</p>
               </>
             ) : null}
             {verdict.teach ? (
               <>
-                <p className="mt-3 text-xs uppercase tracking-[0.14em] text-tertiary">Why this matters</p>
-                <p className="mt-2 text-sm text-muted leading-relaxed">{sanitizeText(verdict.teach)}</p>
+                <p className="mt-3 text-kicker text-tertiary">Why this matters</p>
+                <p className="mt-2 text-body text-muted leading-relaxed">{sanitizeText(verdict.teach)}</p>
               </>
             ) : null}
           </div>
@@ -221,14 +221,14 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
 
         {/* Part 3: What it means for your plan */}
         <div className="px-5 py-4">
-          <p className="text-xs uppercase tracking-[0.14em] text-tertiary">What this means for your plan</p>
-          <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.explanation.whatToDoThisWeek)}</p>
+          <p className="text-kicker text-tertiary">What this means for your plan</p>
+          <p className="mt-2 text-body text-white leading-relaxed">{sanitizeText(verdict.explanation.whatToDoThisWeek)}</p>
           {verdict.explanation.whyItMatters ? (
-            <p className="mt-2 text-sm text-muted leading-relaxed">{sanitizeText(verdict.explanation.whyItMatters)}</p>
+            <p className="mt-2 text-body text-muted leading-relaxed">{sanitizeText(verdict.explanation.whyItMatters)}</p>
           ) : null}
           {showNextCallChip ? (
             <div
-              className="mt-2 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs"
+              className="mt-2 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-ui-label"
               style={{ borderColor: match.border, color: match.color, backgroundColor: match.bg }}
             >
               {nextCallLabel}

--- a/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
@@ -66,7 +66,7 @@ function PillSelector({ label, options, value, onChange }: {
 }) {
   return (
     <div>
-      <p className="mb-1.5 text-xs text-tertiary">{label}</p>
+      <p className="mb-1.5 text-ui-label text-tertiary">{label}</p>
       <div className="flex gap-1.5">
         {options.map((opt) => {
           const isSelected = value === opt.value;
@@ -75,7 +75,7 @@ function PillSelector({ label, options, value, onChange }: {
               key={opt.value}
               type="button"
               onClick={() => onChange(isSelected ? null : opt.value)}
-              className={`rounded-full border px-3 py-1 text-xs font-medium transition-colors ${
+              className={`rounded-full border px-3 py-1 text-ui-label font-medium transition-colors ${
                 isSelected
                   ? "border-[rgba(190,255,0,0.4)] bg-[rgba(190,255,0,0.12)] text-[var(--color-accent)]"
                   : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] text-[rgba(255,255,255,0.5)] hover:border-[rgba(255,255,255,0.25)] hover:text-white"
@@ -119,9 +119,9 @@ function FeelSummary({
         onClick={onEdit}
         className="surface flex w-full items-center justify-between border border-[hsl(var(--border))] px-4 py-3 text-left transition-ui hover:border-[rgba(255,255,255,0.2)]"
       >
-        <span className="text-sm font-medium text-muted">RPE {feel.rpe}/10</span>
-        {feel.note ? <p className="text-xs italic text-muted">{feel.note}</p> : null}
-        <span className="text-[11px] text-tertiary">Edit →</span>
+        <span className="text-body font-medium text-muted">RPE {feel.rpe}/10</span>
+        {feel.note ? <p className="text-ui-label italic text-muted">{feel.note}</p> : null}
+        <span className="text-ui-label text-tertiary">Edit →</span>
       </button>
     );
   }
@@ -142,23 +142,23 @@ function FeelSummary({
         <div className="flex items-center gap-2.5">
           <span className="text-2xl leading-none" aria-hidden="true">{option.icon}</span>
           <div>
-            <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Your rating</p>
-            <p className="mt-0.5 text-base font-semibold leading-none" style={{ color: option.color.text }}>
+            <p className="text-kicker text-tertiary">Your rating</p>
+            <p className="mt-0.5 text-section-title font-semibold leading-none" style={{ color: option.color.text }}>
               {option.label}
             </p>
             {feel.note ? (
-              <p className="mt-1 max-w-[60ch] truncate text-xs italic text-muted">{feel.note}</p>
+              <p className="mt-1 max-w-[60ch] truncate text-ui-label italic text-muted">{feel.note}</p>
             ) : null}
           </div>
         </div>
-        <span className="text-[11px] text-tertiary transition-ui group-hover:text-white">Edit →</span>
+        <span className="text-ui-label text-tertiary transition-ui group-hover:text-white">Edit →</span>
       </div>
       {secondaryItems.length > 0 ? (
         <div className="flex flex-wrap items-center gap-1.5">
           {secondaryItems.map((item) => (
             <span
               key={item.label}
-              className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px]"
+              className="inline-flex items-center gap-1 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-ui-label"
             >
               <span className="text-tertiary">{item.label}</span>
               <span className="font-medium text-[rgba(255,255,255,0.78)]">{item.value}</span>
@@ -248,7 +248,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
   return (
     <article className="surface border border-[hsl(var(--border))] p-5">
       <p className="label">How did that feel?</p>
-      <p className="mt-1 text-sm text-muted">Tap the one that best describes this session.</p>
+      <p className="mt-1 text-body text-muted">Tap the one that best describes this session.</p>
 
       <div className="mt-4 grid grid-cols-5 gap-2" role="radiogroup" aria-label="How did the session feel? (1-5)">
         {FEEL_OPTIONS.map((opt) => {
@@ -261,7 +261,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
               aria-checked={isSelected}
               aria-label={`${opt.label} (${opt.value}/5)`}
               onClick={() => handleFeelSelect(opt.value)}
-              className={`flex min-h-[56px] flex-col items-center justify-center gap-1 rounded-xl border text-xs font-medium transition-colors ${
+              className={`flex min-h-[56px] flex-col items-center justify-center gap-1 rounded-xl border text-ui-label font-medium transition-colors ${
                 isSelected
                   ? ""
                   : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] text-[rgba(255,255,255,0.5)] hover:border-[rgba(255,255,255,0.25)] hover:text-white"
@@ -271,7 +271,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
                 : undefined
               }
             >
-              <span className="text-lg">{opt.icon}</span>
+              <span className="text-section-title">{opt.icon}</span>
               <span>{opt.label}</span>
             </button>
           );
@@ -282,7 +282,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
         <button
           type="button"
           onClick={() => setShowSecondary(true)}
-          className="mt-3 text-xs text-tertiary hover:text-white transition-colors"
+          className="mt-3 text-ui-label text-tertiary hover:text-white transition-colors"
         >
           + Add more details
         </button>
@@ -296,21 +296,21 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
           <PillSelector label="Sleep last night" options={SLEEP_OPTIONS} value={sleepQuality} onChange={setSleepQuality} />
           <PillSelector label="Life stress" options={STRESS_OPTIONS} value={lifeStress} onChange={setLifeStress} />
           <div>
-            <p className="mb-1.5 text-xs text-tertiary">Anything else your coach should know?</p>
+            <p className="mb-1.5 text-ui-label text-tertiary">Anything else your coach should know?</p>
             <textarea
               value={note}
               onChange={(e) => setNote(e.target.value.slice(0, 280))}
               placeholder="e.g. felt strong on the run, legs heavy after yesterday..."
               rows={2}
-              className="w-full rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] px-3 py-2 text-sm text-white placeholder:text-tertiary focus:border-[rgba(190,255,0,0.4)] focus:outline-none"
+              className="w-full rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] px-3 py-2 text-body text-white placeholder:text-tertiary focus:border-[rgba(190,255,0,0.4)] focus:outline-none"
             />
-            <p className="mt-1 text-right text-[11px] text-tertiary">{note.length}/280</p>
+            <p className="mt-1 text-right text-ui-label text-tertiary">{note.length}/280</p>
           </div>
         </div>
       )}
 
       {saveError && (
-        <p className="mt-3 rounded-lg border border-[hsl(var(--danger)/0.3)] bg-[hsl(var(--danger)/0.08)] px-3 py-2 text-xs text-danger" role="alert">
+        <p className="mt-3 rounded-lg border border-[hsl(var(--danger)/0.3)] bg-[hsl(var(--danger)/0.08)] px-3 py-2 text-ui-label text-danger" role="alert">
           {saveError}
         </p>
       )}
@@ -320,7 +320,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
           type="button"
           onClick={() => void handleSave()}
           disabled={selectedFeel === null || saving}
-          className="rounded-lg bg-[rgba(190,255,0,0.15)] px-4 py-2 text-sm font-medium text-[var(--color-accent)] hover:bg-[rgba(190,255,0,0.22)] disabled:cursor-not-allowed disabled:opacity-40"
+          className="rounded-lg bg-[rgba(190,255,0,0.15)] px-4 py-2 text-body font-medium text-[var(--color-accent)] hover:bg-[rgba(190,255,0,0.22)] disabled:cursor-not-allowed disabled:opacity-40"
         >
           {saving ? "Saving\u2026" : "Save"}
         </button>
@@ -346,7 +346,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
               setDismissed(true);
             }
           }}
-          className="text-sm text-tertiary hover:text-white"
+          className="text-body text-tertiary hover:text-white"
         >
           {editing ? "Cancel" : "Skip"}
         </button>

--- a/app/(protected)/sessions/[sessionId]/components/session-comparison-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-comparison-card.tsx
@@ -101,18 +101,18 @@ function ComparisonNarrative({ text }: { text: string }) {
   const { lead, rest } = splitNarrative(text);
   const [expanded, setExpanded] = useState(false);
   if (!rest) {
-    return <p className="mt-3 text-sm text-white">{lead}</p>;
+    return <p className="mt-3 text-body text-white">{lead}</p>;
   }
   return (
     <div className="mt-3">
-      <p className="text-sm text-white">{lead}</p>
+      <p className="text-body text-white">{lead}</p>
       {expanded ? (
-        <p className="mt-2 text-sm text-muted">{rest}</p>
+        <p className="mt-2 text-body text-muted">{rest}</p>
       ) : null}
       <button
         type="button"
         onClick={() => setExpanded((prev) => !prev)}
-        className="mt-2 text-xs text-tertiary hover:text-white"
+        className="mt-2 text-ui-label text-tertiary hover:text-white"
       >
         {expanded ? "Less detail ↑" : "More detail ↓"}
       </button>
@@ -137,12 +137,12 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
         <div className="flex items-center gap-2.5">
           <p className="label">Compared to previous</p>
           {bestAiComparison ? (
-            <span className={`rounded-full border px-2.5 py-0.5 text-[10px] uppercase tracking-[0.1em] leading-none ${trendBadge(bestAiComparison.trendDirection, bestAiComparison.trendConfidence).className}`}>
+            <span className={`rounded-full border px-2.5 py-0.5 text-kicker leading-none ${trendBadge(bestAiComparison.trendDirection, bestAiComparison.trendConfidence).className}`}>
               {trendBadge(bestAiComparison.trendDirection, bestAiComparison.trendConfidence).label}
             </span>
           ) : null}
         </div>
-        <p className="mt-1 text-xs text-tertiary">{previousDateLabel}</p>
+        <p className="mt-1 text-ui-label text-tertiary">{previousDateLabel}</p>
       </div>
 
       {/* AI narrative — 2-line lead + More detail disclosure so the block
@@ -154,11 +154,11 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {comparison.metrics.map((m) => (
           <div key={m.metric} className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-            <p className="text-xs text-muted">{m.metric}</p>
-            <p className="mt-1 text-base font-semibold text-white">{m.current}</p>
+            <p className="text-ui-label text-muted">{m.metric}</p>
+            <p className="mt-1 text-section-title text-white">{m.current}</p>
             <div className="mt-2 flex items-center gap-2">
               <span
-                className={`text-sm font-medium ${
+                className={`text-body font-medium ${
                   m.direction === "better"
                     ? "text-success"
                     : m.direction === "worse"
@@ -169,7 +169,7 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
                 {m.direction === "better" ? "▲ " : m.direction === "worse" ? "▼ " : ""}
                 {m.delta}
               </span>
-              <span className="text-xs text-tertiary">vs {m.previous}</span>
+              <span className="text-ui-label text-tertiary">vs {m.previous}</span>
             </div>
           </div>
         ))}
@@ -177,7 +177,7 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
 
       {matchedTrends.length > 0 ? (
         <div className="mt-4 border-t border-[hsl(var(--border))] pt-4">
-          <p className="mb-3 text-[10px] uppercase tracking-[0.08em] text-tertiary">Multi-week trend</p>
+          <p className="mb-3 text-kicker text-tertiary">Multi-week trend</p>
           <div className="space-y-2.5">
             {matchedTrends.map((trend) => {
               const recent = trend.dataPoints.slice(-5);
@@ -186,15 +186,15 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
               const directionClass = trend.direction === "improving" ? "text-success" : trend.direction === "declining" ? "text-danger" : "text-tertiary";
               return (
                 <div key={trend.metric} className="flex items-center justify-between gap-3">
-                  <span className="text-xs text-muted whitespace-nowrap">{trend.metric}</span>
+                  <span className="text-ui-label text-muted whitespace-nowrap">{trend.metric}</span>
                   <div className="flex items-center gap-2">
                     <TrendSparkline points={recent} direction={trend.direction} />
                     {latest ? (
-                      <span className="rounded border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.06)] px-2 py-1 text-xs font-medium tabular-nums text-white">
+                      <span className="rounded border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.06)] px-2 py-1 text-ui-label font-medium tabular-nums text-white">
                         {latest.label}
                       </span>
                     ) : null}
-                    <span className={`ml-0.5 text-sm font-medium ${directionClass}`}>{directionGlyph}</span>
+                    <span className={`ml-0.5 text-body font-medium ${directionClass}`}>{directionGlyph}</span>
                   </div>
                 </div>
               );

--- a/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-verdict-card.tsx
@@ -292,7 +292,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
       <article className="surface border border-[hsl(var(--border))] p-5">
         <div className="flex items-center gap-3">
           <div className="h-4 w-4 animate-spin rounded-full border-2 border-[rgba(190,255,0,0.3)] border-t-[var(--color-accent)]" />
-          <p className="text-sm text-muted">Generating session verdict...</p>
+          <p className="text-body text-muted">Generating session verdict...</p>
         </div>
       </article>
     );
@@ -301,11 +301,11 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
   if (error && !verdict) {
     return (
       <article className="surface border border-[hsl(var(--border))] p-5">
-        <p className="text-sm text-danger">{error}</p>
+        <p className="text-body text-danger">{error}</p>
         <button
           type="button"
           onClick={() => void fetchVerdict()}
-          className="mt-2 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
+          className="mt-2 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-ui-label text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
         >
           Retry
         </button>
@@ -332,9 +332,9 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
     <article className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]">
       {/* Header */}
       <div className="flex items-center justify-between px-5 pt-4 pb-0">
-        <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Session verdict</p>
+        <p className="text-kicker text-tertiary">Session verdict</p>
         {isAutoRegenerating ? (
-          <span className="inline-flex items-center gap-1.5 text-[11px] text-tertiary">
+          <span className="inline-flex items-center gap-1.5 text-ui-label text-tertiary">
             <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-[var(--color-accent)]" aria-hidden="true" />
             {"Refreshing\u2026"}
           </span>
@@ -342,7 +342,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
           <button
             type="button"
             onClick={handleRetryAutoRegen}
-            className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--warning)/0.35)] bg-[hsl(var(--warning)/0.08)] px-2 py-0.5 text-[11px] text-[hsl(var(--warning))] hover:bg-[hsl(var(--warning)/0.14)]"
+            className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--warning)/0.35)] bg-[hsl(var(--warning)/0.08)] px-2 py-0.5 text-ui-label text-[hsl(var(--warning))] hover:bg-[hsl(var(--warning)/0.14)]"
           >
             Refresh failed — retry
           </button>
@@ -352,9 +352,9 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
       <div className="divide-y divide-[hsl(var(--border))]">
         {/* Part 1: Purpose Statement */}
         <div className="px-5 py-4">
-          <p className="text-sm text-muted">{sanitizeText(verdict.purpose_statement)}</p>
+          <p className="text-body text-muted">{sanitizeText(verdict.purpose_statement)}</p>
           {verdict.training_block_context && (
-            <p className="mt-1 text-xs text-tertiary">{sanitizeText(verdict.training_block_context)}</p>
+            <p className="mt-1 text-ui-label text-tertiary">{sanitizeText(verdict.training_block_context)}</p>
           )}
         </div>
 
@@ -371,23 +371,23 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
               >
                 <StatusIcon status={verdict.verdict_status} />
               </span>
-              <p className="text-sm font-medium" style={{ color: status.color }}>
+              <p className="text-body font-medium" style={{ color: status.color }}>
                 {status.label}
               </p>
             </div>
-            <p className="mt-3 text-sm text-white leading-relaxed">{sanitizeText(verdict.execution_summary)}</p>
+            <p className="mt-3 text-body text-white leading-relaxed">{sanitizeText(verdict.execution_summary)}</p>
           </div>
 
           {/* Metric comparisons */}
           {verdict.metric_comparisons.length > 0 && (
             <div className="mt-4">
               <div className="overflow-hidden rounded-lg border border-[hsl(var(--border))]">
-                <table className="w-full text-sm">
+                <table className="w-full text-body">
                   <thead>
                     <tr className="bg-[rgba(255,255,255,0.03)]">
-                      <th className="px-3 py-2 text-left text-xs font-normal text-tertiary">Metric</th>
-                      <th className="px-3 py-2 text-right text-xs font-normal text-tertiary">Target</th>
-                      <th className="px-3 py-2 text-right text-xs font-normal text-tertiary">Actual</th>
+                      <th className="px-3 py-2 text-left text-ui-label font-normal text-tertiary">Metric</th>
+                      <th className="px-3 py-2 text-right text-ui-label font-normal text-tertiary">Target</th>
+                      <th className="px-3 py-2 text-right text-ui-label font-normal text-tertiary">Actual</th>
                     </tr>
                   </thead>
                   <tbody className="divide-y divide-[hsl(var(--border))]">
@@ -409,7 +409,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
                               <span className="italic text-muted">Not set</span>
                             ) : targetIsMissingWithNote ? (
                               <span className="italic text-muted">
-                                Not set <span className="text-[11px] not-italic text-tertiary">({targetNote})</span>
+                                Not set <span className="text-ui-label not-italic text-tertiary">({targetNote})</span>
                               </span>
                             ) : (
                               rawTarget
@@ -431,7 +431,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
                 <button
                   type="button"
                   onClick={() => setShowAllMetrics(!showAllMetrics)}
-                  className="mt-2 text-xs text-tertiary hover:text-white"
+                  className="mt-2 text-ui-label text-tertiary hover:text-white"
                 >
                   {showAllMetrics
                     ? "Show fewer ↑"
@@ -445,7 +445,7 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
           {verdict.key_deviations && verdict.key_deviations.length > 0 && (
             <div className="mt-4 space-y-2">
               {verdict.key_deviations.map((dev, i) => (
-                <div key={i} className="flex items-start gap-2 text-sm">
+                <div key={i} className="flex items-start gap-2 text-body">
                   <DeviationIcon severity={dev.severity} />
                   <span className="text-muted leading-relaxed">{sanitizeText(dev.description)}</span>
                 </div>
@@ -460,20 +460,20 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
           <button
             type="button"
             onClick={() => setShowExplanation(!showExplanation)}
-            className="mt-3 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
+            className="mt-3 rounded-full border border-[hsl(var(--border))] px-3 py-1 text-ui-label text-tertiary hover:border-[rgba(255,255,255,0.25)] hover:text-white"
           >
             {showExplanation ? "Hide explanation" : "Explain these metrics"}
           </button>
           {showExplanation && (
             <div className="mt-2 rounded-lg bg-[rgba(0,0,0,0.2)] p-3">
-              <p className="text-sm text-muted leading-relaxed">
+              <p className="text-body text-muted leading-relaxed">
                 {getContextualExplanation(verdict.verdict_status, discipline, verdict.key_deviations)}
               </p>
               <Link
                 href={`/coach?prompt=${encodeURIComponent(
                   buildCoachPrompt(discipline, verdict.verdict_status, verdict.key_deviations)
                 )}`}
-                className="mt-2 inline-flex items-center text-[11px] text-[var(--color-accent)] transition-ui hover:text-white"
+                className="mt-2 inline-flex items-center text-ui-label text-[var(--color-accent)] transition-ui hover:text-white"
               >
                 Dig in with coach →
               </Link>
@@ -486,14 +486,14 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
           <div className="px-5 py-4">
             {verdict.non_obvious_insight && (
               <>
-                <p className="text-xs uppercase tracking-[0.14em] text-[var(--color-accent)]">Coach insight</p>
-                <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.non_obvious_insight)}</p>
+                <p className="text-kicker text-[var(--color-accent)]">Coach insight</p>
+                <p className="mt-2 text-body text-white leading-relaxed">{sanitizeText(verdict.non_obvious_insight)}</p>
               </>
             )}
             {verdict.teach && (
               <>
-                <p className="mt-3 text-xs uppercase tracking-[0.14em] text-tertiary">Why this matters</p>
-                <p className="mt-2 text-sm text-muted leading-relaxed">{sanitizeText(verdict.teach)}</p>
+                <p className="mt-3 text-kicker text-tertiary">Why this matters</p>
+                <p className="mt-2 text-body text-muted leading-relaxed">{sanitizeText(verdict.teach)}</p>
               </>
             )}
           </div>
@@ -501,11 +501,11 @@ export function SessionVerdictCard({ sessionId, existingVerdict, sessionComplete
 
         {/* Part 3: Adaptation Signal */}
         <div className="px-5 py-4">
-          <p className="text-xs uppercase tracking-[0.14em] text-tertiary">What this means for your plan</p>
-          <p className="mt-2 text-sm text-white leading-relaxed">{sanitizeText(verdict.adaptation_signal)}</p>
+          <p className="text-kicker text-tertiary">What this means for your plan</p>
+          <p className="mt-2 text-body text-white leading-relaxed">{sanitizeText(verdict.adaptation_signal)}</p>
           {verdict.adaptation_type && verdict.adaptation_type !== "proceed" && (
             <div
-              className="mt-2 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs"
+              className="mt-2 inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-ui-label"
               style={{ borderColor: status.border, color: status.color, backgroundColor: status.bg }}
             >
               {ADAPTATION_LABELS[verdict.adaptation_type] ?? verdict.adaptation_type}

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -93,12 +93,12 @@ function narrativeSourceLabel(source: "ai" | "fallback" | "legacy_unknown") {
 
 function narrativeSourcePillClass(source: "ai" | "fallback" | "legacy_unknown") {
   if (source === "ai") {
-    return "rounded-full border border-[rgba(190,255,0,0.25)] bg-[rgba(190,255,0,0.10)] px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-[var(--color-accent)]";
+    return "rounded-full border border-[rgba(190,255,0,0.25)] bg-[rgba(190,255,0,0.10)] px-2.5 py-1 text-kicker text-[var(--color-accent)]";
   }
   if (source === "fallback") {
-    return "rounded-full border border-[rgba(255,180,60,0.3)] bg-[rgba(255,180,60,0.12)] px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-[hsl(var(--warning))]";
+    return "rounded-full border border-[rgba(255,180,60,0.3)] bg-[rgba(255,180,60,0.12)] px-2.5 py-1 text-kicker text-[hsl(var(--warning))]";
   }
-  return "rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-tertiary";
+  return "rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-kicker text-tertiary";
 }
 
 async function loadActivityReviewRow(params: {
@@ -584,17 +584,17 @@ export default async function SessionReviewPage({ params, searchParams }: { para
   // Badge classes
   const sessionStatusBadgeClass =
     reviewVm.sessionStatusLabel.toLowerCase() === "completed"
-      ? "rounded-full border border-[rgba(52,211,153,0.25)] bg-[rgba(52,211,153,0.12)] px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-success"
-      : "rounded-full border border-[hsl(var(--border))] px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-tertiary";
+      ? "rounded-full border border-[rgba(52,211,153,0.25)] bg-[rgba(52,211,153,0.12)] px-2.5 py-1 text-kicker text-success"
+      : "rounded-full border border-[hsl(var(--border))] px-2.5 py-1 text-kicker text-tertiary";
   const intentBadgeClass =
     reviewVm.intent.label === "Matched intent"
-      ? "rounded-full border border-[rgba(190,255,0,0.25)] bg-[rgba(190,255,0,0.10)] px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] text-[var(--color-accent)]"
-      : `rounded-full border px-2.5 py-1 text-[11px] uppercase tracking-[0.14em] ${toneToBadgeClass(reviewVm.intent.tone)}`;
+      ? "rounded-full border border-[rgba(190,255,0,0.25)] bg-[rgba(190,255,0,0.10)] px-2.5 py-1 text-kicker text-[var(--color-accent)]"
+      : `rounded-full border px-2.5 py-1 text-kicker ${toneToBadgeClass(reviewVm.intent.tone)}`;
 
   return (
     <section className="space-y-4">
       {/* Breadcrumb */}
-      <nav className="flex items-center gap-1.5 text-sm text-tertiary" aria-label="Breadcrumb">
+      <nav className="flex items-center gap-1.5 text-body text-tertiary" aria-label="Breadcrumb">
         <Link href="/dashboard" className="text-cyan-400 hover:text-cyan-300">Dashboard</Link>
         <span className="text-[rgba(255,255,255,0.3)]">/</span>
         <Link href={`/calendar?weekStart=${weekStartIso}`} className="text-cyan-400 hover:text-cyan-300">Calendar</Link>
@@ -610,8 +610,8 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       <article className="surface p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
-            <h1 className="text-xl font-semibold text-[rgba(255,255,255,0.92)] sm:text-2xl">{sessionTitle}</h1>
-            <p className="mt-1 text-sm text-muted">
+            <h1 className="text-page-title font-semibold text-[rgba(255,255,255,0.92)]">{sessionTitle}</h1>
+            <p className="mt-1 text-body text-muted">
               {disciplineLabel} · {sessionDateLabel} · {actualDurationLabel}
             </p>
           </div>
@@ -629,7 +629,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             </span>
           ) : null}
           {blockContext ? (
-            <span className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-[11px] text-[rgba(255,255,255,0.78)]">
+            <span className="inline-flex items-center gap-1.5 rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-1 text-ui-label text-[rgba(255,255,255,0.78)]">
               <svg width="10" height="10" viewBox="0 0 12 12" fill="none" className="text-tertiary" aria-hidden="true">
                 <path d="M6 1L10.5 3.5V8.5L6 11L1.5 8.5V3.5L6 1Z" stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round" />
               </svg>
@@ -647,11 +647,11 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                 {reviewVm.score}
               </span>
               <div className="min-w-0">
-                <p className={`text-lg font-medium ${toneToTextClass(reviewVm.scoreTone)}`}>
+                <p className={`text-section-title font-medium ${toneToTextClass(reviewVm.scoreTone)}`}>
                   {reviewVm.scoreBand}
                 </p>
                 {confidenceQualifier ? (
-                  <p className="text-[11px] text-tertiary">{confidenceQualifier}</p>
+                  <p className="text-ui-label text-tertiary">{confidenceQualifier}</p>
                 ) : null}
               </div>
             </div>
@@ -662,8 +662,8 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                     key={metric.label}
                     className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2"
                   >
-                    <p className="text-[10px] uppercase tracking-[0.08em] text-tertiary">{metric.label}</p>
-                    <p className="mt-1 text-sm font-medium tabular-nums text-white">{metric.value}</p>
+                    <p className="text-kicker text-tertiary">{metric.label}</p>
+                    <p className="mt-1 text-body font-medium tabular-nums text-white">{metric.value}</p>
                   </div>
                 ))}
               </div>
@@ -687,24 +687,24 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               : "border-l-[var(--color-accent)] bg-[rgba(190,255,0,0.04)]"
           } border-y border-r border-[hsl(var(--border))]`}
         >
-          <p className={`text-[11px] font-medium uppercase tracking-[0.14em] ${isKeepDoingAdvice ? "text-success" : "text-[var(--color-accent)]"}`}>
+          <p className={`text-kicker font-medium ${isKeepDoingAdvice ? "text-success" : "text-[var(--color-accent)]"}`}>
             {oneThingLabel}
           </p>
-          <p className="mt-2 text-base font-medium leading-snug text-white">{reviewVm.oneThingToChange}</p>
+          <p className="mt-2 text-body font-medium leading-snug text-white">{reviewVm.oneThingToChange}</p>
           {reviewVm.whyItMatters ? (
-            <p className="mt-2 text-sm text-[rgba(255,255,255,0.68)]">{reviewVm.whyItMatters}</p>
+            <p className="mt-2 text-body text-[rgba(255,255,255,0.68)]">{reviewVm.whyItMatters}</p>
           ) : null}
           <div className="mt-3 flex flex-wrap gap-2">
             <Link
               href={`/coach?prompt=${encodeURIComponent(`${sessionTitle}: how do I apply "${reviewVm.oneThingToChange}" to my next session?`)}`}
-              className="btn-primary px-3 text-xs"
+              className="btn-primary px-3 text-ui-label"
             >
               Apply to next session
             </Link>
             {nextSession ? (
               <Link
                 href={`/sessions/${nextSession.id}`}
-                className="inline-flex items-center rounded-lg border border-[hsl(var(--border))] px-3 py-1.5 text-xs text-tertiary transition-ui hover:border-[rgba(255,255,255,0.2)] hover:text-white"
+                className="inline-flex items-center rounded-lg border border-[hsl(var(--border))] px-3 py-1.5 text-ui-label text-tertiary transition-ui hover:border-[rgba(255,255,255,0.2)] hover:text-white"
               >
                 Next: {nextSession.session_name ?? nextSession.type} →
               </Link>
@@ -727,20 +727,20 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       {/* Post-upload: Impact on your week */}
       {isPostUpload && weekTotalCount > 0 ? (
         <article className="surface p-4 md:p-5">
-          <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-tertiary">Impact on your week</p>
-          <p className="mt-2 text-sm text-white">
+          <p className="text-kicker font-medium text-tertiary">Impact on your week</p>
+          <p className="mt-2 text-body text-white">
             {weekCompletedCount} of {weekTotalCount} session{weekTotalCount === 1 ? "" : "s"} complete this week
           </p>
           {verdictAdaptationType === "modify" || verdictAdaptationType === "redistribute" ? (
-            <p className="mt-2 text-sm text-[hsl(var(--warning))]">
+            <p className="mt-2 text-body text-[hsl(var(--warning))]">
               This session has triggered an adjustment to your upcoming training.{" "}
               <Link href={`/calendar?weekStart=${weekStartIso}`} className="text-cyan-400 hover:text-cyan-300">View adaptation →</Link>
             </p>
           ) : verdictAdaptationType === "proceed" ? (
-            <p className="mt-2 text-sm text-muted">No changes needed — your plan continues as prescribed.</p>
+            <p className="mt-2 text-body text-muted">No changes needed — your plan continues as prescribed.</p>
           ) : null}
           {nextSession ? (
-            <p className="mt-2 text-sm text-muted">
+            <p className="mt-2 text-body text-muted">
               Next up: <Link href={`/sessions/${nextSession.id}`} className="text-cyan-400 hover:text-cyan-300">{nextSession.session_name ?? nextSession.type}</Link> on {new Intl.DateTimeFormat("en-US", { weekday: "long", timeZone: "UTC" }).format(new Date(`${nextSession.date}T00:00:00Z`))}
             </p>
           ) : null}
@@ -756,7 +756,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         <DetailsAccordion
           title="Read full analysis"
           summaryDetail={
-            <span className="text-[11px] text-muted">
+            <span className="text-ui-label text-muted">
               Verdict · purpose · metric deltas · plan impact
             </span>
           }
@@ -774,23 +774,23 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             {/* Execution diagnosis — shown for reviewable sessions without a verdict card (skipped, planned-sync) */}
             {session.status !== "completed" && reviewVm.actualExecutionSummary ? (
               <div>
-                <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Execution quality</p>
-                <p className="mt-2 text-sm">{reviewVm.actualExecutionSummary}</p>
+                <p className="text-kicker text-tertiary">Execution quality</p>
+                <p className="mt-2 text-body">{reviewVm.actualExecutionSummary}</p>
               </div>
             ) : null}
             {session.status !== "completed" && reviewVm.mainGap ? (
               <div className="border-t border-[hsl(var(--border))] pt-4">
-                <p className="text-xs uppercase tracking-[0.14em] text-tertiary">{reviewVm.mainGapLabel}</p>
-                <p className="mt-2 text-sm">{reviewVm.mainGap}</p>
+                <p className="text-kicker text-tertiary">{reviewVm.mainGapLabel}</p>
+                <p className="mt-2 text-body">{reviewVm.mainGap}</p>
               </div>
             ) : null}
 
             {/* This week — consolidated from old "This week" + "What this means for your plan" */}
             <div className="border-t border-[hsl(var(--border))] pt-4">
               <p className={quietLabelClass}>This week</p>
-              <p className="mt-2 text-sm text-muted">{reviewVm.weekAction}</p>
+              <p className="mt-2 text-body text-muted">{reviewVm.weekAction}</p>
               {reviewVm.loadContribution?.sessionTss != null ? (
-                <p className="mt-1.5 text-xs text-tertiary">
+                <p className="mt-1.5 text-ui-label text-tertiary">
                   {Math.round(reviewVm.loadContribution.sessionTss)} TSS
                   {reviewVm.loadContribution.weekTssPct != null
                     ? ` · ${Math.round(reviewVm.loadContribution.weekTssPct * 100)}% of weekly target`
@@ -803,12 +803,12 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                 this exposes the rest (plus the first 3 for a consolidated view). */}
             {reviewVm.usefulMetrics.length > 3 ? (
               <div className="border-t border-[hsl(var(--border))] pt-4">
-                <p className="mb-2 text-xs uppercase tracking-[0.14em] text-tertiary">All metrics</p>
+                <p className="mb-2 text-kicker text-tertiary">All metrics</p>
                 <div className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
                   {reviewVm.usefulMetrics.map((metric) => (
                     <div key={metric.label} className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
-                      <p className="text-xs text-muted">{metric.label}</p>
-                      <p className="mt-1 text-base font-semibold text-white">{metric.value}</p>
+                      <p className="text-ui-label text-muted">{metric.label}</p>
+                      <p className="mt-1 text-body font-semibold text-white">{metric.value}</p>
                     </div>
                   ))}
                 </div>
@@ -820,12 +820,12 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         <section className="surface p-4 md:p-5">
           <div className="grid gap-3 md:grid-cols-[0.9fr_1.1fr]">
             <div>
-              <p className="text-xs uppercase tracking-[0.14em] text-tertiary">Planned intent</p>
-              <p className="mt-2 text-sm">{reviewVm.plannedIntent}</p>
+              <p className="text-kicker text-tertiary">Planned intent</p>
+              <p className="mt-2 text-body">{reviewVm.plannedIntent}</p>
             </div>
             <div className="border-l border-[hsl(var(--border))] pl-5">
-              <p className="text-xs uppercase tracking-[0.14em] text-tertiary">{reviewVm.unlockTitle}</p>
-              <p className="mt-2 text-sm">{reviewVm.unlockDetail}</p>
+              <p className="text-kicker text-tertiary">{reviewVm.unlockTitle}</p>
+              <p className="mt-2 text-body">{reviewVm.unlockDetail}</p>
             </div>
           </div>
         </section>
@@ -854,15 +854,15 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         return (
           <article className="surface p-4 md:p-5">
             <div className="flex items-center justify-between">
-              <p className="text-[10px] font-medium uppercase tracking-[0.12em] text-tertiary">Score breakdown</p>
+              <p className="text-kicker font-medium text-tertiary">Score breakdown</p>
               <div className="flex flex-wrap items-center gap-2">
                 {reviewVm.scoreBand ? (
-                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
+                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-ui-label text-muted">
                     {reviewVm.scoreBand}
                   </span>
                 ) : null}
                 {reviewVm.executionCostLabel ? (
-                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] text-muted">
+                  <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-ui-label text-muted">
                     Execution cost: {reviewVm.executionCostLabel}
                   </span>
                 ) : null}
@@ -870,7 +870,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             </div>
             {/* Refinement: weights collapse to a single explainer line so
                 they stop fighting the sub-score numbers for attention. */}
-            <p className="mt-1 text-[11px] text-tertiary">
+            <p className="mt-1 text-ui-label text-tertiary">
               Weighted: Intent 40 · Pacing 25 · Completion 20 · Recovery 15
             </p>
             <div className="mt-3 grid gap-3 sm:grid-cols-2 sm:gap-x-5 sm:gap-y-4">
@@ -880,7 +880,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                   <div key={label}>
                     <div className="flex items-center justify-between gap-2">
                       <div className="flex items-center gap-2">
-                        <span className={`text-xs font-medium ${isLowest ? "text-warning" : "text-white"}`}>{label}</span>
+                        <span className={`text-ui-label font-medium ${isLowest ? "text-warning" : "text-white"}`}>{label}</span>
                         {isLowest ? (
                           <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Lowest</span>
                         ) : null}
@@ -888,19 +888,19 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                           <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Capped</span>
                         ) : null}
                       </div>
-                      <span className={`font-mono tabular-nums ${isLowest ? "text-sm font-semibold text-warning" : "text-xs font-medium text-white"}`}>{component.score}</span>
+                      <span className={`font-mono tabular-nums ${isLowest ? "text-body font-semibold text-warning" : "text-ui-label font-medium text-white"}`}>{component.score}</span>
                     </div>
-                    <p className="mt-1.5 text-[11px] leading-snug text-muted">{component.detail}</p>
+                    <p className="mt-1.5 text-ui-label leading-snug text-muted">{component.detail}</p>
                   </div>
                 );
               })}
             </div>
             {cappedDominantMetric ? (
-              <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+              <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-ui-label text-warning">
                 {cappedDominantMetric} data missing — Intent Match is capped because the primary effort signal for this session isn&apos;t there to confirm.
               </p>
             ) : missingCriticalData.length > 0 ? (
-              <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-[11px] text-warning">
+              <p className="mt-3 rounded-lg border border-warning/30 bg-warning/5 px-3 py-2 text-ui-label text-warning">
                 {missingCriticalData[0]} missing — pair the right sensor next time to unlock a confirmed read.
               </p>
             ) : null}
@@ -915,11 +915,11 @@ export default async function SessionReviewPage({ params, searchParams }: { para
 
       {reviewVm.uncertaintyDetail && dataCompletenessPct < 0.6 ? (
         <DetailsAccordion title="Data confidence" summaryDetail={
-          <span className="text-[11px] text-muted">{reviewVm.uncertaintyTitle ?? "Limited data"}</span>
+          <span className="text-ui-label text-muted">{reviewVm.uncertaintyTitle ?? "Limited data"}</span>
         }>
-          <p className="text-sm text-muted">{reviewVm.uncertaintyDetail}</p>
+          <p className="text-body text-muted">{reviewVm.uncertaintyDetail}</p>
           {reviewVm.missingEvidence.length > 0 ? (
-            <p className="mt-2 text-sm text-muted">Missing: {reviewVm.missingEvidence.join(", ")}.</p>
+            <p className="mt-2 text-body text-muted">Missing: {reviewVm.missingEvidence.join(", ")}.</p>
           ) : null}
         </DetailsAccordion>
       ) : null}
@@ -928,12 +928,12 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       <section className="border-t border-[hsl(var(--border))] pt-4">
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
-            <h2 className="text-lg font-semibold">Ask coach follow-up</h2>
-            <p className="mt-1 text-sm text-muted">{reviewVm.followUpIntro}</p>
+            <h2 className="text-section-title font-semibold">Ask coach follow-up</h2>
+            <p className="mt-1 text-body text-muted">{reviewVm.followUpIntro}</p>
           </div>
           <Link
             href={`/coach?prompt=${encodeURIComponent(`${sessionTitle}: ${reviewVm.followUpPrompts[0] ?? "What should I change next time?"}`)}`}
-            className="btn-primary px-3 text-xs"
+            className="btn-primary px-3 text-ui-label"
           >
             Ask coach
           </Link>
@@ -943,7 +943,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             <Link
               key={prompt}
               href={`/coach?prompt=${encodeURIComponent(`${sessionTitle}: ${prompt}`)}`}
-              className="inline-flex min-h-[44px] items-center rounded-full border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2 text-xs text-[rgba(255,255,255,0.55)] transition hover:border-[rgba(255,255,255,0.16)] hover:text-[rgba(255,255,255,0.75)] lg:min-h-0 lg:py-1.5"
+              className="inline-flex min-h-[44px] items-center rounded-full border border-[rgba(255,255,255,0.10)] bg-[rgba(255,255,255,0.06)] px-3 py-2 text-ui-label text-[rgba(255,255,255,0.55)] transition hover:border-[rgba(255,255,255,0.16)] hover:text-[rgba(255,255,255,0.75)] lg:min-h-0 lg:py-1.5"
             >
               {prompt}
             </Link>
@@ -963,13 +963,13 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           <div className="flex flex-wrap items-center gap-3">
             <Link
               href="/dashboard"
-              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-[rgba(255,255,255,0.08)] px-4 py-2 text-sm font-medium text-white hover:bg-[rgba(255,255,255,0.14)] lg:min-h-0"
+              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg bg-[rgba(255,255,255,0.08)] px-4 py-2 text-body font-medium text-white hover:bg-[rgba(255,255,255,0.14)] lg:min-h-0"
             >
               Back to Dashboard
             </Link>
             <Link
               href={`/calendar?weekStart=${weekStartIso}`}
-              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.12)] px-4 py-2 text-sm text-[rgba(255,255,255,0.7)] hover:border-[rgba(255,255,255,0.2)] hover:text-white lg:min-h-0"
+              className="inline-flex min-h-[44px] items-center gap-1.5 rounded-lg border border-[rgba(255,255,255,0.12)] px-4 py-2 text-body text-[rgba(255,255,255,0.7)] hover:border-[rgba(255,255,255,0.2)] hover:text-white lg:min-h-0"
             >
               View Calendar
             </Link>
@@ -979,7 +979,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             {prevSession ? (
               <Link
                 href={`/sessions/${prevSession.id}`}
-                className="inline-flex min-h-[44px] items-center gap-1.5 text-sm text-tertiary transition-ui hover:text-white lg:min-h-0"
+                className="inline-flex min-h-[44px] items-center gap-1.5 text-body text-tertiary transition-ui hover:text-white lg:min-h-0"
               >
                 ← Prev: {prevSession.session_name ?? prevSession.type}
               </Link>
@@ -987,7 +987,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
             {nextSession ? (
               <Link
                 href={`/sessions/${nextSession.id}`}
-                className="inline-flex min-h-[44px] items-center gap-1.5 text-sm text-tertiary transition-ui hover:text-white lg:min-h-0"
+                className="inline-flex min-h-[44px] items-center gap-1.5 text-body text-tertiary transition-ui hover:text-white lg:min-h-0"
               >
                 Next: {nextSession.session_name ?? nextSession.type} →
               </Link>

--- a/app/(protected)/sessions/[sessionId]/regenerate-review-button.tsx
+++ b/app/(protected)/sessions/[sessionId]/regenerate-review-button.tsx
@@ -43,11 +43,11 @@ export function RegenerateReviewButton({ sessionId }: { sessionId: string }) {
         type="button"
         onClick={handleRegenerate}
         disabled={isPending}
-        className="text-xs text-tertiary underline-offset-2 transition-ui hover:text-white hover:underline disabled:cursor-not-allowed disabled:opacity-60"
+        className="text-ui-label text-tertiary underline-offset-2 transition-ui hover:text-white hover:underline disabled:cursor-not-allowed disabled:opacity-60"
       >
         {isPending ? "Regenerating..." : "Regenerate review"}
       </button>
-      {message ? <p className="text-xs text-muted">{message}</p> : null}
+      {message ? <p className="text-ui-label text-muted">{message}</p> : null}
     </div>
   );
 }


### PR DESCRIPTION
Stacks on #295 (stage 1 utilities). Applies the six semantic type utilities across the **Session Review** surface — the audit's named evidence block.

## What changes

Six files swap their raw Tailwind size classes for the semantic utility that fits each element's role:
- `app/(protected)/sessions/[sessionId]/page.tsx`
- `components/session-verdict-card.tsx`
- `components/session-comparison-card.tsx`
- `components/feel-capture-banner.tsx`
- `components/extras-verdict-card.tsx`
- `regenerate-review-button.tsx`

Mapping applied:
- Uppercase-tracked labels → `.text-kicker` (11 / 500 · 0.12em) — COMPLETED, PARTIAL MATCH, COACH NOTE, SCORE BREAKDOWN, YOUR RATING, "Why this matters", every other kicker on the page.
- H1 session title → `.text-page-title` (22 / 600).
- Verdict band ("Solid"), feel summary value, follow-up H2 → `.text-section-title` (17 / 500).
- All prose, findings bullets, chip copy, table rows → `.text-body` (15 / 400).
- Metric tile values, table headers, chip secondary text, button copy → `.text-ui-label` (13 / 500).

## Kept out of scale (deliberate)
- `text-6xl sm:text-7xl` on the hero score number — `page-hero` (32px) is too small for the session's flagship stat.
- `text-2xl` on the emoji icon — decorative glyph.
- `text-[9px]` on "LOWEST" / "CAPPED" sub-chips — below the 11px kicker floor.

## Test plan
- [ ] `npm run typecheck` — clean (verified locally)
- [ ] Visual: Session Review — hierarchy now reads at 3–4 distinguishable sizes (title / section / body / ui-label + kicker), down from 7+

🤖 Generated with [Claude Code](https://claude.com/claude-code)