### PR TITLE
fix(weekly-debrief): guarantee 3+ metrics and extend deep-call timeout

### DIFF
--- a/lib/ai/call-with-fallback.ts
+++ b/lib/ai/call-with-fallback.ts
@@ -42,6 +42,12 @@ type CallWithFallbackOptions<T> = {
   postProcess?: (parsed: T) => T;
   /** Extra context fields included in console.warn log entries. */
   logContext?: Record<string, unknown>;
+  /**
+   * Override for the per-request timeout in milliseconds. Defaults to
+   * getCoachRequestTimeoutMs() (60s). Raise for deep-reasoning calls that
+   * routinely exceed the default.
+   */
+  timeoutMs?: number;
 };
 
 type CallWithFallbackResult<T> = {
@@ -66,7 +72,7 @@ export async function callOpenAIWithFallback<T>(
 
   try {
     const client = getOpenAIClient();
-    const timeoutMs = getCoachRequestTimeoutMs();
+    const timeoutMs = opts.timeoutMs ?? getCoachRequestTimeoutMs();
     const startedAt = Date.now();
 
     const requestParams = opts.buildRequest();
@@ -133,7 +139,7 @@ export async function callOpenAIWithFallback<T>(
     const value = opts.postProcess ? opts.postProcess(parsed.data) : parsed.data;
     return { value, source: "ai" };
   } catch (error) {
-    const timeoutMs = getCoachRequestTimeoutMs();
+    const timeoutMs = opts.timeoutMs ?? getCoachRequestTimeoutMs();
     const message =
       error instanceof Error && error.message === "Request timed out."
         ? `OpenAI request timed out after ${Math.round(timeoutMs / 1000)}s`

--- a/lib/progress-report/narrative.ts
+++ b/lib/progress-report/narrative.ts
@@ -43,6 +43,7 @@ export async function generateProgressReportNarrative(args: {
   const result = await callOpenAIWithFallback<ProgressReportNarrative>({
     logTag: "progress-report",
     fallback: args.deterministicFallback,
+    timeoutMs: 120_000,
     buildRequest: () => ({
       model: getCoachModel({ deep: true }),
       instructions: INSTRUCTIONS,

--- a/lib/weekly-debrief.test.ts
+++ b/lib/weekly-debrief.test.ts
@@ -305,4 +305,57 @@ describe("weekly debrief helpers", () => {
     expect(result.evidence.some((item) => item.detail.includes("74 TSS"))).toBe(true);
     expect(result.deterministicNarrative.observations.length).toBeGreaterThan(0);
   });
+
+  // Regression: a clean week with no execution reviews, zero skipped, zero added
+  // used to produce only 2 metrics, which failed the z.array(...).min(3) schema
+  // guard during refreshWeeklyDebrief. The 5th metric now always emits.
+  test("emits at least 3 metrics on a quiet week with no reviews or drift", () => {
+    const result = buildWeeklyDebriefFacts({
+      sessions: [
+        {
+          id: "session-a",
+          date: "2025-11-17",
+          sport: "run",
+          type: "Easy Run",
+          session_name: "Easy Run",
+          notes: null,
+          status: "completed",
+          duration_minutes: 45,
+          updated_at: "2025-11-17T10:00:00.000Z",
+          created_at: "2025-11-16T10:00:00.000Z",
+          execution_result: null,
+          is_key: false
+        },
+        {
+          id: "session-b",
+          date: "2025-11-19",
+          sport: "bike",
+          type: "Endurance Ride",
+          session_name: "Endurance Ride",
+          notes: null,
+          status: "completed",
+          duration_minutes: 60,
+          updated_at: "2025-11-19T10:00:00.000Z",
+          created_at: "2025-11-16T10:00:00.000Z",
+          execution_result: null,
+          is_key: false
+        }
+      ],
+      activities: [],
+      links: [],
+      athleteContext: null,
+      sessionFeels: [],
+      timeZone: "UTC",
+      weekStart: "2025-11-17",
+      weekEnd: "2025-11-23",
+      todayIso: "2025-11-23",
+      checkIn: null
+    });
+
+    expect(result.facts.metrics.length).toBeGreaterThanOrEqual(3);
+    const weekShape = result.facts.metrics.find((metric) => metric.label === "Week shape");
+    expect(weekShape).toBeDefined();
+    expect(weekShape!.value).toBe("On plan");
+    expect(weekShape!.tone).toBe("muted");
+  });
 });

--- a/lib/weekly-debrief/analytic-findings.ts
+++ b/lib/weekly-debrief/analytic-findings.ts
@@ -82,6 +82,7 @@ export async function generateAnalyticFindings(args: {
   const result = await callOpenAIWithFallback<WeeklyFindings>({
     logTag: "weekly-debrief-findings",
     fallback: FINDINGS_FALLBACK_SENTINEL,
+    timeoutMs: 120_000,
     buildRequest: () => ({
       model: getCoachModel({ deep: true }),
       instructions: ANALYTIC_INSTRUCTIONS,

--- a/lib/weekly-debrief/facts.ts
+++ b/lib/weekly-debrief/facts.ts
@@ -857,12 +857,19 @@ export function buildWeeklyDebriefFacts(input: WeeklyDebriefInputs) {
       detail: strongestExecutionSession.review?.deterministic.rulesSummary.intentMatch === "on_target" ? "Stayed closest to target" : strongestExecutionSession.review?.executionScoreBand ?? null,
       tone: "positive" as const
     }] : []),
-    ...((latestIssueSession || skippedSessions > 0 || addedSessions > 0) ? [{
-      label: latestIssueSession ? "Biggest drift" : "Week shape",
-      value: latestIssueSession ? latestIssueSession.label : skippedSessions > 0 ? `${skippedSessions} missed` : `${addedSessions} added`,
-      detail: latestIssueSession ? null : skippedSessions > 0 ? "Back-half looseness" : "Added work changed the shape",
-      tone: latestIssueSession || skippedSessions > 0 ? "caution" as const : "muted" as const
-    }] : [])
+    (latestIssueSession || skippedSessions > 0 || addedSessions > 0)
+      ? {
+          label: latestIssueSession ? "Biggest drift" : "Week shape",
+          value: latestIssueSession ? latestIssueSession.label : skippedSessions > 0 ? `${skippedSessions} missed` : `${addedSessions} added`,
+          detail: latestIssueSession ? null : skippedSessions > 0 ? "Back-half looseness" : "Added work changed the shape",
+          tone: latestIssueSession || skippedSessions > 0 ? "caution" as const : "muted" as const
+        }
+      : {
+          label: "Week shape",
+          value: plannedSessions > 0 ? "On plan" : "Open week",
+          detail: plannedSessions > 0 ? "No drift, skips, or extras" : "No planned sessions",
+          tone: "muted" as const
+        }
   ];
 
   const draftFacts = weeklyDebriefFactsSchema.parse({


### PR DESCRIPTION
## Summary
- **Bug fix:** Quiet weeks (no execution reviews, zero skipped, zero added) only produced 2 metrics, failing the facts schema's `min(3)` guard and throwing out of `refreshWeeklyDebrief`. The 5th "Week shape" metric now always emits — defaulting to `"On plan"` / muted tone when nothing drifted — so historical weeks refresh cleanly.
- **Quality improvement:** Adds optional `timeoutMs` to `callOpenAIWithFallback`. The weekly analytic findings pass (gpt-5.4 deep reasoning, medium effort, 8k output) and progress-report narrative pass now use a 120s timeout. The 60s default was routinely timing out, forcing the narrative pass to run without structured findings and degrading output quality.

Reported via the `refresh-ai` script output on weeks 2025-11-17 and 2025-11-24.

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean
- [x] `npx jest lib/weekly-debrief` — 5 suites, 26 tests passing (1 new regression test)
- [x] Full `npm run test` — only pre-existing unrelated failure in `lib/training/ambient-signals.test.ts` (fails on main too)
- [ ] Re-run `npm run refresh-ai -- --user=<uuid> --scope=weekly` and confirm the previously-failing weeks now persist artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)