### PR TITLE
fix(calendar): persist Mark as extra when no prior session link exists

### DIFF
--- a/app/(protected)/activities/[activityId]/actions.ts
+++ b/app/(protected)/activities/[activityId]/actions.ts
@@ -119,20 +119,34 @@ export async function markUnplannedAction(activityId: string) {
     .filter((link: any) => link.planned_session_id && (link.confirmation_status === "confirmed" || link.confirmation_status === null))
     .map((link: any) => link.planned_session_id as string);
 
-  // Mark links as rejected instead of deleting — preserves audit trail and
-  // provides a fallback signal for classifyActivityStatus (mirrors the
-  // persistExtraActivityMarker logic in calendar/actions.ts).
+  // Upsert a rejected link so classifyActivityStatus has a persistent signal
+  // even when the `is_unplanned` column write silently no-ops. Mirrors the
+  // persistExtraActivityMarker logic in calendar/actions.ts.
+  const nowIso = new Date().toISOString();
   if (existingLinks && existingLinks.length > 0) {
     await supabase
       .from("session_activity_links")
       .update({
         confirmation_status: "rejected",
+        planned_session_id: null,
         matched_by: user.id,
-        matched_at: new Date().toISOString(),
+        matched_at: nowIso,
         match_method: "unmatched"
       })
       .eq("user_id", user.id)
       .eq("completed_activity_id", activityId);
+  } else {
+    await supabase.from("session_activity_links").insert({
+      user_id: user.id,
+      completed_activity_id: activityId,
+      planned_session_id: null,
+      link_type: "manual",
+      confirmation_status: "rejected",
+      matched_by: user.id,
+      matched_at: nowIso,
+      match_method: "unmatched",
+      match_reason: { source: "mark_as_extra" }
+    });
   }
 
   const { error } = await supabase.from("completed_activities").update({ is_unplanned: true, schedule_status: "unscheduled" }).eq("id", activityId).eq("user_id", user.id);

--- a/app/(protected)/calendar/actions.ts
+++ b/app/(protected)/calendar/actions.ts
@@ -108,7 +108,36 @@ async function persistExtraActivityMarker(params: {
     throw new Error(loadLinksError.message ?? "Could not load existing activity links.");
   }
 
+  const nowIso = new Date().toISOString();
+
   if (!existingLinks || existingLinks.length === 0) {
+    const { error: insertError } = await supabase.from("session_activity_links").insert({
+      user_id: userId,
+      completed_activity_id: activityId,
+      planned_session_id: null,
+      link_type: "manual",
+      confirmation_status: "rejected",
+      matched_by: userId,
+      matched_at: nowIso,
+      match_method: "unmatched",
+      match_reason: { source: "mark_as_extra" }
+    });
+
+    if (insertError) {
+      // Schema drift: on DBs that haven't run migration 202602220006
+      // planned_session_id is still NOT NULL, so the sentinel insert fails with
+      // 23502. Log and continue — the upload.status="matched" write still runs,
+      // so the settings page stays correct; the calendar card will only fully
+      // recover once the missing migration (plus 202602220007 for is_unplanned)
+      // is applied.
+      if (insertError.code === "23502" || isMissingColumnError(insertError)) {
+        console.warn(
+          `[mark-extra] Skipping rejected-link sentinel (schema drift): ${insertError.message}`
+        );
+        return;
+      }
+      throw new Error(insertError.message ?? "Could not persist extra workout state.");
+    }
     return;
   }
 
@@ -116,8 +145,9 @@ async function persistExtraActivityMarker(params: {
     .from("session_activity_links")
     .update({
       confirmation_status: "rejected",
+      planned_session_id: null,
       matched_by: userId,
-      matched_at: new Date().toISOString(),
+      matched_at: nowIso,
       match_method: "unmatched"
     })
     .eq("user_id", userId)

--- a/lib/activities/activity-status.test.ts
+++ b/lib/activities/activity-status.test.ts
@@ -41,6 +41,16 @@ describe("classifyActivityStatus", () => {
     ).toBe("extra");
   });
 
+  it("returns 'extra' for a rejected link with null planned_session_id (mark-as-extra sentinel)", () => {
+    expect(
+      classifyActivityStatus({
+        activityId: "a1",
+        isUnplanned: false,
+        links: [{ completed_activity_id: "a1", planned_session_id: null, confirmation_status: "rejected" }]
+      })
+    ).toBe("extra");
+  });
+
   it("returns 'unreviewed' for new upload with no links", () => {
     expect(
       classifyActivityStatus({

--- a/supabase/migrations/202604230001_repair_activity_schema_drift.sql
+++ b/supabase/migrations/202604230001_repair_activity_schema_drift.sql
@@ -1,0 +1,18 @@
+-- Repair migration: a prior project state has migrations 202602220006 and
+-- 202602220007 marked as applied in `supabase_migrations.schema_migrations`,
+-- but their DDL effects are missing from the live schema. This re-applies the
+-- expected end state idempotently.
+--
+-- Drift observed (2026-04-23):
+-- - session_activity_links.planned_session_id is still NOT NULL (should be
+--   nullable per 202602220006).
+-- - completed_activities.is_unplanned / is_race / notes columns are missing
+--   (should exist per 202602220007).
+
+alter table public.session_activity_links
+  alter column planned_session_id drop not null;
+
+alter table public.completed_activities
+  add column if not exists notes text,
+  add column if not exists is_unplanned boolean not null default false,
+  add column if not exists is_race boolean not null default false;


### PR DESCRIPTION
## Summary
- `persistExtraActivityMarker` / `markUnplannedAction` only updated existing `session_activity_links` rows, so activities that had never been auto-matched had no rejected-link signal after Mark as extra. Combined with `completed_activities.is_unplanned` column drift, the calendar classifier had no persistent extra-signal and the card reverted to "Review upload" on refresh — even though the settings page still showed "Extra" (via the `upload.status === "matched"` fallback).
- Insert a rejected-link sentinel with `planned_session_id = null` when no existing link is found, giving `classifyActivityStatus` a persistent signal that survives refresh and is wiped by the existing attach/unlink flows (both delete links by `completed_activity_id` before inserting).
- Tolerate legacy schema: on `23502` (NOT NULL violation) or `42703` (missing column), log and return instead of 500-ing. The `upload.status = "matched"` write still runs so the settings page stays correct.
- Add a repair migration for DBs where `202602220006` (drop `planned_session_id` NOT NULL) and `202602220007` (add `is_unplanned` / `is_race` / `notes`) are marked applied in `schema_migrations` but the DDL never actually ran — idempotent (`DROP NOT NULL`, `ADD COLUMN IF NOT EXISTS`).

## Test plan
- [x] `npx jest lib/activities/activity-status.test.ts` — new test covers rejected link with null `planned_session_id`
- [x] `npx jest app/(protected)/calendar/week-calendar.test.tsx` — all 10 scenarios pass
- [x] `npm run lint` — clean
- [x] `npm run typecheck` — clean
- [x] Manually verified in prod: after applying the repair migration, Mark as extra persists across refresh on the calendar
- [ ] Confirm attach/unlink flows wipe the sentinel link correctly (both use `delete … where completed_activity_id = X`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)