### PR TITLE
feat(design-system): F02 stage 2c — remaining surfaces on canonical type scale

### DIFF
--- a/app/(protected)/account-menu.tsx
+++ b/app/(protected)/account-menu.tsx
@@ -49,7 +49,7 @@ export function AccountMenu({ avatarUrl, initials, displayName, email, signOutAc
             className="h-9 w-9 rounded-full object-cover"
           />
         ) : (
-          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[var(--color-accent-muted)] text-xs font-medium text-accent">
+          <span className="flex h-9 w-9 items-center justify-center rounded-full bg-[var(--color-accent-muted)] text-ui-label text-accent">
             {initials}
           </span>
         )}
@@ -58,24 +58,24 @@ export function AccountMenu({ avatarUrl, initials, displayName, email, signOutAc
       <div className="absolute right-0 z-50 mt-2 w-64 rounded-md border border-[var(--border-default)] bg-[var(--color-surface-overlay)] p-3">
         <div className="border-b border-[var(--border-subtle)] pb-3">
           <p className="label-base">Account</p>
-          <p className="mt-1 text-sm font-medium text-[hsl(var(--fg))]">{displayName}</p>
-          <p className="text-xs text-muted">{email}</p>
+          <p className="mt-1 text-body font-medium text-[hsl(var(--fg))]">{displayName}</p>
+          <p className="text-ui-label text-muted">{email}</p>
         </div>
 
         <div className="mt-3 space-y-1">
-          <Link href="/settings" onClick={closeMenu} className="block rounded-md px-2 py-1.5 text-sm text-[hsl(var(--fg-muted))] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]">
+          <Link href="/settings" onClick={closeMenu} className="block rounded-md px-2 py-1.5 text-body text-[hsl(var(--fg-muted))] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]">
             Account
           </Link>
-          <Link href="/settings/race" onClick={closeMenu} className="block rounded-md px-2 py-1.5 text-sm text-[hsl(var(--fg-muted))] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]">
+          <Link href="/settings/race" onClick={closeMenu} className="block rounded-md px-2 py-1.5 text-body text-[hsl(var(--fg-muted))] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]">
             Race settings
           </Link>
-          <Link href="/settings/integrations" onClick={closeMenu} className="block rounded-md px-2 py-1.5 text-sm text-[hsl(var(--fg-muted))] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]">
+          <Link href="/settings/integrations" onClick={closeMenu} className="block rounded-md px-2 py-1.5 text-body text-[hsl(var(--fg-muted))] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]">
             Integrations
           </Link>
         </div>
 
         <form action={signOutAction} className="mt-3 border-t border-[var(--border-subtle)] pt-3">
-          <button onClick={closeMenu} className="w-full rounded-md px-2 py-1.5 text-left text-sm text-[hsl(var(--fg-muted))] transition hover:bg-[var(--color-danger-muted)] hover:text-[var(--color-danger)]">
+          <button onClick={closeMenu} className="w-full rounded-md px-2 py-1.5 text-left text-body text-[hsl(var(--fg-muted))] transition hover:bg-[var(--color-danger-muted)] hover:text-[var(--color-danger)]">
             Sign out
           </button>
         </form>

--- a/app/(protected)/activities/[activityId]/activity-linking-card.tsx
+++ b/app/(protected)/activities/[activityId]/activity-linking-card.tsx
@@ -35,26 +35,26 @@ export function ActivityLinkingCard({
       <article className="surface p-4">
         {linkedSession ? (
           <>
-            <h2 className="text-sm font-semibold">Linked planned session</h2>
-            <div className="surface-subtle mt-3 rounded-lg p-3 text-sm">
+            <h2 className="text-body font-medium">Linked planned session</h2>
+            <div className="surface-subtle mt-3 rounded-lg p-3 text-body">
               <p className="font-medium">{linkedSession.type}</p>
-              <p className="text-xs text-muted">{linkedSession.sport} · {linkedSession.date}</p>
-              <p className="mt-1 text-xs text-muted">Planned {linkedSession.duration_minutes ?? "—"} min</p>
+              <p className="text-ui-label text-muted">{linkedSession.sport} · {linkedSession.date}</p>
+              <p className="mt-1 text-ui-label text-muted">Planned {linkedSession.duration_minutes ?? "—"} min</p>
             </div>
             <div className="mt-3 flex gap-2">
-              <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void unlinkActivityAction(activityId))}>Unlink</button>
-              <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void unlinkActivityAction(activityId))}>Change link…</button>
+              <button className="btn-secondary text-ui-label" disabled={pending} onClick={() => startTransition(async () => void unlinkActivityAction(activityId))}>Unlink</button>
+              <button className="btn-secondary text-ui-label" disabled={pending} onClick={() => startTransition(async () => void unlinkActivityAction(activityId))}>Change link…</button>
             </div>
           </>
         ) : (
           <>
-            <h2 className="text-sm font-semibold">Attach to planned session</h2>
+            <h2 className="text-body font-medium">Attach to planned session</h2>
             {candidates.length === 0 ? (
-              <p className="mt-2 text-sm text-muted">No planned sessions found for this day.</p>
+              <p className="mt-2 text-body text-muted">No planned sessions found for this day.</p>
             ) : (
               <ul className="mt-3 space-y-2">
                 {candidates.slice(0, 3).map((candidate) => (
-                  <li key={candidate.id} className="surface-subtle rounded-lg p-3 text-sm">
+                  <li key={candidate.id} className="surface-subtle rounded-lg p-3 text-body">
                     <label className="flex cursor-pointer items-start gap-2">
                       <input
                         type="radio"
@@ -66,8 +66,8 @@ export function ActivityLinkingCard({
                       />
                       <span>
                         <span className="font-medium">{candidate.type}</span>
-                        <span className="block text-xs text-muted">{candidate.sport} · {candidate.date}</span>
-                        <span className="block text-xs text-muted">{candidate.duration_minutes ?? "—"} min {candidate.isRecommended ? "· Recommended" : ""}</span>
+                        <span className="block text-ui-label text-muted">{candidate.sport} · {candidate.date}</span>
+                        <span className="block text-ui-label text-muted">{candidate.duration_minutes ?? "—"} min {candidate.isRecommended ? "· Recommended" : ""}</span>
                       </span>
                     </label>
                   </li>
@@ -77,7 +77,7 @@ export function ActivityLinkingCard({
             <div className="mt-3 flex flex-wrap gap-2">
               {candidates.length > 0 && (
                 <button
-                  className="btn-primary text-xs"
+                  className="btn-primary text-ui-label"
                   disabled={pending || !selectedSessionId}
                   onClick={() => startTransition(async () => {
                     const result = await linkActivityAction(activityId, selectedSessionId);
@@ -87,20 +87,20 @@ export function ActivityLinkingCard({
                   Link activity
                 </button>
               )}
-              <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void markUnplannedAction(activityId))}>This wasn&apos;t planned</button>
+              <button className="btn-secondary text-ui-label" disabled={pending} onClick={() => startTransition(async () => void markUnplannedAction(activityId))}>This wasn&apos;t planned</button>
             </div>
-            {isUnplanned ? <p className="mt-2 text-xs text-muted">Marked as intentionally unplanned.</p> : null}
+            {isUnplanned ? <p className="mt-2 text-ui-label text-muted">Marked as intentionally unplanned.</p> : null}
           </>
         )}
       </article>
 
       <article className="surface p-4">
-        <h3 className="text-sm font-semibold">Quick actions</h3>
+        <h3 className="text-body font-medium">Quick actions</h3>
         <div className="mt-3 space-y-2">
-          <label className="block text-xs text-muted">Notes</label>
+          <label className="block text-ui-label text-muted">Notes</label>
           <textarea className="input-base min-h-24 w-full" value={notes} onChange={(event) => setNotes(event.target.value)} />
           <button
-            className="btn-secondary text-xs"
+            className="btn-secondary text-ui-label"
             disabled={pending}
             onClick={() => startTransition(async () => {
               const result = await updateActivityNotesAction(activityId, notes);
@@ -110,13 +110,13 @@ export function ActivityLinkingCard({
             Add note
           </button>
         </div>
-        <button className="btn-secondary mt-3 text-xs" disabled={pending} onClick={() => startTransition(async () => void toggleRaceAction(activityId, !isRace))}>
+        <button className="btn-secondary mt-3 text-ui-label" disabled={pending} onClick={() => startTransition(async () => void toggleRaceAction(activityId, !isRace))}>
           {isRace ? "Unmark race" : "Mark as race"}
         </button>
-        {message ? <p className="mt-2 text-xs text-muted">{message}</p> : null}
+        {message ? <p className="mt-2 text-ui-label text-muted">{message}</p> : null}
         <div className="mt-4 border-t border-white/10 pt-3">
           <button
-            className="btn-secondary text-xs text-rose-400"
+            className="btn-secondary text-ui-label text-rose-400"
             disabled={pending}
             onClick={() => {
               const msg = externalProvider === "strava"

--- a/app/(protected)/activities/[activityId]/page.tsx
+++ b/app/(protected)/activities/[activityId]/page.tsx
@@ -138,21 +138,21 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
 
   return (
     <section className="space-y-4">
-      <Link href="/dashboard" className="text-sm text-cyan-300 underline-offset-2 hover:underline">← Back to Dashboard</Link>
+      <Link href="/dashboard" className="text-body text-cyan-300 underline-offset-2 hover:underline">← Back to Dashboard</Link>
 
       <div className="grid gap-4 lg:grid-cols-[1.3fr_0.8fr]">
         <div className="space-y-4">
           <article className="surface p-5">
             <div className="flex items-start justify-between gap-3">
               <div>
-                <h1 className="text-2xl font-semibold">{sportIcon(activity.sport_type)} Activity</h1>
-                <p className="mt-1 text-sm text-muted">{dateLabel}</p>
-                <div className="mt-2 flex flex-wrap gap-2 text-xs">
+                <h1 className="text-page-title">{sportIcon(activity.sport_type)} Activity</h1>
+                <p className="mt-1 text-body text-muted">{dateLabel}</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-ui-label">
                   <SourceBadge source={activity.source} externalProvider={activity.external_provider} externalActivityId={activity.external_activity_id} externalTitle={activity.external_title} />
                   <span className="rounded-full border border-[hsl(var(--border))] px-2 py-1">{linkedSession ? "Linked" : "Unassigned"}</span>
                   {!linkedSession ? <span className="rounded-full border border-[hsl(var(--signal-risk)/0.5)] bg-[hsl(var(--signal-risk)/0.12)] px-2 py-1 text-[hsl(var(--signal-risk))]">Unscheduled</span> : null}
                 </div>
-                {!linkedSession ? <p className="mt-2 text-xs text-muted">This uploaded activity counts as extra work even without a planned slot.</p> : null}
+                {!linkedSession ? <p className="mt-2 text-ui-label text-muted">This uploaded activity counts as extra work even without a planned slot.</p> : null}
               </div>
             </div>
           </article>
@@ -160,15 +160,15 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
           <article className="grid gap-3 sm:grid-cols-2 xl:grid-cols-5">
             {loadCards.map(([label, value]) => (
               <div key={label} className="surface p-4">
-                <p className="text-xs text-muted">{label}</p>
-                <p className="mt-1 text-xl font-semibold tabular-nums">{value}</p>
+                <p className="text-ui-label text-muted">{label}</p>
+                <p className="mt-1 text-page-title tabular-nums">{value}</p>
               </div>
             ))}
           </article>
 
           <article className="surface p-5">
-            <h2 className="text-sm font-semibold">Key details</h2>
-            <dl className="mt-3 grid grid-cols-2 gap-2 text-sm lg:grid-cols-3">
+            <h2 className="text-body font-medium">Key details</h2>
+            <dl className="mt-3 grid grid-cols-2 gap-2 text-body lg:grid-cols-3">
               <dt className="text-muted">Start time</dt><dd>{new Date(activity.start_time_utc).toLocaleString()}</dd>
               <dt className="text-muted">End time</dt><dd>{activity.end_time_utc ? new Date(activity.end_time_utc).toLocaleString() : "—"}</dd>
               <dt className="text-muted">Calories</dt><dd>{activity.calories ?? "—"}</dd>
@@ -187,16 +187,16 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
           {(powerZones.length > 0 || hrZones.length > 0) ? (
             <article className="surface p-5">
               <div className="flex flex-wrap items-center justify-between gap-2">
-                <h2 className="text-sm font-semibold">Zone distribution</h2>
-                <p className="text-xs text-muted">Source-backed time in zone from Garmin FIT</p>
+                <h2 className="text-body font-medium">Zone distribution</h2>
+                <p className="text-ui-label text-muted">Source-backed time in zone from Garmin FIT</p>
               </div>
               <div className={`mt-4 grid gap-4 ${powerZones.length > 0 && hrZones.length > 0 ? "lg:grid-cols-2" : ""}`}>
                 {powerZones.length > 0 ? (
                   <div>
-                    <p className="text-xs uppercase tracking-[0.14em] text-muted">Power</p>
+                    <p className="text-kicker text-muted">Power</p>
                     <div className="mt-3 space-y-2">
                       {powerZones.map((zone) => (
-                        <div key={`power-${zone.zone}`} className="flex items-center justify-between rounded-xl border border-white/10 px-3 py-2 text-sm">
+                        <div key={`power-${zone.zone}`} className="flex items-center justify-between rounded-xl border border-white/10 px-3 py-2 text-body">
                           <span>Z{zone.zone} · {formatZoneRange(zone.powerMin, zone.powerMax, "w")}</span>
                           <span className="tabular-nums text-muted">{formatSeconds(zone.durationSec)}{zone.pctOfSession !== null ? ` · ${Math.round(zone.pctOfSession * 100)}%` : ""}</span>
                         </div>
@@ -206,10 +206,10 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
                 ) : null}
                 {hrZones.length > 0 ? (
                   <div>
-                    <p className="text-xs uppercase tracking-[0.14em] text-muted">Heart rate</p>
+                    <p className="text-kicker text-muted">Heart rate</p>
                     <div className="mt-3 space-y-2">
                       {hrZones.map((zone) => (
-                        <div key={`hr-${zone.zone}`} className="flex items-center justify-between rounded-xl border border-white/10 px-3 py-2 text-sm">
+                        <div key={`hr-${zone.zone}`} className="flex items-center justify-between rounded-xl border border-white/10 px-3 py-2 text-body">
                           <span>Z{zone.zone} · {formatZoneRange(zone.heartRateMin, zone.heartRateMax, "bpm")}</span>
                           <span className="tabular-nums text-muted">{formatSeconds(zone.durationSec)}{zone.pctOfSession !== null ? ` · ${Math.round(zone.pctOfSession * 100)}%` : ""}</span>
                         </div>
@@ -222,14 +222,14 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
           ) : null}
 
           <article className="surface p-5">
-            <h2 className="text-sm font-semibold">Splits / intervals</h2>
+            <h2 className="text-body font-medium">Splits / intervals</h2>
             {laps.length === 0 ? (
-              <p className="mt-3 text-sm text-muted">Splits coming soon.</p>
+              <p className="mt-3 text-body text-muted">Splits coming soon.</p>
             ) : (
               <div className="mt-3 overflow-auto">
-                <table className="min-w-full text-sm">
+                <table className="min-w-full text-body">
                   <thead>
-                    <tr className="text-left text-xs uppercase text-muted">
+                    <tr className="text-left text-ui-label uppercase text-muted">
                       <th>Lap</th>
                       <th>Time</th>
                       <th>Distance</th>

--- a/app/(protected)/components/coach-panel.tsx
+++ b/app/(protected)/components/coach-panel.tsx
@@ -164,8 +164,8 @@ export function CoachPanel() {
         {/* Header */}
         <div className="flex items-center justify-between border-b border-[rgba(255,255,255,0.08)] px-4 py-3">
           <div className="flex items-center gap-2">
-            <span className="text-sm font-semibold text-white">Coach</span>
-            <Link href="/coach" className="text-[11px] text-cyan-400 hover:text-cyan-300" onClick={close}>
+            <span className="text-body font-medium text-white">Coach</span>
+            <Link href="/coach" className="text-ui-label text-cyan-400 hover:text-cyan-300" onClick={close}>
               Open full →
             </Link>
           </div>
@@ -186,14 +186,14 @@ export function CoachPanel() {
         <div className="flex-1 overflow-y-auto px-4 py-3">
           {messages.length === 0 ? (
             <div className="flex h-full items-center justify-center">
-              <p className="text-sm text-tertiary">Ask your coach anything about your training.</p>
+              <p className="text-body text-tertiary">Ask your coach anything about your training.</p>
             </div>
           ) : (
             <div className="space-y-3">
               {messages.map((message) => (
                 <div
                   key={message.id}
-                  className={`rounded-xl px-3 py-2.5 text-sm leading-relaxed ${
+                  className={`rounded-xl px-3 py-2.5 text-body leading-relaxed ${
                     message.role === "user"
                       ? "ml-8 bg-[hsl(var(--accent)/0.12)] text-white"
                       : "mr-4 bg-[rgba(255,255,255,0.04)] text-[rgba(255,255,255,0.85)]"
@@ -204,7 +204,7 @@ export function CoachPanel() {
               ))}
               {isLoading && messages[messages.length - 1]?.role === "user" ? (
                 <div className="mr-4 rounded-xl bg-[rgba(255,255,255,0.04)] px-3 py-2.5">
-                  <span className="inline-flex gap-1 text-sm text-tertiary">
+                  <span className="inline-flex gap-1 text-body text-tertiary">
                     <span className="animate-pulse">Thinking</span>
                     <span className="animate-pulse" style={{ animationDelay: "0.2s" }}>.</span>
                     <span className="animate-pulse" style={{ animationDelay: "0.4s" }}>.</span>
@@ -232,12 +232,12 @@ export function CoachPanel() {
               }}
               placeholder="Ask your coach..."
               rows={1}
-              className="flex-1 resize-none rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-sm text-white placeholder:text-tertiary focus:border-[rgba(255,255,255,0.2)] focus:outline-none"
+              className="flex-1 resize-none rounded-lg border border-[rgba(255,255,255,0.1)] bg-[rgba(255,255,255,0.04)] px-3 py-2 text-body text-white placeholder:text-tertiary focus:border-[rgba(255,255,255,0.2)] focus:outline-none"
             />
             <button
               type="submit"
               disabled={isLoading || input.trim().length < 3}
-              className="rounded-lg bg-[hsl(var(--accent))] px-3 py-2 text-sm font-medium text-black transition hover:opacity-90 disabled:opacity-40"
+              className="rounded-lg bg-[hsl(var(--accent))] px-3 py-2 text-body font-medium text-black transition hover:opacity-90 disabled:opacity-40"
             >
               Send
             </button>

--- a/app/(protected)/debrief/components/share-card-modal.tsx
+++ b/app/(protected)/debrief/components/share-card-modal.tsx
@@ -97,7 +97,7 @@ export function ShareCardModal({ weekOf, displayName, onClose }: Props) {
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" onClick={(e) => { if (e.target === e.currentTarget) onClose(); }}>
       <div className="w-full max-w-md rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--bg-card))] p-6">
         <div className="flex items-center justify-between">
-          <h2 className="text-lg font-semibold">Share your week</h2>
+          <h2 className="text-section-title font-semibold">Share your week</h2>
           <button type="button" onClick={onClose} className="text-tertiary hover:text-white" aria-label="Close">
             <svg width="20" height="20" viewBox="0 0 20 20" fill="none"><path d="M15 5L5 15M5 5l10 10" stroke="currentColor" strokeWidth="2" strokeLinecap="round"/></svg>
           </button>
@@ -142,10 +142,10 @@ export function ShareCardModal({ weekOf, displayName, onClose }: Props) {
                     : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] hover:border-[rgba(255,255,255,0.2)]"
                 }`}
               >
-                <span className={`text-xs font-medium ${isSelected ? "text-[var(--color-accent)]" : "text-white"}`}>
+                <span className={`text-ui-label ${isSelected ? "text-[var(--color-accent)]" : "text-white"}`}>
                   {opt.label}
                 </span>
-                <span className="text-[10px] text-tertiary">{opt.ratio}</span>
+                <span className="text-ui-label text-tertiary">{opt.ratio}</span>
               </button>
             );
           })}
@@ -153,7 +153,7 @@ export function ShareCardModal({ weekOf, displayName, onClose }: Props) {
 
         {/* Name toggle — only shown when user has a display name */}
         {hasName ? (
-          <label className="mt-4 flex items-center gap-2 text-sm text-muted">
+          <label className="mt-4 flex items-center gap-2 text-body text-muted">
             <input
               type="checkbox"
               checked={showName}
@@ -163,7 +163,7 @@ export function ShareCardModal({ weekOf, displayName, onClose }: Props) {
             Show athlete name
           </label>
         ) : (
-          <p className="mt-4 text-xs text-tertiary">
+          <p className="mt-4 text-ui-label text-tertiary">
             Set a display name in <a href="/settings/athlete-context" className="underline hover:text-white">Settings</a> to include your name on the card.
           </p>
         )}
@@ -175,7 +175,7 @@ export function ShareCardModal({ weekOf, displayName, onClose }: Props) {
               type="button"
               onClick={() => void handleShare()}
               disabled={generating}
-              className="btn-primary flex-1 px-4 py-2.5 text-sm disabled:opacity-40"
+              className="btn-primary flex-1 px-4 py-2.5 text-body disabled:opacity-40"
             >
               {generating ? "Generating…" : "Share"}
             </button>
@@ -184,7 +184,7 @@ export function ShareCardModal({ weekOf, displayName, onClose }: Props) {
             type="button"
             onClick={() => void handleDownload()}
             disabled={generating}
-            className={`${typeof navigator !== "undefined" && "share" in navigator ? "btn-secondary" : "btn-primary"} flex-1 px-4 py-2.5 text-sm disabled:opacity-40`}
+            className={`${typeof navigator !== "undefined" && "share" in navigator ? "btn-secondary" : "btn-primary"} flex-1 px-4 py-2.5 text-body disabled:opacity-40`}
           >
             {generating ? "Generating…" : "Download"}
           </button>

--- a/app/(protected)/debrief/components/share-summary-button.tsx
+++ b/app/(protected)/debrief/components/share-summary-button.tsx
@@ -16,7 +16,7 @@ export function ShareSummaryButton({ weekOf, displayName }: Props) {
       <button
         type="button"
         onClick={() => setShowModal(true)}
-        className="btn-primary inline-flex items-center gap-1.5 px-3 py-1.5 text-xs"
+        className="btn-primary inline-flex items-center gap-1.5 px-3 py-1.5 text-ui-label"
       >
         <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" aria-hidden="true">
           <path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />

--- a/app/(protected)/debrief/debrief-feedback-card.tsx
+++ b/app/(protected)/debrief/debrief-feedback-card.tsx
@@ -56,8 +56,8 @@ export function DebriefFeedbackCard({ weekStart, initialHelpful, initialAccurate
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <p className="label">Feedback</p>
-          <h2 className="mt-1 text-lg font-semibold">Did this match the week?</h2>
-          <p className="mt-2 max-w-2xl text-sm text-muted">A quick signal is enough. Add a note only if something felt missing, overstated, or especially useful.</p>
+          <h2 className="mt-1 text-section-title font-semibold">Did this match the week?</h2>
+          <p className="mt-2 max-w-2xl text-body text-muted">A quick signal is enough. Add a note only if something felt missing, overstated, or especially useful.</p>
         </div>
         {isSaving ? <span className="debrief-pill">Saving…</span> : null}
       </div>
@@ -69,14 +69,14 @@ export function DebriefFeedbackCard({ weekStart, initialHelpful, initialAccurate
             <button
               type="button"
               onClick={() => void save({ helpful: true })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${helpful === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${helpful === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               Yes
             </button>
             <button
               type="button"
               onClick={() => void save({ helpful: false })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${helpful === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${helpful === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               No
             </button>
@@ -89,14 +89,14 @@ export function DebriefFeedbackCard({ weekStart, initialHelpful, initialAccurate
             <button
               type="button"
               onClick={() => void save({ accurate: true })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${accurate === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${accurate === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               Yes
             </button>
             <button
               type="button"
               onClick={() => void save({ accurate: false })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${accurate === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${accurate === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               No
             </button>
@@ -111,7 +111,7 @@ export function DebriefFeedbackCard({ weekStart, initialHelpful, initialAccurate
           >
             {showNoteEditor ? "Hide note" : note.trim() ? "Edit note" : "Add note"}
           </button>
-          {status ? <p className="text-xs text-muted">{status}</p> : null}
+          {status ? <p className="text-ui-label text-muted">{status}</p> : null}
         </div>
       </div>
 
@@ -133,7 +133,7 @@ export function DebriefFeedbackCard({ weekStart, initialHelpful, initialAccurate
               type="button"
               onClick={() => void save({ note })}
               disabled={isSaving}
-              className="btn-secondary px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-60"
+              className="btn-secondary px-3 py-1.5 text-ui-label disabled:cursor-not-allowed disabled:opacity-60"
             >
               Save note
             </button>

--- a/app/(protected)/debrief/loading.tsx
+++ b/app/(protected)/debrief/loading.tsx
@@ -27,7 +27,7 @@ export default function DebriefLoading() {
           <div className="h-8 w-8 animate-spin rounded-full border-2 border-[hsl(var(--border))] border-t-[hsl(var(--accent-performance))]" />
 
           {/* Current step message */}
-          <p className="text-sm font-medium text-white">
+          <p className="text-body font-medium text-white">
             {steps[activeStep]}&hellip;
           </p>
 

--- a/app/(protected)/debrief/page.tsx
+++ b/app/(protected)/debrief/page.tsx
@@ -150,12 +150,12 @@ export default async function DebriefPage({
           <div className="flex items-start justify-between gap-3">
             <div>
               <p className="label">Weekly Debrief</p>
-              <h1 className="mt-1 text-2xl font-semibold">Generating your debrief…</h1>
-              <p className="mt-2 max-w-2xl text-sm text-muted">
+              <h1 className="mt-1 text-page-title">Generating your debrief…</h1>
+              <p className="mt-2 max-w-2xl text-body text-muted">
                 We&rsquo;re pulling this week&rsquo;s sessions together. This usually takes 20–40 seconds — the page will update automatically when it&rsquo;s ready.
               </p>
             </div>
-            <span className="rounded-full border border-[hsl(var(--border))] px-3 py-1 text-xs text-tertiary">
+            <span className="rounded-full border border-[hsl(var(--border))] px-3 py-1 text-ui-label text-tertiary">
               {formatDebriefDate(snapshot.weekStart)} – {formatDebriefDate(snapshot.weekEnd)}
             </span>
           </div>
@@ -174,35 +174,35 @@ export default async function DebriefPage({
       <section className="space-y-4">
         <article className="surface p-5">
           <p className="label">Weekly Debrief</p>
-          <h1 className="mt-1 text-2xl font-semibold">Not enough signal yet</h1>
-          <p className="mt-2 max-w-2xl text-sm text-muted">{snapshot.readiness.reason}</p>
+          <h1 className="mt-1 text-page-title">Not enough signal yet</h1>
+          <p className="mt-2 max-w-2xl text-body text-muted">{snapshot.readiness.reason}</p>
 
           <div className="mt-4 grid grid-cols-2 gap-3 sm:grid-cols-3">
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-[11px] uppercase tracking-[0.1em] text-tertiary">Week</p>
-              <p className="mt-2 text-sm font-medium">{formatDebriefDate(snapshot.weekStart)} – {formatDebriefDate(snapshot.weekEnd)}</p>
+              <p className="text-kicker uppercase tracking-[0.1em] text-tertiary">Week</p>
+              <p className="mt-2 text-body font-medium">{formatDebriefDate(snapshot.weekStart)} – {formatDebriefDate(snapshot.weekEnd)}</p>
             </div>
             {snapshot.readiness.totalKeySessions > 0 ? (
               <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-                <p className="text-[11px] uppercase tracking-[0.1em] text-tertiary">Key sessions</p>
-                <p className="mt-2 text-sm font-medium">{snapshot.readiness.resolvedKeySessions}/{snapshot.readiness.totalKeySessions} resolved</p>
+                <p className="text-kicker uppercase tracking-[0.1em] text-tertiary">Key sessions</p>
+                <p className="mt-2 text-body font-medium">{snapshot.readiness.resolvedKeySessions}/{snapshot.readiness.totalKeySessions} resolved</p>
               </div>
             ) : null}
             {snapshot.readiness.plannedMinutes > 0 ? (
               <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-                <p className="text-[11px] uppercase tracking-[0.1em] text-tertiary">Resolved time</p>
-                <p className="mt-2 text-sm font-medium">{formatDuration(snapshot.readiness.resolvedMinutes)} / {formatDuration(snapshot.readiness.plannedMinutes)}</p>
+                <p className="text-kicker uppercase tracking-[0.1em] text-tertiary">Resolved time</p>
+                <p className="mt-2 text-body font-medium">{formatDuration(snapshot.readiness.resolvedMinutes)} / {formatDuration(snapshot.readiness.plannedMinutes)}</p>
               </div>
             ) : null}
           </div>
 
-          <p className="mt-4 text-xs text-tertiary">Complete 2+ key sessions to unlock your weekly analysis with trends, benchmarks, and coaching notes.</p>
+          <p className="mt-4 text-ui-label text-tertiary">Complete 2+ key sessions to unlock your weekly analysis with trends, benchmarks, and coaching notes.</p>
 
           <div className="mt-3 flex flex-wrap gap-2">
-            <a href="/dashboard" className="btn-secondary px-3 text-xs">
+            <a href="/dashboard" className="btn-secondary px-3 text-ui-label">
               Back to dashboard
             </a>
-            <a href="/calendar" className="btn-secondary px-3 text-xs">
+            <a href="/calendar" className="btn-secondary px-3 text-ui-label">
               View calendar
             </a>
           </div>
@@ -260,9 +260,9 @@ export default async function DebriefPage({
       <article className="debrief-hero surface p-4 sm:p-6 md:p-7">
         {macroArcLine ? (
           <div className="relative mb-4 flex flex-wrap items-center gap-3 border-b border-[rgba(255,255,255,0.07)] pb-4">
-            <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-[rgba(255,255,255,0.6)]">{macroArcLine}</p>
+            <p className="text-kicker text-[rgba(255,255,255,0.6)]">{macroArcLine}</p>
             {cumulativeVolumeLine ? (
-              <p className="text-[11px] text-[rgba(255,255,255,0.45)]">{cumulativeVolumeLine}</p>
+              <p className="text-ui-label text-[rgba(255,255,255,0.45)]">{cumulativeVolumeLine}</p>
             ) : null}
           </div>
         ) : null}
@@ -274,17 +274,17 @@ export default async function DebriefPage({
               <span className={statePillClass(artifact.facts.artifactStateLabel, snapshot.stale)}>{stateLabel(artifact.facts.artifactStateLabel, snapshot.stale)}</span>
               <span className={narrativeSourcePillClass(artifact.facts.narrativeSource)}>{narrativeSourceLabel(artifact.facts.narrativeSource)}</span>
             </div>
-            <h1 className="mt-4 max-w-4xl text-2xl font-semibold leading-[1.05] tracking-[-0.03em] sm:text-4xl md:text-[3.25rem]">{artifact.facts.title}</h1>
+            <h1 className="mt-4 max-w-4xl text-page-title leading-[1.05] tracking-[-0.03em] sm:text-4xl md:text-[3.25rem]">{artifact.facts.title}</h1>
             <p className="mt-3 max-w-3xl text-[15px] leading-7 text-white">{artifact.facts.statusLine}</p>
             {snapshot.stale ? (
-              <p className="mt-3 max-w-2xl text-sm text-muted">The week changed after this version was saved.</p>
+              <p className="mt-3 max-w-2xl text-body text-muted">The week changed after this version was saved.</p>
             ) : artifact.facts.artifactStateNote ? (
-              <p className="mt-3 max-w-2xl text-sm text-muted">{artifact.facts.artifactStateNote}</p>
+              <p className="mt-3 max-w-2xl text-body text-muted">{artifact.facts.artifactStateNote}</p>
             ) : null}
           </div>
           <div className="relative z-10 flex min-w-[220px] flex-col items-start gap-3">
             <div className="flex flex-wrap items-center gap-2">
-              <a href={`/debrief/coach?weekStart=${artifact.weekStart}`} className="btn-secondary px-3 text-xs">
+              <a href={`/debrief/coach?weekStart=${artifact.weekStart}`} className="btn-secondary px-3 text-ui-label">
                 Coach brief
               </a>
               <DebriefRefreshButton weekStart={artifact.weekStart} />
@@ -293,7 +293,7 @@ export default async function DebriefPage({
             <ShareSummaryButton weekOf={artifact.weekStart} displayName={athleteDisplayName} />
             <a
               href={`/coach?prompt=${encodeURIComponent(`Let's discuss my week of ${artifact.facts.weekRange}. ${artifact.narrative.executiveSummary.split(".")[0]}.`)}`}
-              className="btn-secondary inline-flex items-center gap-1.5 px-3 py-1.5 text-xs"
+              className="btn-secondary inline-flex items-center gap-1.5 px-3 py-1.5 text-ui-label"
             >
               Discuss with Coach
             </a>
@@ -304,8 +304,8 @@ export default async function DebriefPage({
           {artifact.facts.metrics.map((metric) => (
             <div key={metric.label} className={`${metricToneClass(metric.tone)} sm:min-h-[110px]`}>
               <p className="debrief-kicker">{metric.label}</p>
-              <p className="mt-4 text-xl font-semibold leading-tight text-white">{metric.value}</p>
-              {metric.detail ? <p className="mt-2 text-xs text-muted">{metric.detail}</p> : null}
+              <p className="mt-4 text-page-title leading-tight text-white">{metric.value}</p>
+              {metric.detail ? <p className="mt-2 text-ui-label text-muted">{metric.detail}</p> : null}
             </div>
           ))}
         </div>
@@ -327,19 +327,19 @@ export default async function DebriefPage({
         return (
           <article className="grid grid-cols-2 gap-3 sm:grid-cols-3">
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-[11px] uppercase tracking-[0.1em] text-tertiary">Sessions completed</p>
-              <p className="mt-2 text-sm font-medium">{sessionsLabel}</p>
-              <p className="mt-1 text-[11px] text-muted">vs {prevSessionsLabel} last week</p>
+              <p className="text-kicker uppercase tracking-[0.1em] text-tertiary">Sessions completed</p>
+              <p className="mt-2 text-body font-medium">{sessionsLabel}</p>
+              <p className="mt-1 text-ui-label text-muted">vs {prevSessionsLabel} last week</p>
             </div>
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-[11px] uppercase tracking-[0.1em] text-tertiary">Training time</p>
-              <p className="mt-2 text-sm font-medium">{timeLabel}</p>
-              <p className="mt-1 text-[11px] text-muted">vs {prevTimeLabel} last week</p>
+              <p className="text-kicker uppercase tracking-[0.1em] text-tertiary">Training time</p>
+              <p className="mt-2 text-body font-medium">{timeLabel}</p>
+              <p className="mt-1 text-ui-label text-muted">vs {prevTimeLabel} last week</p>
             </div>
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-[11px] uppercase tracking-[0.1em] text-tertiary">Execution quality</p>
-              <p className={`mt-2 text-sm font-medium ${qualityColor}`}>{qualityTrend}</p>
-              <p className="mt-1 text-[11px] text-muted">{artifact.facts.completionPct}% vs {prevFacts.completionPct ?? 0}% last week</p>
+              <p className="text-kicker uppercase tracking-[0.1em] text-tertiary">Execution quality</p>
+              <p className={`mt-2 text-body font-medium ${qualityColor}`}>{qualityTrend}</p>
+              <p className="mt-1 text-ui-label text-muted">{artifact.facts.completionPct}% vs {prevFacts.completionPct ?? 0}% last week</p>
             </div>
           </article>
         );
@@ -372,7 +372,7 @@ export default async function DebriefPage({
           <div className="mt-3 space-y-3">
             {artifact.narrative.highlights.map((item) => (
               <div key={item} className="debrief-list-card debrief-list-card--positive">
-                <p className="text-sm text-white">{item}</p>
+                <p className="text-body text-white">{item}</p>
               </div>
             ))}
           </div>
@@ -383,7 +383,7 @@ export default async function DebriefPage({
           <div className="mt-3 space-y-3">
             {artifact.narrative.observations.map((item) => (
               <div key={item} className="debrief-list-card debrief-list-card--notice">
-                <p className="text-sm text-white">{item}</p>
+                <p className="text-body text-white">{item}</p>
               </div>
             ))}
           </div>
@@ -394,7 +394,7 @@ export default async function DebriefPage({
         <div className="flex flex-wrap items-end justify-between gap-3">
           <div>
             <p className="debrief-kicker">Carry into next week</p>
-            <p className="mt-2 text-sm text-muted">Two reminders worth keeping in mind next week.</p>
+            <p className="mt-2 text-body text-muted">Two reminders worth keeping in mind next week.</p>
           </div>
         </div>
         <div className="mt-4 grid gap-3 md:grid-cols-2">
@@ -428,7 +428,7 @@ export default async function DebriefPage({
             {teach ? (
               <>
                 <p className="debrief-kicker mt-5">Why this matters</p>
-                <p className="mt-3 text-sm leading-6 text-muted">{teach}</p>
+                <p className="mt-3 text-body leading-6 text-muted">{teach}</p>
               </>
             ) : null}
           </article>
@@ -447,7 +447,7 @@ export default async function DebriefPage({
         <div className="flex flex-wrap items-start justify-between gap-3">
           <div>
             <p className="debrief-kicker">What supports this summary</p>
-            <p className="mt-2 text-sm text-muted">Open the supporting claims when you want to inspect the sessions behind them.</p>
+            <p className="mt-2 text-body text-muted">Open the supporting claims when you want to inspect the sessions behind them.</p>
           </div>
           {snapshot.stale ? <span className="debrief-pill signal-load">Week data changed since this version</span> : null}
         </div>
@@ -470,8 +470,8 @@ export default async function DebriefPage({
                 <div key={group.claim} className="debrief-list-card">
                   <div className="flex flex-wrap items-start justify-between gap-3">
                     <div className="max-w-3xl">
-                      <p className="text-sm font-semibold text-white">{group.claim}</p>
-                      <p className="mt-1.5 text-sm leading-6 text-muted">{group.detail}</p>
+                      <p className="text-body font-medium text-white">{group.claim}</p>
+                      <p className="mt-1.5 text-body leading-6 text-muted">{group.detail}</p>
                     </div>
                     <span className="debrief-pill">{group.supports.length} support{group.supports.length === 1 ? "" : "s"}</span>
                   </div>
@@ -479,8 +479,8 @@ export default async function DebriefPage({
                   <div className="mt-3 space-y-2.5">
                     {group.supports.map((support) => (
                       <a key={`${support.kind}-${support.id}`} href={support.href} className="block rounded-2xl border border-[hsl(var(--border))] bg-[rgba(255,255,255,0.02)] px-4 py-3 transition hover:border-[hsl(var(--accent)/0.42)]">
-                        <p className="text-sm font-medium text-white">{support.label}</p>
-                        <p className="mt-1.5 text-sm leading-6 text-muted">{support.reason}</p>
+                        <p className="text-body font-medium text-white">{support.label}</p>
+                        <p className="mt-1.5 text-body leading-6 text-muted">{support.reason}</p>
                       </a>
                     ))}
                   </div>
@@ -493,8 +493,8 @@ export default async function DebriefPage({
                     {artifact.evidence.map((item) => (
                       <a key={`${item.kind}-${item.id}`} href={item.href} className="debrief-list-card block transition hover:border-[hsl(var(--accent)/0.42)]">
                         <div>
-                          <p className="text-sm font-semibold text-white">{item.label}</p>
-                          <p className="mt-2 text-sm text-muted">{item.detail}</p>
+                          <p className="text-body font-medium text-white">{item.label}</p>
+                          <p className="mt-2 text-body text-muted">{item.detail}</p>
                         </div>
                       </a>
                     ))}
@@ -517,17 +517,17 @@ export default async function DebriefPage({
         <div className="flex flex-wrap items-center justify-between gap-3">
           <div className="flex flex-wrap gap-2">
             {adjacent.previousWeekStart ? (
-              <a href={`/debrief?weekStart=${adjacent.previousWeekStart}`} className="btn-secondary w-full px-3 text-xs sm:w-auto">
+              <a href={`/debrief?weekStart=${adjacent.previousWeekStart}`} className="btn-secondary w-full px-3 text-ui-label sm:w-auto">
                 Previous saved week
               </a>
             ) : null}
             {adjacent.nextWeekStart ? (
-              <a href={`/debrief?weekStart=${adjacent.nextWeekStart}`} className="btn-secondary w-full px-3 text-xs sm:w-auto">
+              <a href={`/debrief?weekStart=${adjacent.nextWeekStart}`} className="btn-secondary w-full px-3 text-ui-label sm:w-auto">
                 Next saved week
               </a>
             ) : null}
           </div>
-          <a href="/dashboard" className="inline-flex min-h-[44px] items-center text-xs text-muted underline-offset-2 hover:text-white hover:underline lg:min-h-0">
+          <a href="/dashboard" className="inline-flex min-h-[44px] items-center text-ui-label text-muted underline-offset-2 hover:text-white hover:underline lg:min-h-0">
             Back to dashboard
           </a>
         </div>
@@ -556,23 +556,23 @@ async function DebriefTrends(props: {
   return (
     <article className="debrief-section-card p-5">
       <p className="debrief-kicker">Trends</p>
-      <p className="mt-2 text-sm text-muted">Patterns observed over the last 6 weeks.</p>
+      <p className="mt-2 text-body text-muted">Patterns observed over the last 6 weeks.</p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {trends.map((trend) => (
           <div key={trend.metric} className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
             <div className="flex items-center justify-between gap-2">
-              <p className="text-xs font-medium text-muted">{trend.metric}</p>
-              <span className={`text-[11px] font-medium uppercase tracking-[0.08em] ${trend.direction === "improving" ? "text-success" : trend.direction === "declining" ? "text-danger" : "text-tertiary"}`}>
+              <p className="text-ui-label text-muted">{trend.metric}</p>
+              <span className={`text-ui-label uppercase tracking-[0.08em] ${trend.direction === "improving" ? "text-success" : trend.direction === "declining" ? "text-danger" : "text-tertiary"}`}>
                 {trend.direction === "improving" ? "▲ Improving" : trend.direction === "declining" ? "▼ Declining" : "Stable"}
               </span>
             </div>
-            <p className="mt-2 text-sm text-white">{trend.detail}</p>
+            <p className="mt-2 text-body text-white">{trend.detail}</p>
             <div className="mt-3 flex flex-wrap gap-1.5">
               {trend.dataPoints.slice(-4).map((pt) => (
-                <span key={pt.weekStart} className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[11px] text-tertiary">{pt.label}</span>
+                <span key={pt.weekStart} className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-ui-label text-tertiary">{pt.label}</span>
               ))}
             </div>
-            <p className="mt-2 text-[11px] text-tertiary">Confidence: {trend.confidence}</p>
+            <p className="mt-2 text-ui-label text-tertiary">Confidence: {trend.confidence}</p>
           </div>
         ))}
       </div>
@@ -600,21 +600,21 @@ async function DebriefBenchmarks(props: {
   return (
     <article className="debrief-section-card p-5">
       <p className="debrief-kicker">Best efforts</p>
-      <p className="mt-2 text-sm text-muted">Training-block bests from the last 12 weeks.</p>
+      <p className="mt-2 text-body text-muted">Training-block bests from the last 12 weeks.</p>
       <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
         {benchmarks.map((benchmark) => (
           <a key={benchmark.activityId} href={`/activities/${benchmark.activityId}`} className="block rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4 transition hover:border-[hsl(var(--accent)/0.42)]">
             <div className="flex items-center gap-2">
               <span>{benchmark.sport === "run" ? "🏃" : benchmark.sport === "bike" ? "🚴" : "🏊"}</span>
-              <p className="text-xs font-medium text-muted">{benchmark.label}</p>
+              <p className="text-ui-label text-muted">{benchmark.label}</p>
             </div>
-            <p className="mt-2 text-xl font-semibold leading-tight text-white">{benchmark.formattedValue}</p>
+            <p className="mt-2 text-page-title leading-tight text-white">{benchmark.formattedValue}</p>
             {benchmark.isThisWeek ? (
-              <span className="mt-1 inline-block text-[11px] font-medium uppercase tracking-[0.08em] text-success">New this week</span>
+              <span className="mt-1 inline-block text-ui-label uppercase tracking-[0.08em] text-success">New this week</span>
             ) : null}
-            <p className="mt-1 text-sm text-muted">{benchmark.detail}</p>
+            <p className="mt-1 text-body text-muted">{benchmark.detail}</p>
             {benchmark.deltaLabel ? (
-              <p className={`mt-1 text-[11px] ${(benchmark.deltaVsPriorBlock ?? 0) > 0 ? "text-success" : "text-muted"}`}>{benchmark.deltaLabel}</p>
+              <p className={`mt-1 text-ui-label ${(benchmark.deltaVsPriorBlock ?? 0) > 0 ? "text-success" : "text-muted"}`}>{benchmark.deltaLabel}</p>
             ) : null}
           </a>
         ))}

--- a/app/(protected)/details-accordion.tsx
+++ b/app/(protected)/details-accordion.tsx
@@ -12,7 +12,7 @@ export function DetailsAccordion({
   return (
     <details className="surface-subtle rounded-[18px] p-3.5">
       <summary className="flex min-h-[44px] cursor-pointer list-none items-center justify-between gap-3 marker:hidden lg:min-h-0">
-        <span className="text-sm font-medium text-accent">{title}</span>
+        <span className="text-body font-medium text-accent">{title}</span>
         {summaryDetail ? <span className="flex flex-wrap items-center justify-end gap-2">{summaryDetail}</span> : null}
       </summary>
       <div className="mt-3">{children}</div>

--- a/app/(protected)/error.tsx
+++ b/app/(protected)/error.tsx
@@ -18,14 +18,14 @@ export default function ProtectedError({
     <section className="flex min-h-[60vh] items-center justify-center px-4">
       <article className="surface max-w-lg p-6 text-center">
         <p className="label">Something went wrong</p>
-        <h1 className="mt-2 text-2xl font-semibold">
+        <h1 className="mt-2 text-page-title">
           We hit a problem loading this page
         </h1>
-        <p className="mt-3 text-sm text-muted">
+        <p className="mt-3 text-body text-muted">
           {error.message || "An unexpected error occurred. Please try again."}
         </p>
         {error.digest ? (
-          <p className="mt-2 text-[11px] text-tertiary">
+          <p className="mt-2 text-ui-label text-tertiary">
             Error ID: {error.digest}
           </p>
         ) : null}
@@ -33,11 +33,11 @@ export default function ProtectedError({
           <button
             type="button"
             onClick={reset}
-            className="btn-primary px-4 py-2 text-sm"
+            className="btn-primary px-4 py-2 text-body"
           >
             Try again
           </button>
-          <a href="/dashboard" className="btn-ghost px-4 py-2 text-sm">
+          <a href="/dashboard" className="btn-ghost px-4 py-2 text-body">
             Back to dashboard
           </a>
         </div>

--- a/app/(protected)/global-header.tsx
+++ b/app/(protected)/global-header.tsx
@@ -53,7 +53,7 @@ export function GlobalHeader({
               </span>
             </span>
           ) : null}
-          <Link href="/coach" className="btn-header-cta px-2.5 py-1 text-xs">Ask tri.ai</Link>
+          <Link href="/coach" className="btn-header-cta px-2.5 py-1 text-ui-label">Ask tri.ai</Link>
           <AccountMenu
             avatarUrl={account.avatarUrl}
             initials={account.initials}

--- a/app/(protected)/layout.tsx
+++ b/app/(protected)/layout.tsx
@@ -75,11 +75,11 @@ export default async function ProtectedLayout({ children }: { children: React.Re
               <div className="surface flex flex-wrap items-center justify-between gap-3 px-4 py-3">
                 <div>
                   <p className="label">Agent Preview</p>
-                  <p className="mt-1 text-sm text-muted">You are browsing seeded local data. Reset the workspace whenever you want a clean UI state.</p>
+                  <p className="mt-1 text-body text-muted">You are browsing seeded local data. Reset the workspace whenever you want a clean UI state.</p>
                 </div>
                 <div className="flex flex-wrap gap-2">
-                  <a href="/dev/agent-reset" className="btn-secondary px-3 py-1.5 text-xs">Reset data</a>
-                  <a href="/dev/agent-preview" className="btn-secondary px-3 py-1.5 text-xs">Preview guide</a>
+                  <a href="/dev/agent-reset" className="btn-secondary px-3 py-1.5 text-ui-label">Reset data</a>
+                  <a href="/dev/agent-preview" className="btn-secondary px-3 py-1.5 text-ui-label">Preview guide</a>
                 </div>
               </div>
             ) : null}

--- a/app/(protected)/page-header.tsx
+++ b/app/(protected)/page-header.tsx
@@ -12,7 +12,7 @@ export function PageHeader({ title, objective, actions = [] }: { title: string; 
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <p className="label">{title}</p>
-          <p className="mt-2 max-w-3xl text-sm text-muted">{objective}</p>
+          <p className="mt-2 max-w-3xl text-body text-muted">{objective}</p>
         </div>
 
         {actions.length > 0 ? (

--- a/app/(protected)/progress-report/page.tsx
+++ b/app/(protected)/progress-report/page.tsx
@@ -49,8 +49,8 @@ function renderBlockSelector(
             }
           >
             <span className="font-medium">{block.name}</span>
-            <span className="ml-2 text-[11px] text-muted">· {block.block_type}</span>
-            <span className="ml-2 text-[11px] text-tertiary">
+            <span className="ml-2 text-ui-label text-muted">· {block.block_type}</span>
+            <span className="ml-2 text-ui-label text-tertiary">
               {formatShortRange(block.start_date, block.end_date)}
             </span>
           </a>
@@ -137,15 +137,15 @@ function renderArtifact(
           <div className="max-w-4xl">
             <p className="label">Progress Report</p>
             {renderFactsHeader(facts, stale)}
-            <h1 className="mt-4 max-w-4xl text-2xl font-semibold leading-[1.05] tracking-[-0.03em] sm:text-4xl md:text-[3.25rem]">
+            <h1 className="mt-4 max-w-4xl text-page-title leading-[1.05] tracking-[-0.03em] sm:text-4xl md:text-[3.25rem]">
               {narrative.coachHeadline}
             </h1>
             <p className="mt-3 max-w-3xl text-[15px] leading-7 text-white">
               {narrative.executiveSummary}
             </p>
-            <p className="mt-2 text-sm text-muted">{renderVolumeDelta(facts)}</p>
+            <p className="mt-2 text-body text-muted">{renderVolumeDelta(facts)}</p>
             {facts.confidenceNote ? (
-              <p className="mt-2 max-w-2xl text-xs text-tertiary">{facts.confidenceNote}</p>
+              <p className="mt-2 max-w-2xl text-ui-label text-tertiary">{facts.confidenceNote}</p>
             ) : null}
           </div>
           <div className="relative z-10 flex min-w-[180px] flex-col items-end gap-3">
@@ -157,29 +157,29 @@ function renderArtifact(
           <div className="mt-6 grid gap-3 sm:grid-cols-3">
             <div className="debrief-metric-card">
               <p className="debrief-kicker">Total CTL</p>
-              <p className="mt-4 text-xl font-semibold leading-tight text-white">
+              <p className="mt-4 text-page-title leading-tight text-white">
                 {totalFitness.currentCtlStart} → {totalFitness.currentCtlEnd}
               </p>
-              <p className="mt-2 text-xs text-muted">
+              <p className="mt-2 text-ui-label text-muted">
                 Δ {totalFitness.currentCtlDelta >= 0 ? "+" : ""}
                 {totalFitness.currentCtlDelta} across the block
               </p>
             </div>
             <div className="debrief-metric-card">
               <p className="debrief-kicker">vs Prior Block</p>
-              <p className="mt-4 text-xl font-semibold leading-tight text-white">
+              <p className="mt-4 text-page-title leading-tight text-white">
                 {totalFitness.deltaVsPrior !== null
                   ? `${totalFitness.deltaVsPrior >= 0 ? "+" : ""}${totalFitness.deltaVsPrior}`
                   : "—"}
               </p>
-              <p className="mt-2 text-xs text-muted">End-of-block CTL delta</p>
+              <p className="mt-2 text-ui-label text-muted">End-of-block CTL delta</p>
             </div>
             <div className="debrief-metric-card">
               <p className="debrief-kicker">Ramp Rate</p>
-              <p className="mt-4 text-xl font-semibold leading-tight text-white">
+              <p className="mt-4 text-page-title leading-tight text-white">
                 {totalFitness.rampRate !== null ? `${totalFitness.rampRate} / wk` : "—"}
               </p>
-              <p className="mt-2 text-xs text-muted">7-day CTL slope</p>
+              <p className="mt-2 text-ui-label text-muted">7-day CTL slope</p>
             </div>
           </div>
         ) : null}
@@ -196,14 +196,14 @@ function renderArtifact(
                 className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4"
               >
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-xs font-medium text-muted">
+                  <p className="text-ui-label text-muted">
                     {sportGlyph(f.sport)} CTL ({f.sport})
                   </p>
                   <span className={directionPillClass(f.direction)}>
                     {directionGlyph(f.direction)} {f.direction}
                   </span>
                 </div>
-                <p className="mt-2 text-sm text-white">
+                <p className="mt-2 text-body text-white">
                   {f.currentCtlStart} → {f.currentCtlEnd}
                   {f.deltaVsPrior !== null
                     ? ` (Δ ${f.deltaVsPrior >= 0 ? "+" : ""}${f.deltaVsPrior} vs prior end)`
@@ -219,25 +219,25 @@ function renderArtifact(
           <p className="debrief-summary mt-4 max-w-3xl">{narrative.durabilityReport}</p>
           <div className="mt-4 grid gap-3 sm:grid-cols-2">
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-xs font-medium text-muted">This block</p>
-              <p className="mt-2 text-sm text-white">
+              <p className="text-ui-label text-muted">This block</p>
+              <p className="mt-2 text-body text-white">
                 {facts.durability.current.avgDecouplingPct !== null
                   ? `${facts.durability.current.avgDecouplingPct}% avg decoupling`
                   : "No samples"}
               </p>
-              <p className="mt-1 text-[11px] text-tertiary">
+              <p className="mt-1 text-ui-label text-tertiary">
                 {facts.durability.current.decouplingSamples} samples ·{" "}
                 {facts.durability.current.poorDurabilityCount} poor-durability
               </p>
             </div>
             <div className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4">
-              <p className="text-xs font-medium text-muted">Prior block</p>
-              <p className="mt-2 text-sm text-white">
+              <p className="text-ui-label text-muted">Prior block</p>
+              <p className="mt-2 text-body text-white">
                 {facts.durability.prior.avgDecouplingPct !== null
                   ? `${facts.durability.prior.avgDecouplingPct}% avg decoupling`
                   : "No samples"}
               </p>
-              <p className="mt-1 text-[11px] text-tertiary">
+              <p className="mt-1 text-ui-label text-tertiary">
                 {facts.durability.prior.decouplingSamples} samples ·{" "}
                 {facts.durability.prior.poorDurabilityCount} poor-durability
               </p>
@@ -251,10 +251,10 @@ function renderArtifact(
         <div className="mt-4 grid gap-3 md:grid-cols-3">
           {narrative.disciplineVerdicts.map((v) => (
             <div key={v.sport} className="debrief-list-card">
-              <p className="text-xs font-medium text-muted">
+              <p className="text-ui-label text-muted">
                 {sportGlyph(v.sport)} {v.sport}
               </p>
-              <p className="mt-2 text-sm leading-6 text-white">{v.verdict}</p>
+              <p className="mt-2 text-body leading-6 text-white">{v.verdict}</p>
             </div>
           ))}
         </div>
@@ -263,7 +263,7 @@ function renderArtifact(
       {facts.paceAtHrByDiscipline.length > 0 ? (
         <article className="debrief-section-card p-5">
           <p className="debrief-kicker">Pace-at-HR</p>
-          <p className="mt-2 text-sm text-muted">
+          <p className="mt-2 text-body text-muted">
             Same cost, different output — read the aerobic economy shift.
           </p>
           <div className="mt-4 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
@@ -273,15 +273,15 @@ function renderArtifact(
                 className="rounded-2xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-4"
               >
                 <div className="flex items-center justify-between gap-2">
-                  <p className="text-xs font-medium text-muted">
+                  <p className="text-ui-label text-muted">
                     {sportGlyph(p.sport)} {p.sport}
                   </p>
                   <span className={directionPillClass(p.direction)}>
                     {directionGlyph(p.direction)} {p.direction}
                   </span>
                 </div>
-                <p className="mt-2 text-sm leading-6 text-white">{p.summary}</p>
-                <p className="mt-2 text-[11px] text-tertiary">
+                <p className="mt-2 text-body leading-6 text-white">{p.summary}</p>
+                <p className="mt-2 text-ui-label text-tertiary">
                   {p.current.sessionCount} / {p.prior.sessionCount} sessions (this / prior)
                 </p>
               </div>
@@ -299,17 +299,17 @@ function renderArtifact(
               <div key={`${peak.sport}-${peak.label}`} className="debrief-list-card">
                 <div className="flex items-center gap-2">
                   <span>{sportGlyph(peak.sport)}</span>
-                  <p className="text-xs font-medium text-muted">{peak.label}</p>
+                  <p className="text-ui-label text-muted">{peak.label}</p>
                 </div>
-                <p className="mt-2 text-xl font-semibold leading-tight text-white">
+                <p className="mt-2 text-page-title leading-tight text-white">
                   {peak.current.formatted}
                 </p>
                 {peak.prior.formatted ? (
-                  <p className="mt-1 text-xs text-muted">vs. {peak.prior.formatted} prior block</p>
+                  <p className="mt-1 text-ui-label text-muted">vs. {peak.prior.formatted} prior block</p>
                 ) : null}
                 {peak.deltaLabel ? (
                   <p
-                    className={`mt-1 text-[11px] ${peak.delta && peak.delta > 0 ? "text-success" : peak.delta && peak.delta < 0 ? "text-warning" : "text-muted"}`}
+                    className={`mt-1 text-ui-label ${peak.delta && peak.delta > 0 ? "text-success" : peak.delta && peak.delta < 0 ? "text-warning" : "text-muted"}`}
                   >
                     {peak.deltaLabel}
                   </p>
@@ -317,7 +317,7 @@ function renderArtifact(
                 {peak.current.activityId ? (
                   <a
                     href={`/activities/${peak.current.activityId}`}
-                    className="mt-2 inline-flex text-[11px] text-muted underline-offset-2 hover:text-white hover:underline"
+                    className="mt-2 inline-flex text-ui-label text-muted underline-offset-2 hover:text-white hover:underline"
                   >
                     View activity
                   </a>
@@ -336,14 +336,14 @@ function renderArtifact(
         {narrative.teach ? (
           <>
             <p className="debrief-kicker mt-5">Why this matters</p>
-            <p className="mt-3 text-sm leading-6 text-muted">{narrative.teach}</p>
+            <p className="mt-3 text-body leading-6 text-muted">{narrative.teach}</p>
           </>
         ) : null}
       </article>
 
       <article className="debrief-section-card p-5">
         <p className="debrief-kicker">Carry into next block</p>
-        <p className="mt-2 text-sm text-muted">
+        <p className="mt-2 text-body text-muted">
           Two reminders worth keeping in mind as the next block starts.
         </p>
         <div className="mt-4 grid gap-3 md:grid-cols-2">
@@ -375,9 +375,9 @@ function renderEmptyState(
   return (
     <article className="surface p-5">
       <p className="label">Progress Report</p>
-      <h1 className="mt-1 text-2xl font-semibold">No block-over-block data yet</h1>
-      <p className="mt-2 max-w-2xl text-sm text-muted">{reason}</p>
-      <p className="mt-2 max-w-2xl text-xs text-tertiary">
+      <h1 className="mt-1 text-page-title">No block-over-block data yet</h1>
+      <p className="mt-2 max-w-2xl text-body text-muted">{reason}</p>
+      <p className="mt-2 max-w-2xl text-ui-label text-tertiary">
         Block ending {blockEnd}. Data last changed {sourceUpdatedAt.slice(0, 10)}.
       </p>
       <div className="mt-4 flex flex-wrap gap-2">
@@ -386,7 +386,7 @@ function renderEmptyState(
           blockEnd={blockEnd}
           label="Try again"
         />
-        <a href="/dashboard" className="btn-secondary px-3 text-xs">
+        <a href="/dashboard" className="btn-secondary px-3 text-ui-label">
           Back to dashboard
         </a>
       </div>

--- a/app/(protected)/progress-report/progress-report-feedback-card.tsx
+++ b/app/(protected)/progress-report/progress-report-feedback-card.tsx
@@ -61,8 +61,8 @@ export function ProgressReportFeedbackCard({
       <div className="flex flex-wrap items-start justify-between gap-4">
         <div>
           <p className="label">Feedback</p>
-          <h2 className="mt-1 text-lg font-semibold">Did this read the block right?</h2>
-          <p className="mt-2 max-w-2xl text-sm text-muted">
+          <h2 className="mt-1 text-section-title font-semibold">Did this read the block right?</h2>
+          <p className="mt-2 max-w-2xl text-body text-muted">
             A quick signal is enough. Add a note only if something felt missing,
             overstated, or especially useful.
           </p>
@@ -77,14 +77,14 @@ export function ProgressReportFeedbackCard({
             <button
               type="button"
               onClick={() => void save({ helpful: true })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${helpful === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${helpful === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               Yes
             </button>
             <button
               type="button"
               onClick={() => void save({ helpful: false })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${helpful === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${helpful === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               No
             </button>
@@ -97,14 +97,14 @@ export function ProgressReportFeedbackCard({
             <button
               type="button"
               onClick={() => void save({ accurate: true })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${accurate === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${accurate === true ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent)/0.14)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               Yes
             </button>
             <button
               type="button"
               onClick={() => void save({ accurate: false })}
-              className={`rounded-full border px-3 py-1.5 text-sm transition ${accurate === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
+              className={`rounded-full border px-3 py-1.5 text-body transition ${accurate === false ? "border-[hsl(var(--warning))] bg-[hsl(var(--warning)/0.12)] text-white" : "border-[hsl(var(--border))] text-muted hover:text-white"}`}
             >
               No
             </button>
@@ -119,7 +119,7 @@ export function ProgressReportFeedbackCard({
           >
             {showNoteEditor ? "Hide note" : note.trim() ? "Edit note" : "Add note"}
           </button>
-          {status ? <p className="text-xs text-muted">{status}</p> : null}
+          {status ? <p className="text-ui-label text-muted">{status}</p> : null}
         </div>
       </div>
 
@@ -141,7 +141,7 @@ export function ProgressReportFeedbackCard({
               type="button"
               onClick={() => void save({ note })}
               disabled={isSaving}
-              className="btn-secondary px-3 py-1.5 text-xs disabled:cursor-not-allowed disabled:opacity-60"
+              className="btn-secondary px-3 py-1.5 text-ui-label disabled:cursor-not-allowed disabled:opacity-60"
             >
               Save note
             </button>

--- a/app/(protected)/progress-report/progress-report-refresh-button.tsx
+++ b/app/(protected)/progress-report/progress-report-refresh-button.tsx
@@ -49,7 +49,7 @@ export function ProgressReportRefreshButton({ blockEnd, blockId, label = "Refres
       >
         {isRefreshing ? "Refreshing…" : label}
       </button>
-      {error ? <p className="text-[11px] text-danger">{error}</p> : null}
+      {error ? <p className="text-ui-label text-danger">{error}</p> : null}
     </div>
   );
 }

--- a/app/(protected)/settings/athlete-context/athlete-context-form.tsx
+++ b/app/(protected)/settings/athlete-context/athlete-context-form.tsx
@@ -33,7 +33,7 @@ function parseDisciplines(values: string[]): Discipline[] {
 // ── shared input class ───────────────────────────────────────────────────────
 
 const inputCls =
-  "w-full rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-sm";
+  "w-full rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-body";
 // [color-scheme:dark] makes native date pickers render in dark mode
 const dateCls = `${inputCls} [color-scheme:dark]`;
 
@@ -42,7 +42,7 @@ const dateCls = `${inputCls} [color-scheme:dark]`;
 function SectionLabel({ children }: { children: React.ReactNode }) {
   return (
     <div className="flex items-center gap-3 pt-2">
-      <span className="shrink-0 text-xs uppercase tracking-[0.14em] text-zinc-500">
+      <span className="shrink-0 text-kicker text-zinc-500">
         {children}
       </span>
       <div className="h-px flex-1 bg-[hsl(var(--border))]" />
@@ -78,7 +78,7 @@ function CoachingStyleCards({
   onChange: (v: string) => void;
 }) {
   return (
-    <div className="space-y-1.5 text-sm">
+    <div className="space-y-1.5 text-body">
       <span className="text-muted">Coaching style</span>
       <div className="grid grid-cols-3 gap-2">
         {COACHING_OPTIONS.map((opt) => {
@@ -96,13 +96,13 @@ function CoachingStyleCards({
               }`}
             >
               <p
-                className={`mb-1 text-sm font-medium ${
+                className={`mb-1 text-body font-medium ${
                   active ? "text-[hsl(var(--accent))]" : ""
                 }`}
               >
                 {opt.label}
               </p>
-              <p className="text-xs leading-snug text-muted">{opt.description}</p>
+              <p className="text-ui-label leading-snug text-muted">{opt.description}</p>
             </button>
           );
         })}
@@ -128,7 +128,7 @@ function DisciplineChips({
     );
   }
   return (
-    <div className="space-y-1.5 text-sm">
+    <div className="space-y-1.5 text-body">
       <span className="text-muted">{label}</span>
       <div className="flex flex-wrap gap-2">
         {DISCIPLINES.map((d) => {
@@ -138,7 +138,7 @@ function DisciplineChips({
               key={d}
               type="button"
               onClick={() => toggle(d)}
-              className={`rounded-full border px-3.5 py-1 text-xs font-medium transition-colors ${
+              className={`rounded-full border px-3.5 py-1 text-ui-label transition-colors ${
                 active
                   ? "border-[hsl(var(--accent))] bg-[hsl(var(--accent))] text-black"
                   : "border-[hsl(var(--border))] text-muted hover:border-zinc-500 hover:text-[hsl(var(--foreground))]"
@@ -172,12 +172,12 @@ function CountedTextarea({
 }) {
   const count = countLines(value);
   return (
-    <div className="space-y-1 text-sm">
+    <div className="space-y-1 text-body">
       <div className="flex items-center justify-between">
         <span className="text-muted">{label}</span>
         {count > 0 && (
           <span
-            className={`tabular-nums text-xs ${
+            className={`tabular-nums text-ui-label ${
               count >= max ? "text-[hsl(var(--danger))]" : "text-muted"
             }`}
           >
@@ -212,7 +212,7 @@ function InjuryNotes({
       <button
         type="button"
         onClick={() => setExpanded(true)}
-        className="text-sm text-muted underline-offset-2 transition-colors hover:text-[hsl(var(--foreground))] hover:underline"
+        className="text-body text-muted underline-offset-2 transition-colors hover:text-[hsl(var(--foreground))] hover:underline"
       >
         + Add injury or caution notes
       </button>
@@ -220,14 +220,14 @@ function InjuryNotes({
   }
 
   return (
-    <div className="space-y-1 text-sm">
+    <div className="space-y-1 text-body">
       <div className="flex items-center justify-between">
         <span className="text-muted">Injury or caution notes</span>
         {!value && (
           <button
             type="button"
             onClick={() => setExpanded(false)}
-            className="text-xs text-muted transition-colors hover:text-[hsl(var(--foreground))]"
+            className="text-ui-label text-muted transition-colors hover:text-[hsl(var(--foreground))]"
           >
             Cancel
           </button>
@@ -243,7 +243,7 @@ function InjuryNotes({
         autoFocus
       />
       {value.length > 0 && (
-        <p className="text-right text-xs tabular-nums text-muted">{value.length}/600</p>
+        <p className="text-right text-ui-label tabular-nums text-muted">{value.length}/600</p>
       )}
     </div>
   );
@@ -276,7 +276,7 @@ function CompletenessBar({
   if (filled === total) return null;
   const pct = Math.round((filled / total) * 100);
   return (
-    <div className="flex items-center gap-3 text-xs text-muted">
+    <div className="flex items-center gap-3 text-ui-label text-muted">
       <div className="h-1 flex-1 overflow-hidden rounded-full bg-[hsl(var(--border))]">
         <div
           className="h-full rounded-full bg-[hsl(var(--accent))] transition-all duration-300"
@@ -365,7 +365,7 @@ export function AthleteContextForm({ snapshot, compact = false, raceName, raceDa
       <SectionLabel>Racing Profile</SectionLabel>
 
       <div className={`grid gap-3 ${colGrid}`}>
-        <label className="space-y-1 text-sm">
+        <label className="space-y-1 text-body">
           <span className="text-muted">Experience level</span>
           <select
             value={experienceLevel}
@@ -379,7 +379,7 @@ export function AthleteContextForm({ snapshot, compact = false, raceName, raceDa
           </select>
         </label>
 
-        <label className="space-y-1 text-sm">
+        <label className="space-y-1 text-body">
           <span className="text-muted">Goal type</span>
           <select
             value={goalType}
@@ -394,17 +394,17 @@ export function AthleteContextForm({ snapshot, compact = false, raceName, raceDa
           </select>
         </label>
 
-        <div className="space-y-1 text-sm sm:col-span-2">
+        <div className="space-y-1 text-body sm:col-span-2">
           <span className="text-muted">Race target</span>
           <div className="flex items-center gap-2 rounded-xl border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2">
-            <span className="flex-1 truncate text-sm">
+            <span className="flex-1 truncate text-body">
               {raceName && raceDate
                 ? `${raceName} — ${new Date(`${raceDate}T00:00:00.000Z`).toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric", timeZone: "UTC" })}`
                 : raceName
                   ? raceName
                   : "No race set yet"}
             </span>
-            <a href="/settings/race" className="shrink-0 text-xs text-accent underline-offset-2 hover:underline">
+            <a href="/settings/race" className="shrink-0 text-ui-label text-accent underline-offset-2 hover:underline">
               {raceName ? "Change" : "Set race"}
             </a>
           </div>
@@ -412,7 +412,7 @@ export function AthleteContextForm({ snapshot, compact = false, raceName, raceDa
       </div>
 
       {compact ? (
-        <label className="block space-y-1 text-sm">
+        <label className="block space-y-1 text-body">
           <span className="text-muted">Coaching style</span>
           <select
             value={coachingPreference}
@@ -487,7 +487,7 @@ export function AthleteContextForm({ snapshot, compact = false, raceName, raceDa
           >
             {isSaving ? "Saving..." : compact ? "Save context" : "Save athlete context"}
           </button>
-          {message ? <p className="text-sm text-muted">{message}</p> : null}
+          {message ? <p className="text-body text-muted">{message}</p> : null}
         </div>
       </div>
     </form>
@@ -578,12 +578,12 @@ export function FtpSection({
       {/* header */}
       <div className="flex items-start justify-between gap-4">
         <div>
-          <p className="text-xs uppercase tracking-[0.14em] text-accent mb-1">
+          <p className="text-kicker text-accent mb-1">
             Physical Metrics
           </p>
-          <h3 className="text-sm font-medium">Bike FTP</h3>
+          <h3 className="text-body font-medium">Bike FTP</h3>
           {currentFtp ? (
-            <p className="mt-0.5 text-sm text-muted">
+            <p className="mt-0.5 text-body text-muted">
               Current:{" "}
               <span className="font-mono text-[hsl(var(--foreground))]">
                 {currentFtp.value}W
@@ -592,7 +592,7 @@ export function FtpSection({
               {currentFtp.recorded_at}
             </p>
           ) : (
-            <p className="mt-0.5 text-sm text-muted">
+            <p className="mt-0.5 text-body text-muted">
               Not set — add your FTP for power-zone guidance.
             </p>
           )}
@@ -601,7 +601,7 @@ export function FtpSection({
           <button
             type="button"
             onClick={() => setShowHistory((v) => !v)}
-            className="shrink-0 text-xs text-muted underline-offset-2 hover:underline"
+            className="shrink-0 text-ui-label text-muted underline-offset-2 hover:underline"
           >
             {showHistory ? "Hide history" : `History (${history.length})`}
           </button>
@@ -611,7 +611,7 @@ export function FtpSection({
       {/* history table with deltas */}
       {showHistory && history.length > 1 && (
         <div className="overflow-hidden rounded-xl border border-[hsl(var(--border))]">
-          <table className="w-full text-xs">
+          <table className="w-full text-ui-label">
             <thead>
               <tr className="border-b border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))]">
                 <th className="px-3 py-2 text-left font-normal text-muted">Date</th>
@@ -680,11 +680,11 @@ export function FtpSection({
 
       {/* log new reading */}
       <form onSubmit={handleFtpSubmit} className="space-y-3">
-        <p className="text-xs uppercase tracking-[0.14em] text-zinc-500">
+        <p className="text-kicker text-zinc-500">
           {currentFtp ? "Log new reading" : "Set FTP"}
         </p>
         <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-          <label className="space-y-1 text-sm">
+          <label className="space-y-1 text-body">
             <span className="text-muted">Watts</span>
             <input
               type="number"
@@ -696,7 +696,7 @@ export function FtpSection({
               className={inputCls}
             />
           </label>
-          <label className="space-y-1 text-sm">
+          <label className="space-y-1 text-body">
             <span className="text-muted">Source</span>
             <select
               value={ftpSource}
@@ -708,7 +708,7 @@ export function FtpSection({
               <option value="estimated">Estimated</option>
             </select>
           </label>
-          <label className="space-y-1 text-sm">
+          <label className="space-y-1 text-body">
             <span className="text-muted">Date</span>
             <input
               type="date"
@@ -717,7 +717,7 @@ export function FtpSection({
               className={dateCls}
             />
           </label>
-          <label className="space-y-1 text-sm">
+          <label className="space-y-1 text-body">
             <span className="text-muted">Notes (optional)</span>
             <input
               value={ftpNotes}
@@ -735,7 +735,7 @@ export function FtpSection({
           >
             {isSaving ? "Saving..." : "Log FTP"}
           </button>
-          {message && <p className="text-sm text-muted">{message}</p>}
+          {message && <p className="text-body text-muted">{message}</p>}
         </div>
       </form>
     </div>

--- a/app/(protected)/settings/athlete-context/page.tsx
+++ b/app/(protected)/settings/athlete-context/page.tsx
@@ -21,13 +21,13 @@ export default async function AthleteContextSettingsPage() {
 
   return (
     <section className="space-y-4">
-      <Link href="/settings" className="text-sm text-cyan-300 underline-offset-2 hover:underline">
+      <Link href="/settings" className="text-body text-cyan-300 underline-offset-2 hover:underline">
         ← Back to Settings
       </Link>
       <header className="surface p-6">
-        <p className="text-xs uppercase tracking-[0.14em] text-accent">Athlete context</p>
-        <h1 className="mt-2 text-2xl font-semibold">Coaching context</h1>
-        <p className="mt-1 text-sm text-muted">
+        <p className="text-kicker text-accent">Athlete context</p>
+        <h1 className="mt-2 text-page-title">Coaching context</h1>
+        <p className="mt-1 text-body text-muted">
           This context feeds every AI coaching response — the more complete, the better.
         </p>
       </header>

--- a/app/(protected)/settings/integrations/activity-metrics-backfill-button.tsx
+++ b/app/(protected)/settings/integrations/activity-metrics-backfill-button.tsx
@@ -46,15 +46,15 @@ export function ActivityMetricsBackfillButton() {
     <article className="surface p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-[0.14em] text-accent">Data tools</p>
-          <h2 className="mt-1 text-lg font-semibold">Backfill richer activity metrics</h2>
-          <p className="mt-1 text-sm text-muted">Reparse retained uploaded FIT/TCX files so older activities gain the richer metrics now used by reviews and debriefs.</p>
+          <p className="text-kicker text-accent">Data tools</p>
+          <h2 className="mt-1 text-section-title font-semibold">Backfill richer activity metrics</h2>
+          <p className="mt-1 text-body text-muted">Reparse retained uploaded FIT/TCX files so older activities gain the richer metrics now used by reviews and debriefs.</p>
         </div>
-        <button type="button" onClick={handleBackfill} disabled={isPending} className="btn-primary px-4 py-2 text-sm disabled:opacity-60">
+        <button type="button" onClick={handleBackfill} disabled={isPending} className="btn-primary px-4 py-2 text-body disabled:opacity-60">
           {isPending ? "Backfilling..." : "Run activity backfill"}
         </button>
       </div>
-      {message ? <p className="mt-3 text-sm text-muted">{message}</p> : null}
+      {message ? <p className="mt-3 text-body text-muted">{message}</p> : null}
     </article>
   );
 }

--- a/app/(protected)/settings/integrations/activity-uploads-panel.tsx
+++ b/app/(protected)/settings/integrations/activity-uploads-panel.tsx
@@ -101,7 +101,7 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
   return (
     <div className="space-y-4">
       <div
-        className="surface-subtle rounded-xl border border-dashed border-white/20 p-5 text-sm"
+        className="surface-subtle rounded-xl border border-dashed border-white/20 p-5 text-body"
         onDragOver={(event) => event.preventDefault()}
         onDrop={(event) => {
           event.preventDefault();
@@ -115,7 +115,7 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
         }}
       >
         <p className="font-medium">Drop Garmin files here</p>
-        <p className="mt-1 text-xs text-muted">Accepted formats: .fit (preferred), .tcx. Max 20MB.</p>
+        <p className="mt-1 text-ui-label text-muted">Accepted formats: .fit (preferred), .tcx. Max 20MB.</p>
         <label className="btn-secondary mt-3 inline-flex cursor-pointer">
           Pick file
           <input
@@ -128,13 +128,13 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
             }}
           />
         </label>
-        {message ? <p className="mt-2 text-xs text-cyan-200">{message}</p> : null}
+        {message ? <p className="mt-2 text-ui-label text-cyan-200">{message}</p> : null}
       </div>
 
       <div className="overflow-x-auto">
-        <table className="min-w-full text-sm">
+        <table className="min-w-full text-body">
           <thead>
-            <tr className="text-left text-xs uppercase text-muted">
+            <tr className="text-left text-ui-label uppercase text-muted">
               <th className="py-2">Date</th><th>Sport</th><th>Duration</th><th>Distance</th><th>Status</th><th></th>
             </tr>
           </thead>
@@ -152,7 +152,7 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
                   <td>{fmtDuration(activity?.duration_sec)}</td>
                   <td>{activity?.distance_m ? `${(Number(activity.distance_m) / 1000).toFixed(2)} km` : "—"}</td>
                   <td>{upload.status === "error" ? "Error" : linked ? "Scheduled" : hasRejectedLink || upload.status === "matched" ? "Extra" : hasSuggestion ? "Suggested" : "Unscheduled"}</td>
-                  <td className="space-x-2 text-xs">
+                  <td className="space-x-2 text-ui-label">
                     {activity?.id ? <Link className="text-cyan-300 underline" href={`/activities/${activity.id}`}>View activity</Link> : <button className="text-cyan-300 underline" onClick={() => setDetailId(upload.id)}>View details</button>}
                     {!linked && upload.status !== "error" ? (
                       <button className="text-cyan-300 underline" onClick={() => { setAttachFor(upload); setAttachError(""); }}>Attach to planned session</button>
@@ -177,7 +177,7 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
       </div>
 
       {detail ? (
-        <div className="surface-subtle flex items-center justify-between gap-3 p-3 text-xs">
+        <div className="surface-subtle flex items-center justify-between gap-3 p-3 text-ui-label">
           <span>{detail.filename} • {detail.file_type.toUpperCase()} • {detail.error_message ?? "No errors"}</span>
           <button
             className="text-rose-300 underline"
@@ -196,13 +196,13 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
       {attachFor ? (
         <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4">
           <div className="surface w-full max-w-xl p-4">
-            <h3 className="text-lg font-semibold">Attach to planned session</h3>
+            <h3 className="text-section-title font-semibold">Attach to planned session</h3>
             <ul className="mt-3 max-h-72 space-y-2 overflow-auto">
               {sortedCandidates.length === 0 ? (
-                <li className="surface-subtle p-3 text-sm text-muted">No planned sessions found. Create a session in Plan first, then attach.</li>
+                <li className="surface-subtle p-3 text-body text-muted">No planned sessions found. Create a session in Plan first, then attach.</li>
               ) : null}
               {sortedCandidates.map((candidate) => (
-                <li key={candidate.id} className="surface-subtle flex items-center justify-between p-2 text-sm">
+                <li key={candidate.id} className="surface-subtle flex items-center justify-between p-2 text-body">
                   <span>{candidate.date} · {candidate.sport} · {candidate.type}</span>
                   <button
                     className="btn-secondary"
@@ -257,8 +257,8 @@ export function ActivityUploadsPanel({ initialUploads, plannedSessions, initialO
                 </li>
               ))}
             </ul>
-            {attachError ? <p className="mt-3 text-xs text-red-400">{attachError}</p> : null}
-            <button className="mt-3 text-xs underline" onClick={() => setAttachFor(null)}>Close</button>
+            {attachError ? <p className="mt-3 text-ui-label text-red-400">{attachError}</p> : null}
+            <button className="mt-3 text-ui-label underline" onClick={() => setAttachFor(null)}>Close</button>
           </div>
         </div>
       ) : null}

--- a/app/(protected)/settings/integrations/connected-services.tsx
+++ b/app/(protected)/settings/integrations/connected-services.tsx
@@ -54,8 +54,8 @@ export async function ConnectedServices() {
   return (
     <section className="surface p-6 space-y-4">
       <header>
-        <h2 className="text-lg font-semibold">Connected services</h2>
-        <p className="mt-1 text-sm text-muted">
+        <h2 className="text-section-title font-semibold">Connected services</h2>
+        <p className="mt-1 text-body text-muted">
           Connect third-party accounts to import your completed workouts automatically.
         </p>
       </header>

--- a/app/(protected)/settings/integrations/page.tsx
+++ b/app/(protected)/settings/integrations/page.tsx
@@ -129,9 +129,9 @@ export default async function IntegrationsPage() {
   return (
     <section className="space-y-4">
       <header className="surface p-6">
-        <p className="text-xs uppercase tracking-[0.16em] text-cyan-300">Settings → Integrations / Uploads</p>
-        <h1 className="mt-2 text-2xl font-semibold">Integrations &amp; uploads</h1>
-        <p className="mt-1 text-sm text-muted">Connect third-party accounts or upload .fit / .tcx files to import your completed activities.</p>
+        <p className="text-kicker text-cyan-300">Settings → Integrations / Uploads</p>
+        <h1 className="mt-2 text-page-title">Integrations &amp; uploads</h1>
+        <p className="mt-1 text-body text-muted">Connect third-party accounts or upload .fit / .tcx files to import your completed activities.</p>
       </header>
 
       <Suspense fallback={null}>

--- a/app/(protected)/settings/integrations/review-backfill-button.tsx
+++ b/app/(protected)/settings/integrations/review-backfill-button.tsx
@@ -40,15 +40,15 @@ export function ReviewBackfillButton() {
     <article className="surface p-5">
       <div className="flex flex-wrap items-start justify-between gap-3">
         <div>
-          <p className="text-xs uppercase tracking-[0.14em] text-accent">Execution reviews</p>
-          <h2 className="mt-1 text-lg font-semibold">Run reviews for linked sessions</h2>
-          <p className="mt-1 text-sm text-muted">Manually trigger the execution review process for all confirmed linked sessions.</p>
+          <p className="text-kicker text-accent">Execution reviews</p>
+          <h2 className="mt-1 text-section-title font-semibold">Run reviews for linked sessions</h2>
+          <p className="mt-1 text-body text-muted">Manually trigger the execution review process for all confirmed linked sessions.</p>
         </div>
-        <button type="button" onClick={handleRunReviews} disabled={isPending} className="btn-primary px-4 py-2 text-sm disabled:opacity-60">
+        <button type="button" onClick={handleRunReviews} disabled={isPending} className="btn-primary px-4 py-2 text-body disabled:opacity-60">
           {isPending ? "Running reviews..." : "Run execution reviews"}
         </button>
       </div>
-      {message ? <p className="mt-3 text-sm text-muted">{message}</p> : null}
+      {message ? <p className="mt-3 text-body text-muted">{message}</p> : null}
     </article>
   );
 }

--- a/app/(protected)/settings/integrations/strava-connection-card.tsx
+++ b/app/(protected)/settings/integrations/strava-connection-card.tsx
@@ -97,16 +97,16 @@ export function StravaConnectionCard({ connection }: Props) {
             <StravaLogo className="w-4 h-4" />
           </span>
           <div className="min-w-0">
-            <p className="font-medium text-sm leading-tight">Strava</p>
-            <p className="text-xs text-muted">Not connected</p>
+            <p className="font-medium text-body leading-tight">Strava</p>
+            <p className="text-ui-label text-muted">Not connected</p>
           </div>
         </div>
-        <p className="text-xs text-muted">
+        <p className="text-ui-label text-muted">
           Import completed workouts from your Strava account.
         </p>
         <a
           href="/api/integrations/strava/connect"
-          className="inline-flex items-center justify-center px-3 py-1.5 text-xs font-medium rounded bg-[#FC4C02] text-white hover:bg-[#e04400] transition-colors"
+          className="inline-flex items-center justify-center px-3 py-1.5 text-ui-label rounded bg-[#FC4C02] text-white hover:bg-[#e04400] transition-colors"
         >
           Connect Strava
         </a>
@@ -125,10 +125,10 @@ export function StravaConnectionCard({ connection }: Props) {
           <StravaLogo className="w-4 h-4" />
         </span>
         <div className="min-w-0 flex-1">
-          <p className="font-medium text-sm leading-tight truncate">
+          <p className="font-medium text-body leading-tight truncate">
             {connection.provider_display_name ?? "Strava"}
           </p>
-          <p className="text-xs text-muted">
+          <p className="text-ui-label text-muted">
             {isRunning ? (
               <span className="text-cyan-400">Syncing…</span>
             ) : hasError ? (
@@ -148,24 +148,24 @@ export function StravaConnectionCard({ connection }: Props) {
       </div>
 
       {hasError && connection.last_sync_error && (
-        <p className="text-xs text-danger bg-danger/10 rounded px-2 py-1 leading-snug">
+        <p className="text-ui-label text-danger bg-danger/10 rounded px-2 py-1 leading-snug">
           {connection.last_sync_error}
         </p>
       )}
 
       {!isRunning && connection.last_sync_metadata && (
-        <p className="text-xs text-muted">
+        <p className="text-ui-label text-muted">
           {formatSyncSummary(connection.last_sync_metadata)}
         </p>
       )}
 
       <div className="flex items-center gap-2">
-        <label htmlFor="sync-window" className="text-xs text-muted whitespace-nowrap">Sync window</label>
+        <label htmlFor="sync-window" className="text-ui-label text-muted whitespace-nowrap">Sync window</label>
         <select
           id="sync-window"
           value={syncWindow}
           onChange={(e) => handleSyncWindowChange(Number(e.target.value))}
-          className="flex-1 text-xs rounded border border-border bg-[var(--color-base)] px-2 py-1 text-foreground"
+          className="flex-1 text-ui-label rounded border border-border bg-[var(--color-base)] px-2 py-1 text-foreground"
         >
           <option value={7}>7 days</option>
           <option value={14}>14 days</option>
@@ -178,14 +178,14 @@ export function StravaConnectionCard({ connection }: Props) {
         <button
           onClick={handleSync}
           disabled={isRunning || isDisconnecting}
-          className="flex-1 btn-primary px-3 py-1.5 text-xs disabled:opacity-50 disabled:cursor-not-allowed"
+          className="flex-1 btn-primary px-3 py-1.5 text-ui-label disabled:opacity-50 disabled:cursor-not-allowed"
         >
           {isRunning ? "Syncing…" : "Sync now"}
         </button>
         <button
           onClick={handleDisconnect}
           disabled={isRunning || isDisconnecting}
-          className="px-3 py-1.5 text-xs font-medium rounded border border-border text-muted hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          className="px-3 py-1.5 text-ui-label rounded border border-border text-muted hover:text-foreground disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
           Disconnect
         </button>

--- a/app/(protected)/settings/integrations/sync-history.tsx
+++ b/app/(protected)/settings/integrations/sync-history.tsx
@@ -53,9 +53,9 @@ export async function SyncHistory() {
 
   return (
     <section className="surface p-5 space-y-3">
-      <h3 className="text-sm font-semibold">Sync history</h3>
+      <h3 className="text-body font-medium">Sync history</h3>
       <div className="overflow-x-auto">
-        <table className="w-full text-xs">
+        <table className="w-full text-ui-label">
           <thead>
             <tr className="border-b border-border text-left text-muted">
               <th className="pb-2 pr-3 font-medium">Time</th>

--- a/app/(protected)/settings/locale/page.tsx
+++ b/app/(protected)/settings/locale/page.tsx
@@ -29,8 +29,8 @@ export default async function LocaleSettingsPage() {
     <section className="space-y-4">
       <header className="surface p-6">
         <p className="label">Settings</p>
-        <h1 className="mt-3 text-2xl">Language &amp; units</h1>
-        <p className="mt-2 text-sm text-muted">Set your language, units, timezone, and week start day.</p>
+        <h1 className="mt-3 text-page-title">Language &amp; units</h1>
+        <p className="mt-2 text-body text-muted">Set your language, units, timezone, and week start day.</p>
       </header>
 
       <article className="surface p-5">
@@ -61,7 +61,7 @@ export default async function LocaleSettingsPage() {
               placeholder="Europe/Dublin"
               className="input-base mt-1"
             />
-            <p className="mt-1 text-xs text-muted">IANA timezone identifier (e.g. Europe/Berlin, America/New_York)</p>
+            <p className="mt-1 text-ui-label text-muted">IANA timezone identifier (e.g. Europe/Berlin, America/New_York)</p>
           </div>
 
           <div>

--- a/app/(protected)/settings/page.tsx
+++ b/app/(protected)/settings/page.tsx
@@ -5,33 +5,33 @@ export default function SettingsPage() {
     <section className="space-y-4">
       <header className="surface p-6">
         <p className="label">Settings</p>
-        <h1 className="mt-3 text-2xl">Settings</h1>
-        <p className="mt-2 text-sm text-muted">Manage race targets, athlete context, and integration workflows.</p>
+        <h1 className="mt-3 text-page-title">Settings</h1>
+        <p className="mt-2 text-body text-muted">Manage race targets, athlete context, and integration workflows.</p>
       </header>
 
       <div className="grid gap-4 md:grid-cols-2">
         <Link href="/settings/race" className="surface p-5 transition hover:border-[var(--border-default)]">
           <p className="label">Race</p>
-          <h2 className="mt-3 text-lg">Race settings</h2>
-          <p className="mt-1 text-sm text-muted">Set your race name and date for dashboard countdown context.</p>
+          <h2 className="mt-3 text-section-title">Race settings</h2>
+          <p className="mt-1 text-body text-muted">Set your race name and date for dashboard countdown context.</p>
         </Link>
 
         <Link href="/settings/integrations" className="surface p-5 transition hover:border-[var(--border-default)]">
           <p className="label">Integrations</p>
-          <h2 className="mt-3 text-lg">Integrations &amp; uploads</h2>
-          <p className="mt-1 text-sm text-muted">Connect Strava, upload FIT/TCX files, and manage activity data.</p>
+          <h2 className="mt-3 text-section-title">Integrations &amp; uploads</h2>
+          <p className="mt-1 text-body text-muted">Connect Strava, upload FIT/TCX files, and manage activity data.</p>
         </Link>
 
         <Link href="/settings/athlete-context" className="surface p-5 transition hover:border-[var(--border-default)]">
           <p className="label">Coach</p>
-          <h2 className="mt-3 text-lg">Athlete context</h2>
-          <p className="mt-1 text-sm text-muted">Set the durable context Coach should use across reviews, briefs, and chat.</p>
+          <h2 className="mt-3 text-section-title">Athlete context</h2>
+          <p className="mt-1 text-body text-muted">Set the durable context Coach should use across reviews, briefs, and chat.</p>
         </Link>
 
         <Link href="/settings/locale" className="surface p-5 transition hover:border-[var(--border-default)]">
           <p className="label">Preferences</p>
-          <h2 className="mt-3 text-lg">Language &amp; units</h2>
-          <p className="mt-1 text-sm text-muted">Set your language, units, timezone, and week start day.</p>
+          <h2 className="mt-3 text-section-title">Language &amp; units</h2>
+          <p className="mt-1 text-body text-muted">Set your language, units, timezone, and week start day.</p>
         </Link>
       </div>
     </section>

--- a/app/(protected)/settings/race/page.tsx
+++ b/app/(protected)/settings/race/page.tsx
@@ -58,23 +58,23 @@ export default async function RaceSettingsPage() {
     <section className="space-y-4">
       <header className="surface p-6">
         <p className="label">Settings</p>
-        <h1 className="mt-3 text-2xl">Race settings</h1>
-        <p className="mt-2 text-sm text-muted">Manage your race calendar. Set your A-race and tune-up events.</p>
+        <h1 className="mt-3 text-page-title">Race settings</h1>
+        <p className="mt-2 text-body text-muted">Manage your race calendar. Set your A-race and tune-up events.</p>
       </header>
 
       {/* Race Profiles */}
       {!isMissingTable(rpError) && (
         <article className="surface p-5">
-          <h2 className="text-lg font-semibold">Race Calendar</h2>
-          <p className="mt-1 text-sm text-muted">Add races with priority: A (peak for), B (mini-taper), C (train through).</p>
+          <h2 className="text-section-title font-semibold">Race Calendar</h2>
+          <p className="mt-1 text-body text-muted">Add races with priority: A (peak for), B (mini-taper), C (train through).</p>
           <RaceProfileList races={races} />
         </article>
       )}
 
       {/* Legacy single-race fallback */}
       <article className="surface p-5">
-        <h2 className="text-lg font-semibold">Dashboard Countdown</h2>
-        <p className="mt-1 text-sm text-muted">Primary race shown on your dashboard countdown.</p>
+        <h2 className="text-section-title font-semibold">Dashboard Countdown</h2>
+        <p className="mt-1 text-body text-muted">Primary race shown on your dashboard countdown.</p>
         <form action={updateRaceSettingsAction} className="mt-3 grid gap-3 md:max-w-lg">
           <div>
             <label htmlFor="raceName" className="label-base">Race name</label>

--- a/app/(protected)/settings/race/race-profile-list.tsx
+++ b/app/(protected)/settings/race/race-profile-list.tsx
@@ -60,21 +60,21 @@ export function RaceProfileList({ races }: { races: RaceProfileRow[] }) {
   return (
     <div className="mt-4 space-y-3">
       {races.length === 0 && !showForm && (
-        <p className="text-sm text-muted">No races added yet.</p>
+        <p className="text-body text-muted">No races added yet.</p>
       )}
 
       {races.map((race) => (
         <div key={race.id} className="flex items-center gap-3 rounded-md border border-[var(--border-subtle)] p-3">
-          <span className={`inline-flex h-6 w-6 items-center justify-center rounded border text-xs font-bold ${PRIORITY_BADGE[race.priority] ?? ""}`}>
+          <span className={`inline-flex h-6 w-6 items-center justify-center rounded border text-ui-label font-semibold ${PRIORITY_BADGE[race.priority] ?? ""}`}>
             {race.priority}
           </span>
           <div className="min-w-0 flex-1">
-            <p className="text-sm font-medium">{race.name}</p>
-            <p className="text-xs text-muted">
+            <p className="text-body font-medium">{race.name}</p>
+            <p className="text-ui-label text-muted">
               {DISTANCE_LABELS[race.distance_type] ?? race.distance_type} &middot; {race.date}
             </p>
           </div>
-          {race.notes && <p className="hidden text-xs text-muted md:block">{race.notes}</p>}
+          {race.notes && <p className="hidden text-ui-label text-muted md:block">{race.notes}</p>}
         </div>
       ))}
 
@@ -122,7 +122,7 @@ export function RaceProfileList({ races }: { races: RaceProfileRow[] }) {
           </div>
         </form>
       ) : (
-        <button className="btn-secondary text-sm" onClick={() => setShowForm(true)}>
+        <button className="btn-secondary text-body" onClick={() => setShowForm(true)}>
           + Add race
         </button>
       )}

--- a/app/(protected)/shell-nav.tsx
+++ b/app/(protected)/shell-nav.tsx
@@ -25,14 +25,14 @@ export function ShellNavRail({ compact = false }: { compact?: boolean }) {
             aria-label={item.label}
             aria-current={active ? "page" : undefined}
             prefetch
-            className={`relative rounded-md border border-transparent px-3 py-2 text-[13px] transition ${
+            className={`relative rounded-md border border-transparent px-3 py-2 text-ui-label transition ${
               active
                 ? "nav-item-active pl-5"
                 : `${item.deemphasized ? "text-[hsl(var(--fg-muted)/0.78)]" : "text-[hsl(var(--fg-muted))]"} hover:border-[var(--border-subtle)] hover:bg-[var(--color-surface-raised)] hover:text-[hsl(var(--fg))]`
             } ${compact ? "flex items-center justify-center px-2.5" : "block"}`}
           >
             {compact ? (
-              <span aria-hidden="true" className="text-base">{item.icon}</span>
+              <span aria-hidden="true" className="text-body">{item.icon}</span>
             ) : (
               <span className="block font-medium">{item.label}</span>
             )}
@@ -60,8 +60,8 @@ export function MobileBottomTabs() {
               prefetch
               className={`relative flex min-h-[52px] flex-col items-center justify-center gap-0.5 rounded-md border border-transparent px-2 py-2 text-center transition ${active ? "nav-item-active nav-item-active--mobile pl-3" : "text-[hsl(var(--fg-muted))]"}`}
             >
-              <span aria-hidden="true" className={`text-base leading-none ${active ? "" : "opacity-60"}`}>{item.icon}</span>
-              <span className={`block text-[10px] font-medium leading-none ${active ? "" : "opacity-70"}`}>{item.label}</span>
+              <span aria-hidden="true" className={`text-body leading-none ${active ? "" : "opacity-60"}`}>{item.icon}</span>
+              <span className={`block text-ui-label leading-none ${active ? "" : "opacity-70"}`}>{item.label}</span>
             </Link>
           );
         })}

--- a/app/(protected)/status-strip.tsx
+++ b/app/(protected)/status-strip.tsx
@@ -10,9 +10,9 @@ export function StatusStrip({ items }: { items: StatusStripItem[] }) {
       <div className="flex min-w-max items-center gap-2">
         {items.map((item, index) => (
           <div key={item.label} className="flex items-center gap-2 rounded-lg px-2 py-1">
-            <p className="label-base text-[10px]">{item.label}</p>
-            <p className="stat text-sm">{item.value}</p>
-            {item.hint ? <p className="text-[11px] text-muted">{item.hint}</p> : null}
+            <p className="label-base text-ui-label">{item.label}</p>
+            <p className="stat text-body">{item.value}</p>
+            {item.hint ? <p className="text-ui-label text-muted">{item.hint}</p> : null}
             {index < items.length - 1 ? <span className="ml-1 text-muted">•</span> : null}
           </div>
         ))}

--- a/app/auth/forgot-password/page.tsx
+++ b/app/auth/forgot-password/page.tsx
@@ -7,8 +7,8 @@ export default function ForgotPasswordPage() {
       <div className="auth-panel auth-stack">
         <div className="surface space-y-2 p-6 text-center">
           <p className="label">Tri.ai</p>
-          <h1 className="mt-3 text-3xl">Reset your password</h1>
-          <p className="mt-2 text-sm text-muted">Enter your email and we&apos;ll send you a secure password reset link.</p>
+          <h1 className="mt-3 text-page-hero">Reset your password</h1>
+          <p className="mt-2 text-body text-muted">Enter your email and we&apos;ll send you a secure password reset link.</p>
         </div>
         <Suspense fallback={<div className="mt-4 h-40 animate-pulse rounded-md bg-[var(--color-surface-raised)]" />}>
           <div className="surface p-6">

--- a/app/auth/forgot-password/reset-password-form.tsx
+++ b/app/auth/forgot-password/reset-password-form.tsx
@@ -66,14 +66,14 @@ export function ForgotPasswordForm() {
         />
       </div>
 
-      {error ? <p className="text-sm text-[var(--color-danger)]">{error}</p> : null}
-      {message ? <p className="text-sm text-[var(--color-success)]">{message}</p> : null}
+      {error ? <p className="text-body text-[var(--color-danger)]">{error}</p> : null}
+      {message ? <p className="text-body text-[var(--color-success)]">{message}</p> : null}
 
       <button type="submit" disabled={isSubmitting} className="btn-primary w-full disabled:opacity-70">
         {isSubmitting ? "Sending reset link..." : "Send reset email"}
       </button>
 
-      <p className="text-center text-sm text-muted">
+      <p className="text-center text-body text-muted">
         Remembered it?{" "}
         <Link href="/auth/sign-in" className="font-medium text-accent hover:text-white">
           Back to sign in

--- a/app/auth/sign-in/page.tsx
+++ b/app/auth/sign-in/page.tsx
@@ -11,8 +11,8 @@ export default function SignInPage() {
       <div className="auth-panel auth-stack">
         <div className="surface space-y-2 p-6 text-center">
           <p className="label">Tri.ai</p>
-          <h1 className="mt-3 text-3xl">Sign in to Tri.AI</h1>
-          <p className="mt-2 text-sm text-muted">Access your dashboard, plan, calendar, and coach workspace.</p>
+          <h1 className="mt-3 text-page-hero">Sign in to Tri.AI</h1>
+          <p className="mt-2 text-body text-muted">Access your dashboard, plan, calendar, and coach workspace.</p>
         </div>
         <Suspense fallback={<div className="mt-4 h-40 animate-pulse rounded-md bg-[var(--color-surface-raised)]" />}>
           <div className="surface p-6">
@@ -22,7 +22,7 @@ export default function SignInPage() {
         {showAgentPreview ? (
           <div className="surface space-y-3 p-6">
             <p className="label">Local Preview</p>
-            <p className="text-sm text-muted">For agent screenshots and UI inspection, skip live auth and enter the seeded preview workspace.</p>
+            <p className="text-body text-muted">For agent screenshots and UI inspection, skip live auth and enter the seeded preview workspace.</p>
             <div className="flex flex-wrap gap-2">
               <Link href="/dev/agent-login" className="btn-primary">
                 Enter preview mode

--- a/app/auth/sign-in/sign-in-form.tsx
+++ b/app/auth/sign-in/sign-in-form.tsx
@@ -120,13 +120,13 @@ export function SignInForm() {
       </div>
 
       <div className="flex justify-end">
-        <Link href="/auth/forgot-password" className="text-sm font-medium text-accent hover:text-white">
+        <Link href="/auth/forgot-password" className="text-body font-medium text-accent hover:text-white">
           I forgot my password
         </Link>
       </div>
 
-      {error ? <p className="text-sm text-[var(--color-danger)]">{error}</p> : null}
-      {message ? <p className="text-sm text-[var(--color-success)]">{message}</p> : null}
+      {error ? <p className="text-body text-[var(--color-danger)]">{error}</p> : null}
+      {message ? <p className="text-body text-[var(--color-success)]">{message}</p> : null}
 
       <button type="submit" disabled={isSubmitting} className="btn-primary w-full disabled:opacity-70">
         {isSubmitting ? "Signing in..." : "Sign in"}
@@ -141,7 +141,7 @@ export function SignInForm() {
         {isSendingLink ? "Sending link..." : "Email me a sign-in link"}
       </button>
 
-      <p className="text-center text-sm text-muted">
+      <p className="text-center text-body text-muted">
         Need an account?{" "}
         <Link href="/auth/sign-up" className="font-medium text-accent hover:text-white">
           Sign up

--- a/app/auth/sign-up/page.tsx
+++ b/app/auth/sign-up/page.tsx
@@ -6,8 +6,8 @@ export default function SignUpPage() {
       <div className="auth-panel auth-stack">
         <div className="surface space-y-2 p-6 text-center">
           <p className="label">Tri.ai</p>
-          <h1 className="mt-3 text-3xl">Create your Tri.AI account</h1>
-          <p className="mt-2 text-sm text-muted">Sign up with email and password to unlock protected training tools.</p>
+          <h1 className="mt-3 text-page-hero">Create your Tri.AI account</h1>
+          <p className="mt-2 text-body text-muted">Sign up with email and password to unlock protected training tools.</p>
         </div>
         <div className="surface p-6">
           <SignUpForm />

--- a/app/auth/sign-up/sign-up-form.tsx
+++ b/app/auth/sign-up/sign-up-form.tsx
@@ -67,14 +67,14 @@ export function SignUpForm() {
         />
       </div>
 
-      {error ? <p className="text-sm text-[var(--color-danger)]">{error}</p> : null}
-      {message ? <p className="text-sm text-[var(--color-success)]">{message}</p> : null}
+      {error ? <p className="text-body text-[var(--color-danger)]">{error}</p> : null}
+      {message ? <p className="text-body text-[var(--color-success)]">{message}</p> : null}
 
       <button type="submit" disabled={isSubmitting} className="btn-primary w-full disabled:opacity-70">
         {isSubmitting ? "Creating account..." : "Sign up"}
       </button>
 
-      <p className="text-center text-sm text-muted">
+      <p className="text-center text-body text-muted">
         Already have an account?{" "}
         <Link href="/auth/sign-in" className="font-medium text-accent hover:text-white">
           Sign in

--- a/app/auth/update-password/page.tsx
+++ b/app/auth/update-password/page.tsx
@@ -7,8 +7,8 @@ export default function UpdatePasswordPage() {
       <div className="auth-panel auth-stack">
         <div className="surface space-y-2 p-6 text-center">
           <p className="label">Tri.ai</p>
-          <h1 className="mt-3 text-3xl">Choose a new password</h1>
-          <p className="mt-2 text-sm text-muted">Set a new password for your Tri.AI account, then sign back in if needed.</p>
+          <h1 className="mt-3 text-page-hero">Choose a new password</h1>
+          <p className="mt-2 text-body text-muted">Set a new password for your Tri.AI account, then sign back in if needed.</p>
         </div>
         <Suspense fallback={<div className="mt-4 h-40 animate-pulse rounded-md bg-[var(--color-surface-raised)]" />}>
           <div className="surface p-6">

--- a/app/auth/update-password/update-password-form.tsx
+++ b/app/auth/update-password/update-password-form.tsx
@@ -88,14 +88,14 @@ export function UpdatePasswordForm() {
         />
       </div>
 
-      {error ? <p className="text-sm text-[var(--color-danger)]">{error}</p> : null}
-      {message ? <p className="text-sm text-[var(--color-success)]">{message}</p> : null}
+      {error ? <p className="text-body text-[var(--color-danger)]">{error}</p> : null}
+      {message ? <p className="text-body text-[var(--color-success)]">{message}</p> : null}
 
       <button type="submit" disabled={isSubmitting} className="btn-primary w-full disabled:opacity-70">
         {isSubmitting ? "Updating password..." : "Update password"}
       </button>
 
-      <p className="text-center text-sm text-muted">
+      <p className="text-center text-body text-muted">
         Need to start over?{" "}
         <Link href="/auth/forgot-password" className="font-medium text-accent hover:text-white">
           Send another reset email

--- a/app/dev/agent-preview/page.tsx
+++ b/app/dev/agent-preview/page.tsx
@@ -29,8 +29,8 @@ export default async function AgentPreviewPage() {
       <div className="mx-auto flex min-h-screen w-full max-w-[960px] flex-col gap-4 px-4 py-10 md:px-6">
         <section className="surface p-6">
           <p className="label">Agent Preview</p>
-          <h1 className="mt-3 text-3xl">Local UI preview mode</h1>
-          <p className="mt-2 max-w-2xl text-sm text-muted">
+          <h1 className="mt-3 text-page-hero">Local UI preview mode</h1>
+          <p className="mt-2 max-w-2xl text-body text-muted">
             Use this when agents need a stable authenticated view across the full product without real Supabase sign-in.
           </p>
 
@@ -51,7 +51,7 @@ export default async function AgentPreviewPage() {
           <p className="label">Routes</p>
           <div className="mt-4 grid gap-3 md:grid-cols-2">
             {previewLinks.map((link) => (
-              <Link key={link.href} href={link.href} className="rounded-xl border border-[var(--border-default)] px-4 py-3 text-sm transition hover:border-[var(--border-accent)] hover:bg-[var(--color-surface-raised)]">
+              <Link key={link.href} href={link.href} className="rounded-xl border border-[var(--border-default)] px-4 py-3 text-body transition hover:border-[var(--border-accent)] hover:bg-[var(--color-surface-raised)]">
                 {link.label}
               </Link>
             ))}

--- a/app/offline/offline-content.tsx
+++ b/app/offline/offline-content.tsx
@@ -20,7 +20,7 @@ export function OfflineContent() {
           />
         </svg>
       </div>
-      <h1 className="font-[family-name:var(--font-geist-sans)] text-2xl font-bold text-[var(--color-text-primary)]">
+      <h1 className="font-[family-name:var(--font-geist-sans)] text-page-title font-semibold text-[var(--color-text-primary)]">
         You&apos;re offline
       </h1>
       <p className="mt-3 max-w-sm font-[family-name:var(--font-geist-sans)] text-[var(--color-text-secondary)]">
@@ -29,7 +29,7 @@ export function OfflineContent() {
       </p>
       <button
         onClick={() => window.location.reload()}
-        className="mt-8 rounded-[var(--radius-md)] bg-[var(--color-accent)] px-6 py-3 font-[family-name:var(--font-geist-sans)] text-sm font-semibold text-[var(--color-base)] transition-opacity hover:opacity-90"
+        className="mt-8 rounded-[var(--radius-md)] bg-[var(--color-accent)] px-6 py-3 font-[family-name:var(--font-geist-sans)] text-body font-medium text-[var(--color-base)] transition-opacity hover:opacity-90"
       >
         Try again
       </button>

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -6,7 +6,7 @@ export default function HomePage() {
       <div className="space-y-4">
         <p className="label">tri.ai</p>
         <h1 className="text-4xl tracking-tight">Your AI training companion for triathlon</h1>
-        <p className="max-w-2xl text-lg text-muted">
+        <p className="max-w-2xl text-section-title text-muted">
           Build your weekly plan, track execution, and get coach-style insights without a noisy interface.
         </p>
       </div>


### PR DESCRIPTION
Stacks on #298. Sweeps every remaining surface — everything except plan / calendar / coach (still blocked by Sprint 4 #294).

## Scope

43 files · 322 insertions · 322 deletions · pure class rename, no logic or markup changes.

Surfaces covered:
- `debrief`
- `progress-report`
- `activities`
- `settings` (page, race, integrations, athlete-context, locale)
- `auth` (sign-in, sign-up, forgot-password, update-password)
- Global shell (layout, global-header, shell-nav, status-strip, account-menu, coach-panel, error)
- `dev/agent-preview`
- `offline`

## Rules applied (same as #296–#298)

**Size swaps:**
| Raw Tailwind | Semantic utility |
|---|---|
| `text-xs` | `text-ui-label` (13 / 500) |
| `text-sm` / `text-base` | `text-body` (15 / 400) |
| `text-lg` | `text-section-title` (17 / 500) |
| `text-xl` / `text-2xl` | `text-page-title` (22 / 600) |
| `text-3xl` | `text-page-hero` (32 / 600) |
| `text-[10/11/13px]` + uppercase tracking | `text-kicker` (11 / 500 · 0.12em) |
| `text-[10/11/13px]` other | `text-ui-label` |

**Weight audit:**
- `text-body font-semibold` → `text-body font-medium` (audit demote)
- Redundant weights (`text-kicker font-medium`, `text-page-title font-semibold`, etc.) dropped
- Genuine emphasis (section H2 semibold, status-chip semibold, alert kickers, display heroes) kept

## Kept out of scale
- `text-4xl` / `text-6xl` / `text-7xl` on display hero numbers
- `text-[9px]` on micro-badges (below 11px kicker floor)

## Test plan
- [ ] `npm run typecheck` — clean (verified locally)
- [ ] Visual: debrief, settings, activities, auth pages render with the same 3-tier weight hierarchy established on dashboard + session review
- [ ] With #295 → #296 → #297 → #298 → this PR merged, F02 covers every surface except plan / calendar / coach (waiting on Sprint 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)