### PR TITLE
fix(dashboard): hide "new activity" banner for backfilled old uploads

### DIFF
--- a/app/(protected)/dashboard/page.tsx
+++ b/app/(protected)/dashboard/page.tsx
@@ -1069,12 +1069,15 @@ async function DashboardRecentUpload(props: {
   if (!props?.supabase) return null;
   const { supabase, userId } = props;
   try {
-    // Find recently-synced activities (last 4 hours) that haven't been reviewed via feel capture
+    // Find recently-synced activities (last 4 hours) whose workout actually happened recently (last 36 hours)
+    // so backfilled uploads of old sessions don't trigger the "how did it feel?" prompt.
+    const now = Date.now();
     const { data: recentActivity } = await supabase
       .from("completed_activities")
       .select("id,sport_type,duration_sec")
       .eq("user_id", userId)
-      .gte("created_at", new Date(Date.now() - 4 * 3600 * 1000).toISOString())
+      .gte("created_at", new Date(now - 4 * 3600 * 1000).toISOString())
+      .gte("start_time_utc", new Date(now - 36 * 3600 * 1000).toISOString())
       .order("created_at", { ascending: false })
       .limit(1)
       .maybeSingle();


### PR DESCRIPTION
## Summary
- `DashboardRecentUpload` filtered only on `created_at`, so re-uploading an old workout (e.g. a Jan 5th activity uploaded today) surfaced it as *"You completed X — how did it feel?"* on the dashboard.
- Added a `start_time_utc >= now - 36h` filter so the banner only fires when the workout itself actually happened recently. The 4h `created_at` window is retained so a fresh sync is still required to trigger the prompt.
- Narrow fix, no behavior change for genuinely recent uploads.

## Test plan
- [ ] Upload an activity whose `start_time_utc` is > 36h ago → no "new activity" banner on `/dashboard`.
- [ ] Upload a same-day activity → banner appears with feel prompt.
- [ ] Dismissing and refreshing re-evaluates the query (already existing behavior, unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)