### PR TITLE
fix(progress-report): normalize Postgres timestamps before Zod validation

### DIFF
--- a/app/(protected)/progress-report/page.tsx
+++ b/app/(protected)/progress-report/page.tsx
@@ -465,9 +465,11 @@ export default async function ProgressReportPage({
         stale: false,
         sourceUpdatedAt: artifact.sourceUpdatedAt
       };
-    } catch {
+    } catch (err) {
       // Keep the existing snapshot; render will fall back to the empty state
-      // below if there is still no artifact.
+      // below if there is still no artifact. Log so silent failures here don't
+      // hide upstream bugs (e.g. schema validation rejecting persisted rows).
+      console.error("[progress-report] refreshProgressReport failed", err);
     }
   }
 

--- a/lib/progress-report/index.ts
+++ b/lib/progress-report/index.ts
@@ -166,6 +166,16 @@ async function resolveBlockBounds(args: {
   return { ...bounds, blockId: null, priorBlockId: null };
 }
 
+/**
+ * Postgres `timestamptz` columns come back from PostgREST in the form
+ * `2026-04-23T20:49:27.22214+00:00` — Zod's default `.datetime()` wants a
+ * `Z` suffix and rejects offset form. Round-trip through `Date` so the
+ * schema sees a canonical `…Z` string.
+ */
+function normalizeIsoTimestamp(value: string): string {
+  return new Date(value).toISOString();
+}
+
 function hydratePersistedArtifact(record: ProgressReportRecord): ProgressReportArtifact | null {
   try {
     const facts = progressReportFactsSchema.parse(record.facts);
@@ -174,8 +184,8 @@ function hydratePersistedArtifact(record: ProgressReportRecord): ProgressReportA
       blockStart: record.block_start,
       blockEnd: record.block_end,
       status: record.status,
-      sourceUpdatedAt: record.source_updated_at,
-      generatedAt: record.generated_at,
+      sourceUpdatedAt: normalizeIsoTimestamp(record.source_updated_at),
+      generatedAt: normalizeIsoTimestamp(record.generated_at),
       generationVersion: record.generation_version,
       facts,
       narrative,
@@ -184,9 +194,15 @@ function hydratePersistedArtifact(record: ProgressReportRecord): ProgressReportA
         accurate: record.accurate,
         note: record.feedback_note,
         updatedAt: record.feedback_updated_at
+          ? normalizeIsoTimestamp(record.feedback_updated_at)
+          : null
       }
     });
-  } catch {
+  } catch (err) {
+    console.error(
+      "[progress-report] hydratePersistedArtifact failed — falling back to null",
+      err
+    );
     return null;
   }
 }

--- a/lib/progress-report/persistence.ts
+++ b/lib/progress-report/persistence.ts
@@ -36,6 +36,17 @@ export type ProgressReportReadiness = {
   sourceUpdatedAt: string;
 };
 
+/**
+ * Postgres `timestamptz` columns come back from PostgREST in the form
+ * `2026-04-23T20:49:27.22214+00:00` — i.e. offset suffix + arbitrary
+ * fractional precision — which Zod's default `.datetime()` rejects (it wants
+ * a `Z` suffix). Round-trip through `Date` so the schema sees a canonical
+ * `…Z` string regardless of how Postgres formatted it.
+ */
+function normalizeIsoTimestamp(value: string): string {
+  return new Date(value).toISOString();
+}
+
 function normalizePersistedRecord(
   record: ProgressReportRecord,
   effectiveStatus: "ready" | "stale" | "failed"
@@ -46,8 +57,8 @@ function normalizePersistedRecord(
     blockStart: record.block_start,
     blockEnd: record.block_end,
     status: effectiveStatus,
-    sourceUpdatedAt: record.source_updated_at,
-    generatedAt: record.generated_at,
+    sourceUpdatedAt: normalizeIsoTimestamp(record.source_updated_at),
+    generatedAt: normalizeIsoTimestamp(record.generated_at),
     generationVersion: record.generation_version,
     facts: rawFacts,
     narrative: rawNarrative,
@@ -56,6 +67,8 @@ function normalizePersistedRecord(
       accurate: record.accurate,
       note: record.feedback_note,
       updatedAt: record.feedback_updated_at
+        ? normalizeIsoTimestamp(record.feedback_updated_at)
+        : null
     }
   });
 }

--- a/lib/progress-report/schema.test.ts
+++ b/lib/progress-report/schema.test.ts
@@ -1,4 +1,5 @@
 import {
+  progressReportArtifactSchema,
   progressReportFactsSchema,
   progressReportNarrativeSchema,
   type ProgressReportFacts,
@@ -188,6 +189,68 @@ describe("progressReportNarrativeSchema", () => {
       carryForward: [validNarrative.carryForward[0]]
     });
     expect(parsed.success).toBe(false);
+  });
+});
+
+describe("progressReportArtifactSchema timestamp handling", () => {
+  // Postgres `timestamptz` columns return values like
+  // `2026-04-23T20:49:27.22214+00:00` — offset suffix + arbitrary fractional
+  // precision — which Zod's default `.datetime()` rejects. The persistence
+  // layer must normalize these via `new Date(value).toISOString()` before
+  // validating; these tests lock that contract in.
+  const baseArtifact = {
+    blockStart: "2026-03-23",
+    blockEnd: "2026-04-19",
+    status: "ready" as const,
+    generationVersion: 1,
+    facts: validFacts,
+    narrative: {
+      coachHeadline: "Run economy stepped up while bike held flat",
+      executiveSummary:
+        "You added 70 minutes and one session while total CTL rose 3.9 points. Run pace-at-HR improved from 5:12 to 5:05/km at the same cost; bike power-at-HR held.",
+      fitnessReport:
+        "Total CTL moved 58.2 → 62.1 (Δ +3.9). Run CTL climbed from 26.1 to 28.4 (Δ +2.3).",
+      durabilityReport:
+        "Aerobic decoupling averaged 3.2% across three ≥45-min endurance sessions, down from 5.1% last block.",
+      peakPerformancesReport:
+        "Best run pace of 4:40/km came from the Apr 12 session — 12s/km faster than the prior block's peak.",
+      disciplineVerdicts: [
+        {
+          sport: "run" as const,
+          verdict: "Run economy is the clearest adaptation: 5:05/km at 148 bpm vs 5:12 at 149 bpm last block."
+        }
+      ],
+      nonObviousInsight:
+        "Run CTL rose more than bike CTL, yet ramp rate stayed inside 3 points — adaptation is concentrating on running.",
+      teach: null,
+      carryForward: [
+        "Hold the current easy-pace discipline on run — it is producing 7–12s/km improvement at the same HR.",
+        "Add one ≥60-min bike endurance ride per week next block to give the bike aerobic system the same stimulus."
+      ] as [string, string]
+    }
+  };
+
+  const pgTimestamp = "2026-04-23T20:49:27.22214+00:00";
+
+  test("rejects raw Postgres timestamptz format (motivates boundary normalization)", () => {
+    const parsed = progressReportArtifactSchema.safeParse({
+      ...baseArtifact,
+      sourceUpdatedAt: pgTimestamp,
+      generatedAt: pgTimestamp,
+      feedback: { helpful: null, accurate: null, note: null, updatedAt: null }
+    });
+    expect(parsed.success).toBe(false);
+  });
+
+  test("accepts Postgres timestamps once normalized through `new Date().toISOString()`", () => {
+    const normalized = new Date(pgTimestamp).toISOString();
+    const parsed = progressReportArtifactSchema.safeParse({
+      ...baseArtifact,
+      sourceUpdatedAt: normalized,
+      generatedAt: normalized,
+      feedback: { helpful: null, accurate: null, note: null, updatedAt: normalized }
+    });
+    expect(parsed.success).toBe(true);
   });
 });
 


### PR DESCRIPTION
## Summary

- Postgres `timestamptz` columns return values like `2026-04-23T20:49:27.22214+00:00` (offset suffix, 5-digit fractional seconds), which Zod's default `.datetime()` rejects — it expects a `Z` suffix. The artifact schema therefore failed on every persisted row.
- This made `/progress-report` take ~40s per visit (silent validation failure → re-running the AI on every load → swallowing the same error → empty state).
- Fix: normalize via `new Date(value).toISOString()` at the DB boundary in both `hydratePersistedArtifact` and `normalizePersistedRecord`.
- Stop swallowing errors silently in the page's refresh catch and in `hydratePersistedArtifact` — log them so this class of bug surfaces next time.

## Test plan

- [x] `npx jest lib/progress-report` — 23 tests pass, includes new regression tests proving the schema rejects raw PG format and accepts the normalized form
- [x] `npm run typecheck` — clean
- [x] Verified end-to-end against real production data: `refreshProgressReport` now persists and hydrates a clean artifact (`hasArtifact: true, stale: false`) — subsequent visits will be instant with no AI re-run
- [ ] Visit `/progress-report` in the browser; first visit may regenerate (~40s) for blocks without a clean artifact, subsequent visits should be instant

🤖 Generated with [Claude Code](https://claude.com/claude-code)