### PR TITLE
feat(design-system): F02 stage 3 — weight audit (session review + dashboard)

### DIFF
--- a/app/(protected)/dashboard/components/discipline-balance-compact.tsx
+++ b/app/(protected)/dashboard/components/discipline-balance-compact.tsx
@@ -122,7 +122,7 @@ export function DisciplineBalanceCompact({ balance }: Props) {
                   <span className="text-tertiary">/{formatHours(plannedMins)}</span>
                 </span>
                 {delta ? (
-                  <span className={`text-ui-label font-medium ${deltaClass}`}>{delta}</span>
+                  <span className={`text-ui-label ${deltaClass}`}>{delta}</span>
                 ) : null}
               </div>
             </div>

--- a/app/(protected)/dashboard/components/monday-transition-flow.tsx
+++ b/app/(protected)/dashboard/components/monday-transition-flow.tsx
@@ -29,7 +29,7 @@ export function MondayTransitionFlow({ briefing, morningBrief, debriefSummary, p
         className="flex w-full items-center justify-between gap-3 p-4 text-left md:p-5"
       >
         <div className="flex min-w-0 items-center gap-3">
-          <p className="shrink-0 text-kicker font-medium text-[rgba(190,255,0,0.7)]">
+          <p className="shrink-0 text-kicker text-[rgba(190,255,0,0.7)]">
             Monday brief
           </p>
           {!expanded ? (
@@ -53,7 +53,7 @@ export function MondayTransitionFlow({ briefing, morningBrief, debriefSummary, p
         <div className="space-y-0">
           {/* Section 1: Last Week */}
           <div className="border-t border-b border-[rgba(255,255,255,0.06)] p-4 md:p-5">
-            <p className="text-kicker font-medium text-tertiary">Last week</p>
+            <p className="text-kicker text-tertiary">Last week</p>
             <p className="mt-2 text-body leading-relaxed text-white">{briefing.lastWeekTakeaway}</p>
             {debriefSummary ? (
               <p className="mt-1.5 text-body leading-relaxed text-[rgba(255,255,255,0.65)]">{debriefSummary}</p>
@@ -65,7 +65,7 @@ export function MondayTransitionFlow({ briefing, morningBrief, debriefSummary, p
 
           {/* Section 2: This Week */}
           <div className="border-b border-[rgba(255,255,255,0.06)] p-4 md:p-5">
-            <p className="text-kicker font-medium text-tertiary">This week</p>
+            <p className="text-kicker text-tertiary">This week</p>
             <p className="mt-2 text-body leading-relaxed text-white">{briefing.thisWeekFocus}</p>
             {briefing.adaptationContext ? (
               <p className="mt-1.5 rounded-lg border border-[rgba(251,191,36,0.25)] bg-[rgba(251,191,36,0.06)] px-3 py-2 text-ui-label text-[hsl(var(--warning))]">
@@ -80,7 +80,7 @@ export function MondayTransitionFlow({ briefing, morningBrief, debriefSummary, p
           {/* Section 3: Today */}
           {morningBrief?.sessionPreview ? (
             <div className="border-b border-[rgba(255,255,255,0.06)] p-4 md:p-5">
-              <p className="text-kicker font-medium text-tertiary">Today</p>
+              <p className="text-kicker text-tertiary">Today</p>
               <p className="mt-2 text-body leading-relaxed text-white">{morningBrief.sessionPreview}</p>
             </div>
           ) : null}

--- a/app/(protected)/dashboard/components/morning-brief-card.tsx
+++ b/app/(protected)/dashboard/components/morning-brief-card.tsx
@@ -33,7 +33,7 @@ export function MorningBriefCard({ brief }: Props) {
         >
           ai
         </span>
-        <p className="text-kicker font-medium text-[var(--color-accent)]">
+        <p className="text-kicker text-[var(--color-accent)]">
           Coach brief
         </p>
       </div>

--- a/app/(protected)/dashboard/components/readiness-indicator.tsx
+++ b/app/(protected)/dashboard/components/readiness-indicator.tsx
@@ -63,7 +63,7 @@ export function ReadinessIndicator({ readiness, tsb, tsbTrend, signalContext }: 
             className="inline-block h-2.5 w-2.5 rounded-full"
             style={{ backgroundColor: config.color }}
           />
-          <span className="text-ui-label font-medium uppercase tracking-[0.12em]" style={{ color: config.color }}>
+          <span className="text-ui-label uppercase tracking-[0.12em]" style={{ color: config.color }}>
             {config.label}
           </span>
           <span className="text-ui-label font-mono text-tertiary">

--- a/app/(protected)/dashboard/components/recent-upload-card.tsx
+++ b/app/(protected)/dashboard/components/recent-upload-card.tsx
@@ -23,7 +23,7 @@ export function RecentUploadCard({ sessionId, sessionName, sport, durationMinute
     <article className="rounded-xl border border-[hsl(var(--accent)/0.3)] bg-[hsl(var(--accent)/0.06)] p-4">
       <div className="flex items-start justify-between gap-3">
         <div>
-          <p className="text-kicker font-medium text-[hsl(var(--accent))]">New activity</p>
+          <p className="text-kicker text-[hsl(var(--accent))]">New activity</p>
           <p className="mt-1 text-body text-white">
             You completed <span className="font-medium">{sessionName}</span> ({durationLabel}) — how did it feel?
           </p>

--- a/app/(protected)/dashboard/components/training-score-card.tsx
+++ b/app/(protected)/dashboard/components/training-score-card.tsx
@@ -134,7 +134,7 @@ export function TrainingScoreCard({ score }: Props) {
             />
           </svg>
           <div className="absolute inset-0 flex items-center justify-center">
-            <span className={`text-page-title font-semibold ${getScoreColour(score.compositeScore)}`}>
+            <span className={`text-page-title ${getScoreColour(score.compositeScore)}`}>
               {Math.round(score.compositeScore)}
             </span>
           </div>

--- a/app/(protected)/dashboard/components/transition-briefing-card.tsx
+++ b/app/(protected)/dashboard/components/transition-briefing-card.tsx
@@ -39,7 +39,7 @@ export function TransitionBriefingCard({ briefing }: Props) {
           onClick={() => setExpanded((v) => !v)}
           className="flex min-w-0 flex-1 items-center gap-3 text-left"
         >
-          <p className="shrink-0 text-kicker font-medium text-[rgba(190,255,0,0.7)]">
+          <p className="shrink-0 text-kicker text-[rgba(190,255,0,0.7)]">
             Monday brief
           </p>
           {!expanded ? (
@@ -89,7 +89,7 @@ export function TransitionBriefingCard({ briefing }: Props) {
               {briefing.pendingRationaleIds.length > 0 ? (
                 <Link
                   href="/calendar"
-                  className="mt-1.5 inline-block text-ui-label font-medium text-[hsl(var(--warning))] hover:underline"
+                  className="mt-1.5 inline-block text-ui-label text-[hsl(var(--warning))] hover:underline"
                 >
                   Review {briefing.pendingRationaleIds.length} adaptation{briefing.pendingRationaleIds.length > 1 ? "s" : ""}
                 </Link>

--- a/app/(protected)/dashboard/components/week-ahead-card.tsx
+++ b/app/(protected)/dashboard/components/week-ahead-card.tsx
@@ -57,7 +57,7 @@ export function WeekAheadCard({ preview }: Props) {
         className="flex w-full items-center justify-between gap-3 text-left"
       >
         <div className="flex min-w-0 items-center gap-3">
-          <p className="shrink-0 text-kicker font-medium text-accent">Week ahead</p>
+          <p className="shrink-0 text-kicker text-accent">Week ahead</p>
           {!expanded ? (
             <p className="min-w-0 truncate text-body text-[rgba(255,255,255,0.6)]">
               {summaryParts.join(" · ")}

--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -515,7 +515,7 @@ export default async function DashboardPage({
       <section className="space-y-4">
         <article className="surface p-6">
           <p className="text-kicker text-accent">Get started</p>
-          <h1 className="mt-2 text-page-title font-semibold">Build your first week</h1>
+          <h1 className="mt-2 text-page-title">Build your first week</h1>
           <p className="mt-2 text-body text-muted">
             Create a plan to unlock this week progress, today execution, and focused coaching decisions.
           </p>
@@ -536,7 +536,7 @@ export default async function DashboardPage({
       {dashboardMoment === "race_day" && raceWeekCtx ? (
         <article className="rounded-xl border border-[rgba(251,191,36,0.5)] bg-[rgba(251,191,36,0.08)] px-5 py-5">
           <p className="text-kicker font-semibold text-amber-400">Race day</p>
-          <h2 className="mt-2 text-page-title font-semibold text-white">{raceWeekCtx.race.name}</h2>
+          <h2 className="mt-2 text-page-title text-white">{raceWeekCtx.race.name}</h2>
           <p className="mt-1 text-body text-[rgba(255,255,255,0.72)]">{formatRaceDistance(raceWeekCtx)}</p>
           <p className="mt-3 text-body text-[rgba(255,255,255,0.84)]">{getConfidenceStatement(raceWeekCtx)}</p>
           {raceWeekCtx.readiness.readinessState === "fresh" ? (
@@ -546,7 +546,7 @@ export default async function DashboardPage({
       ) : dashboardMoment === "race_eve" && raceWeekCtx ? (
         <article className="rounded-xl border border-[rgba(251,191,36,0.35)] bg-[rgba(251,191,36,0.06)] px-5 py-4">
           <p className="text-kicker font-semibold text-amber-400">Tomorrow is race day</p>
-          <h2 className="mt-2 text-page-title font-semibold text-white">{raceWeekCtx.race.name}</h2>
+          <h2 className="mt-2 text-page-title text-white">{raceWeekCtx.race.name}</h2>
           <p className="mt-1 text-body text-[rgba(255,255,255,0.72)]">{formatRaceDistance(raceWeekCtx)}</p>
           <p className="mt-3 text-body text-[rgba(255,255,255,0.84)]">You have done the work. Trust your training.</p>
           <div className="mt-3 space-y-1 text-ui-label text-[rgba(255,255,255,0.68)]">
@@ -564,7 +564,7 @@ export default async function DashboardPage({
               <p className="mt-1 text-body text-[rgba(255,255,255,0.72)]">{raceWeekCtx.race.priority} Race · {formatRaceDistance(raceWeekCtx)}</p>
             </div>
             {raceWeekCtx.taperStatus.inTaper ? (
-              <span className="rounded-full border border-[rgba(6,182,212,0.3)] bg-[rgba(6,182,212,0.1)] px-2.5 py-1 text-ui-label font-medium text-cyan-400">Taper</span>
+              <span className="rounded-full border border-[rgba(6,182,212,0.3)] bg-[rgba(6,182,212,0.1)] px-2.5 py-1 text-ui-label text-cyan-400">Taper</span>
             ) : null}
           </div>
           <p className="mt-3 text-body text-[rgba(255,255,255,0.84)]">{getConfidenceStatement(raceWeekCtx)}</p>
@@ -572,7 +572,7 @@ export default async function DashboardPage({
       ) : dashboardMoment === "post_race" && raceWeekCtx ? (
         <article className="rounded-xl border border-[rgba(16,185,129,0.3)] bg-[rgba(16,185,129,0.06)] px-5 py-4">
           <p className="text-kicker font-semibold text-emerald-400">Recovery mode</p>
-          <h2 className="mt-2 text-page-title font-semibold text-white">{raceWeekCtx.race.name} — completed</h2>
+          <h2 className="mt-2 text-page-title text-white">{raceWeekCtx.race.name} — completed</h2>
           <p className="mt-1 text-body text-[rgba(255,255,255,0.72)]">{Math.abs(raceWeekCtx.race.daysUntil)} day{Math.abs(raceWeekCtx.race.daysUntil) === 1 ? "" : "s"} since race</p>
           <p className="mt-3 text-body text-[rgba(255,255,255,0.84)]">
             {Math.abs(raceWeekCtx.race.daysUntil) <= 2
@@ -609,7 +609,7 @@ export default async function DashboardPage({
                 {leftStatusRow ? (
                   <span
                     role="status"
-                    className="inline-flex items-center gap-1.5 rounded-full border border-[rgba(255,180,60,0.32)] bg-[rgba(255,180,60,0.12)] px-2 py-0.5 text-ui-label font-medium uppercase tracking-[0.08em] text-[var(--color-warning)]"
+                    className="inline-flex items-center gap-1.5 rounded-full border border-[rgba(255,180,60,0.32)] bg-[rgba(255,180,60,0.12)] px-2 py-0.5 text-ui-label uppercase tracking-[0.08em] text-[var(--color-warning)]"
                   >
                     <span aria-hidden="true" className="h-1 w-1 rounded-full bg-[var(--color-warning)]" />
                     {leftStatusRow.title}
@@ -642,7 +642,7 @@ export default async function DashboardPage({
           <div className="mt-5 flex flex-wrap items-end justify-between gap-x-6 gap-y-2">
             <div className="min-w-0">
               <p className="text-4xl font-semibold leading-none tracking-[-0.03em] sm:text-5xl lg:text-6xl">{completionPct}%</p>
-              <p className="mt-3 text-section-title font-medium leading-tight text-[rgba(255,255,255,0.94)]">{toHoursAndMinutes(remainingMinutes)} left this week</p>
+              <p className="mt-3 text-section-title leading-tight text-[rgba(255,255,255,0.94)]">{toHoursAndMinutes(remainingMinutes)} left this week</p>
             </div>
           </div>
 
@@ -681,7 +681,7 @@ export default async function DashboardPage({
                     <span aria-hidden="true" className={`h-1.5 w-1.5 rounded-full ${pipClass}`} />
                   </div>
                   {chipContent.title ? (
-                    <p className="mt-1 line-clamp-2 text-ui-label font-medium leading-tight text-white">{chipContent.title}</p>
+                    <p className="mt-1 line-clamp-2 text-ui-label leading-tight text-white">{chipContent.title}</p>
                   ) : null}
                   {chipContent.meta ? (
                     <p className="mt-0.5 truncate text-ui-label leading-tight text-[rgba(255,255,255,0.6)]">{chipContent.meta}</p>
@@ -723,7 +723,7 @@ export default async function DashboardPage({
           {pendingTodaySessions.length > 0 ? (
             <>
               <p className={`text-kicker text-[rgba(255,255,255,0.68)] ${isCurrentWeek ? "mt-4" : ""}`}>Today</p>
-              <h2 className="mt-2 text-page-title font-semibold">What matters right now</h2>
+              <h2 className="mt-2 text-page-title">What matters right now</h2>
               <p className="mt-1 text-ui-label text-[rgba(255,255,255,0.56)]">{pendingTodaySessions.length} remaining{` · ${completedTodaySessions.length + extraTodayActivities.length} completed`}</p>
               {todayCue ? <p className="mt-2 text-ui-label text-[rgba(255,255,255,0.68)]">Cue: {todayCue}</p> : null}
 
@@ -791,7 +791,7 @@ export default async function DashboardPage({
                 <div className="mt-4 space-y-2 border-t border-[rgba(255,255,255,0.07)] pt-4">
                   {contextualItems.map((item) => (
                     <div key={item.kicker} className={`rounded-xl border px-3 py-2.5 ${item.kicker.toLowerCase() === "needs attention" ? "border-[rgba(255,90,40,0.28)] bg-[rgba(255,90,40,0.06)]" : "border-[rgba(190,255,0,0.14)] bg-[rgba(190,255,0,0.04)]"}`}>
-                      <p className={`text-kicker font-medium ${kickerClassName(item.kicker)}`}>{item.kicker}</p>
+                      <p className={`text-kicker ${kickerClassName(item.kicker)}`}>{item.kicker}</p>
                       <p className="mt-1 text-body font-medium text-white">{item.title}</p>
                       <p className="mt-0.5 text-ui-label text-[rgba(255,255,255,0.68)]">{item.detail}</p>
                       <Link href={item.href} className={`mt-2 inline-flex ${item.ctaStyle === "primary" ? "btn-primary" : "btn-secondary"} px-3 text-ui-label`}>{item.cta}</Link>
@@ -803,11 +803,11 @@ export default async function DashboardPage({
           ) : completedTodaySessions.length > 0 || extraTodayActivities.length > 0 ? (
             <>
               <p className="text-kicker text-[rgba(255,255,255,0.68)]">Today</p>
-              <h2 className="mt-2 text-page-title font-semibold">Today is done</h2>
+              <h2 className="mt-2 text-page-title">Today is done</h2>
               <p className="mt-1 text-ui-label text-[rgba(255,255,255,0.56)]">0 remaining · {completedTodaySessions.length + extraTodayActivities.length} completed</p>
               <div className="mt-4 space-y-1">
                 <h3 className="text-body font-medium text-[rgba(255,255,255,0.72)]">Up next</h3>
-                <p className="text-page-title font-semibold leading-tight text-white">{nextImportantSession ? getSessionDisplayName(nextImportantSession) : "Next planned session"}</p>
+                <p className="text-page-title leading-tight text-white">{nextImportantSession ? getSessionDisplayName(nextImportantSession) : "Next planned session"}</p>
                 {nextImportantSession ? <p className="text-body text-[rgba(255,255,255,0.64)]">{getUpcomingSessionMeta(nextImportantSession)}</p> : null}
               </div>
 
@@ -836,7 +836,7 @@ export default async function DashboardPage({
                 <div className="mt-4 space-y-2 border-t border-[rgba(255,255,255,0.07)] pt-4">
                   {contextualItems.map((item) => (
                     <div key={item.kicker} className={`rounded-xl border px-3 py-2.5 ${item.kicker.toLowerCase() === "needs attention" ? "border-[rgba(255,90,40,0.28)] bg-[rgba(255,90,40,0.06)]" : "border-[rgba(190,255,0,0.14)] bg-[rgba(190,255,0,0.04)]"}`}>
-                      <p className={`text-kicker font-medium ${kickerClassName(item.kicker)}`}>{item.kicker}</p>
+                      <p className={`text-kicker ${kickerClassName(item.kicker)}`}>{item.kicker}</p>
                       <p className="mt-1 text-body font-medium text-white">{item.title}</p>
                       <p className="mt-0.5 text-ui-label text-[rgba(255,255,255,0.68)]">{item.detail}</p>
                       <Link href={item.href} className={`mt-2 inline-flex ${item.ctaStyle === "primary" ? "btn-primary" : "btn-secondary"} px-3 text-ui-label`}>{item.cta}</Link>
@@ -848,7 +848,7 @@ export default async function DashboardPage({
           ) : (
             <>
               <p className="text-kicker text-[rgba(255,255,255,0.68)]">Today</p>
-              <h2 className="mt-2 text-page-title font-semibold">No sessions scheduled</h2>
+              <h2 className="mt-2 text-page-title">No sessions scheduled</h2>
               <p className="mt-2 text-body text-[rgba(255,255,255,0.74)]">Use today for recovery and reset, then protect the next planned key session.</p>
               <div className="mt-4">
                 <Link href="/calendar" className="btn-secondary px-3 text-ui-label">View plan</Link>
@@ -858,7 +858,7 @@ export default async function DashboardPage({
                 <div className="mt-4 space-y-2 border-t border-[rgba(255,255,255,0.07)] pt-4">
                   {contextualItems.map((item) => (
                     <div key={item.kicker} className={`rounded-xl border px-3 py-2.5 ${item.kicker.toLowerCase() === "needs attention" ? "border-[rgba(255,90,40,0.28)] bg-[rgba(255,90,40,0.06)]" : "border-[rgba(190,255,0,0.14)] bg-[rgba(190,255,0,0.04)]"}`}>
-                      <p className={`text-kicker font-medium ${kickerClassName(item.kicker)}`}>{item.kicker}</p>
+                      <p className={`text-kicker ${kickerClassName(item.kicker)}`}>{item.kicker}</p>
                       <p className="mt-1 text-body font-medium text-white">{item.title}</p>
                       <p className="mt-0.5 text-ui-label text-[rgba(255,255,255,0.68)]">{item.detail}</p>
                       <Link href={item.href} className={`mt-2 inline-flex ${item.ctaStyle === "primary" ? "btn-primary" : "btn-secondary"} px-3 text-ui-label`}>{item.cta}</Link>

--- a/app/(protected)/dashboard/progress-glance-card.tsx
+++ b/app/(protected)/dashboard/progress-glance-card.tsx
@@ -46,7 +46,7 @@ export function ProgressGlanceCard({
 
           <div className="min-w-0 flex-1">
             <p className="text-kicker text-[hsl(var(--fg-muted))]">{weekRangeLabel}</p>
-            <p className="text-body font-semibold text-[hsl(var(--fg))]">{completedTimeLabel} / {plannedTimeLabel}</p>
+            <p className="text-body font-medium text-[hsl(var(--fg))]">{completedTimeLabel} / {plannedTimeLabel}</p>
             <p className="text-ui-label text-[hsl(var(--fg-muted))]">{remainingTimeLabel} remaining • {unmatchedExtraCount} extra sessions (additive) • {missedPlannedCount} missed planned</p>
           </div>
 

--- a/app/(protected)/dashboard/trend-cards.tsx
+++ b/app/(protected)/dashboard/trend-cards.tsx
@@ -81,7 +81,7 @@ export function TrendCards({ trends, fatigueSignal }: { trends: WeeklyTrend[]; f
           }`}
           aria-label="Cross-discipline fatigue synthesis"
         >
-          <p className="text-kicker font-medium text-white">
+          <p className="text-kicker text-white">
             Cross-discipline fatigue
           </p>
           <p className="mt-2 text-body text-white">
@@ -115,10 +115,10 @@ export function TrendCards({ trends, fatigueSignal }: { trends: WeeklyTrend[]; f
                     <Sparkline values={values} color={color} width={80} height={24} />
                   </div>
                   <div className="mt-2 flex items-baseline gap-2">
-                    <span className="text-body font-semibold text-white">
+                    <span className="text-body font-medium text-white">
                       {currentLabel}
                     </span>
-                    <span className={`text-ui-label font-medium ${DIRECTION_CLASS[trend.direction]}`}>
+                    <span className={`text-ui-label ${DIRECTION_CLASS[trend.direction]}`}>
                       {DIRECTION_ARROW[trend.direction]} {trend.direction}
                     </span>
                   </div>

--- a/app/(protected)/dashboard/week-progress-card.tsx
+++ b/app/(protected)/dashboard/week-progress-card.tsx
@@ -71,7 +71,7 @@ export function WeekProgressCard({
       <div className="flex items-center justify-between">
         <h2 className="text-section-title font-semibold">Week Progress</h2>
         {showStatusChip ? (
-          <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-body font-semibold ${overMinutes > 0 ? "signal-chip signal-load" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"}`}>
+          <span className={`inline-flex h-fit items-center gap-2 rounded-full border px-3 py-1 text-body font-medium ${overMinutes > 0 ? "signal-chip signal-load" : "border-[hsl(var(--border))] bg-[hsl(var(--surface-2))]"}`}>
             {overMinutes > 0 ? <span aria-hidden className="h-2 w-2 rounded-full bg-[hsl(var(--signal-load))]" /> : null}
             <span>{chipLabel}</span>
           </span>
@@ -95,7 +95,7 @@ export function WeekProgressCard({
           <p className="text-ui-label text-[hsl(var(--fg-muted))]">Extra work: {formatMinutes(extraTotalMinutes)}</p>
         </div>
         <div className="mb-2 flex items-center justify-between">
-          <p className="text-body font-semibold">By discipline</p>
+          <p className="text-body font-medium">By discipline</p>
           {emptyCount > 0 || !hideEmpty ? (
             <button
               type="button"
@@ -135,11 +135,11 @@ export function WeekProgressCard({
                         {Math.round(item.visibleCompletedMinutes)} / {Math.round(item.visiblePlannedMinutes)} min
                       </div>
                       {chipLabel ? (
-                        <span className={`inline-flex h-5 items-center rounded-full border px-2.5 text-ui-label font-medium ${item.discGapMinutes > 0 ? "signal-load" : "signal-risk"}`}>
+                        <span className={`inline-flex h-5 items-center rounded-full border px-2.5 text-ui-label ${item.discGapMinutes > 0 ? "signal-load" : "signal-risk"}`}>
                           {chipLabel}
                         </span>
                       ) : isCompletedDiscipline ? (
-                        <span className="inline-flex h-5 items-center gap-1 rounded-full border border-[hsl(var(--success)/0.25)] bg-[hsl(var(--success)/0.08)] px-2 text-ui-label font-medium text-[hsl(var(--fg-muted))]">
+                        <span className="inline-flex h-5 items-center gap-1 rounded-full border border-[hsl(var(--success)/0.25)] bg-[hsl(var(--success)/0.08)] px-2 text-ui-label text-[hsl(var(--fg-muted))]">
                           <span aria-hidden className="h-1.5 w-1.5 rounded-full bg-[hsl(var(--success)/0.62)]" />
                           Complete
                         </span>

--- a/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/extras-verdict-card.tsx
@@ -127,7 +127,7 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
         {/* Part 1: What this session was */}
         <div className="px-5 py-4">
           <div className="flex flex-wrap items-center gap-2">
-            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-0.5 text-ui-label font-medium text-muted">
+            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2.5 py-0.5 text-ui-label text-muted">
               {intentLabel}
             </span>
             {sessionId && sport ? (
@@ -160,7 +160,7 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
                 {match.label}
               </p>
             </div>
-            <p className="mt-2 text-ui-label font-medium" style={{ color: match.color }}>
+            <p className="mt-2 text-ui-label" style={{ color: match.color }}>
               {sanitizeText(verdict.sessionVerdict.headline)}
             </p>
             <p className="mt-2 text-body text-white leading-relaxed">{sanitizeText(verdict.sessionVerdict.summary)}</p>
@@ -185,7 +185,7 @@ export function ExtrasVerdictCard({ verdict, intentCategory, narrativeSource, se
                 <div className="mt-2 space-y-2 rounded-lg bg-[rgba(0,0,0,0.2)] p-3">
                   {verdict.citedEvidence.map((item, i) => (
                     <div key={i}>
-                      <p className="text-ui-label font-medium text-white">{sanitizeText(item.claim)}</p>
+                      <p className="text-ui-label text-white">{sanitizeText(item.claim)}</p>
                       <ul className="mt-1 space-y-0.5">
                         {item.support.map((s, j) => (
                           <li key={j} className="text-ui-label text-muted pl-3 relative before:absolute before:left-0 before:top-[7px] before:h-1 before:w-1 before:rounded-full before:bg-[rgba(255,255,255,0.2)]">

--- a/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/feel-capture-banner.tsx
@@ -75,7 +75,7 @@ function PillSelector({ label, options, value, onChange }: {
               key={opt.value}
               type="button"
               onClick={() => onChange(isSelected ? null : opt.value)}
-              className={`rounded-full border px-3 py-1 text-ui-label font-medium transition-colors ${
+              className={`rounded-full border px-3 py-1 text-ui-label transition-colors ${
                 isSelected
                   ? "border-[rgba(190,255,0,0.4)] bg-[rgba(190,255,0,0.12)] text-[var(--color-accent)]"
                   : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] text-[rgba(255,255,255,0.5)] hover:border-[rgba(255,255,255,0.25)] hover:text-white"
@@ -261,7 +261,7 @@ export function FeelCaptureBanner({ sessionId, existingFeel }: FeelCaptureBanner
               aria-checked={isSelected}
               aria-label={`${opt.label} (${opt.value}/5)`}
               onClick={() => handleFeelSelect(opt.value)}
-              className={`flex min-h-[56px] flex-col items-center justify-center gap-1 rounded-xl border text-ui-label font-medium transition-colors ${
+              className={`flex min-h-[56px] flex-col items-center justify-center gap-1 rounded-xl border text-ui-label transition-colors ${
                 isSelected
                   ? ""
                   : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] text-[rgba(255,255,255,0.5)] hover:border-[rgba(255,255,255,0.25)] hover:text-white"

--- a/app/(protected)/sessions/[sessionId]/components/session-comparison-card.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/session-comparison-card.tsx
@@ -190,7 +190,7 @@ export function SessionComparisonCard({ comparison, trends = [], aiComparisons =
                   <div className="flex items-center gap-2">
                     <TrendSparkline points={recent} direction={trend.direction} />
                     {latest ? (
-                      <span className="rounded border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.06)] px-2 py-1 text-ui-label font-medium tabular-nums text-white">
+                      <span className="rounded border border-[rgba(255,255,255,0.15)] bg-[rgba(255,255,255,0.06)] px-2 py-1 text-ui-label tabular-nums text-white">
                         {latest.label}
                       </span>
                     ) : null}

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -610,7 +610,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       <article className="surface p-5">
         <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
           <div className="min-w-0">
-            <h1 className="text-page-title font-semibold text-[rgba(255,255,255,0.92)]">{sessionTitle}</h1>
+            <h1 className="text-page-title text-[rgba(255,255,255,0.92)]">{sessionTitle}</h1>
             <p className="mt-1 text-body text-muted">
               {disciplineLabel} · {sessionDateLabel} · {actualDurationLabel}
             </p>
@@ -647,7 +647,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                 {reviewVm.score}
               </span>
               <div className="min-w-0">
-                <p className={`text-section-title font-medium ${toneToTextClass(reviewVm.scoreTone)}`}>
+                <p className={`text-section-title ${toneToTextClass(reviewVm.scoreTone)}`}>
                   {reviewVm.scoreBand}
                 </p>
                 {confidenceQualifier ? (
@@ -687,7 +687,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
               : "border-l-[var(--color-accent)] bg-[rgba(190,255,0,0.04)]"
           } border-y border-r border-[hsl(var(--border))]`}
         >
-          <p className={`text-kicker font-medium ${isKeepDoingAdvice ? "text-success" : "text-[var(--color-accent)]"}`}>
+          <p className={`text-kicker ${isKeepDoingAdvice ? "text-success" : "text-[var(--color-accent)]"}`}>
             {oneThingLabel}
           </p>
           <p className="mt-2 text-body font-medium leading-snug text-white">{reviewVm.oneThingToChange}</p>
@@ -727,7 +727,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
       {/* Post-upload: Impact on your week */}
       {isPostUpload && weekTotalCount > 0 ? (
         <article className="surface p-4 md:p-5">
-          <p className="text-kicker font-medium text-tertiary">Impact on your week</p>
+          <p className="text-kicker text-tertiary">Impact on your week</p>
           <p className="mt-2 text-body text-white">
             {weekCompletedCount} of {weekTotalCount} session{weekTotalCount === 1 ? "" : "s"} complete this week
           </p>
@@ -808,7 +808,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                   {reviewVm.usefulMetrics.map((metric) => (
                     <div key={metric.label} className="rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
                       <p className="text-ui-label text-muted">{metric.label}</p>
-                      <p className="mt-1 text-body font-semibold text-white">{metric.value}</p>
+                      <p className="mt-1 text-body font-medium text-white">{metric.value}</p>
                     </div>
                   ))}
                 </div>
@@ -854,7 +854,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         return (
           <article className="surface p-4 md:p-5">
             <div className="flex items-center justify-between">
-              <p className="text-kicker font-medium text-tertiary">Score breakdown</p>
+              <p className="text-kicker text-tertiary">Score breakdown</p>
               <div className="flex flex-wrap items-center gap-2">
                 {reviewVm.scoreBand ? (
                   <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-ui-label text-muted">
@@ -880,7 +880,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                   <div key={label}>
                     <div className="flex items-center justify-between gap-2">
                       <div className="flex items-center gap-2">
-                        <span className={`text-ui-label font-medium ${isLowest ? "text-warning" : "text-white"}`}>{label}</span>
+                        <span className={`text-ui-label ${isLowest ? "text-warning" : "text-white"}`}>{label}</span>
                         {isLowest ? (
                           <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Lowest</span>
                         ) : null}
@@ -888,7 +888,7 @@ export default async function SessionReviewPage({ params, searchParams }: { para
                           <span className="rounded-full border border-warning/30 bg-warning/5 px-1.5 py-0.5 text-[9px] uppercase tracking-[0.1em] text-warning">Capped</span>
                         ) : null}
                       </div>
-                      <span className={`font-mono tabular-nums ${isLowest ? "text-body font-semibold text-warning" : "text-ui-label font-medium text-white"}`}>{component.score}</span>
+                      <span className={`font-mono tabular-nums ${isLowest ? "text-body font-medium text-warning" : "text-ui-label text-white"}`}>{component.score}</span>
                     </div>
                     <p className="mt-1.5 text-ui-label leading-snug text-muted">{component.detail}</p>
                   </div>


### PR DESCRIPTION
Stacks on #297. Step 4 of the audit's 4-step rollout: now that weight works as a hierarchy lever again, this PR audits the `font-semibold` / `font-medium` overrides on every size utility and cleans them up.

## Two kinds of changes

**1. Drop redundant weight tokens** where the class already matches the utility default (zero visual change):
- `text-kicker font-medium` → `text-kicker` (both 500)
- `text-ui-label font-medium` → `text-ui-label` (both 500)
- `text-section-title font-medium` → `text-section-title` (both 500)
- `text-page-title font-semibold` → `text-page-title` (both 600)
- `text-page-hero font-semibold` → `text-page-hero` (both 600)

**2. Demote `text-body font-semibold` → `text-body font-medium`** across every callsite. The audit's exact diagnosis: *"most body text wants 500 or 400 with a larger size, not a bold."* Body copy forced to 600 was the single biggest reason hierarchy used to feel flat.

## Kept as-is (genuine emphasis above utility default)
- `text-section-title font-semibold` on H2s (weekly-debrief, week-ahead stats, Week Progress, Ask coach follow-up, feel summary value) — deliberate H2 bump.
- `text-ui-label font-semibold` on status chips / nav pills / score wheel / progress-glance badges — interactive status.
- `text-kicker font-semibold` on louder alert kickers (Race day / Recovery mode / etc.) — pedagogical weight.
- Display heroes (`text-4xl`, `text-6xl`, `text-7xl`) — bespoke numbers outside the 6-row scale.

## Scope
Same 16 files as #296 + #297 (session-review + dashboard). Future stage-2 surfaces will handle their weight audit inline with the size swaps, not as a follow-up.

## Test plan
- [ ] `npm run typecheck` — clean (verified)
- [ ] Visual: section H2s render at 500 not 600 where appropriate; body copy no longer bolds itself; the hierarchy tiers ↔ kicker/body/section/page are now clearly distinct in weight as well as size

🤖 Generated with [Claude Code](https://claude.com/claude-code)