### PR TITLE
feat(race-bundling): collapse multi-activity triathlons into one calendar item

### DIFF
--- a/app/(protected)/calendar/week-calendar.tsx
+++ b/app/(protected)/calendar/week-calendar.tsx
@@ -39,6 +39,13 @@ type CalendarSession = {
   is_key?: boolean;
   isUnplanned?: boolean;
   displayType?: "planned_session" | "completed_activity";
+  raceSegments?: Array<{
+    activityId: string;
+    role: "swim" | "t1" | "bike" | "t2" | "run";
+    sport: string;
+    durationMin: number;
+    distanceKm: number | null;
+  }> | null;
 };
 
 type WeekDay = { iso: string; weekday: string; label: string };
@@ -911,6 +918,17 @@ export function WeekCalendar({
                   const isClickable = reviewableCompleted || Boolean(extraActivityId);
                   const showCompletedFooter = state === "completed" || state === "assigned_from_upload" || state === "extra";
                   const cardTitle = state === "unmatched_upload" ? "Uploaded workout" : getSessionTitle(session);
+                  const raceSegments = session.raceSegments ?? null;
+                  const isRaceCard = Boolean(raceSegments && raceSegments.length >= 3);
+                  const raceSubtitle = isRaceCard && raceSegments
+                    ? raceSegments
+                        .filter((seg) => seg.role === "swim" || seg.role === "bike" || seg.role === "run")
+                        .map((seg) => `${seg.role === "swim" ? "Swim" : seg.role === "bike" ? "Bike" : "Run"} ${seg.durationMin}m`)
+                        .join(" · ")
+                    : null;
+                  const raceTotalMin = isRaceCard && raceSegments
+                    ? raceSegments.reduce((sum, seg) => sum + seg.durationMin, 0)
+                    : null;
 
                   return (
                     <article
@@ -939,11 +957,22 @@ export function WeekCalendar({
                     >
                       <div className="flex items-center justify-between gap-1">
                         <div className="flex items-center gap-1">
-                          <span className="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px]" style={{ backgroundColor: disciplineTone.bg, color: disciplineTone.text, borderColor: disciplineTone.border }}>
-                            <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: disciplineTone.dot }} />
-                            {discipline.label}
-                          </span>
+                          {isRaceCard ? (
+                            <span className="inline-flex items-center gap-0.5 rounded-full border px-1.5 py-0.5 text-[10px]"
+                                  style={{ backgroundColor: "rgba(196,135,114,0.12)", color: "#F0D3C8", borderColor: "rgba(196,135,114,0.28)" }}>
+                              <span aria-hidden="true">🏊</span>
+                              <span aria-hidden="true">🚴</span>
+                              <span aria-hidden="true">🏃</span>
+                              <span className="ml-1 font-medium tracking-wide">Race</span>
+                            </span>
+                          ) : (
+                            <span className="inline-flex items-center gap-1 rounded-full border px-1.5 py-0.5 text-[10px]" style={{ backgroundColor: disciplineTone.bg, color: disciplineTone.text, borderColor: disciplineTone.border }}>
+                              <span className="h-1.5 w-1.5 rounded-full" style={{ backgroundColor: disciplineTone.dot }} />
+                              {discipline.label}
+                            </span>
+                          )}
                           {(() => {
+                            if (isRaceCard) return null;
                             const pill = getRolePill(session);
                             if (!pill) return null;
                             return (
@@ -976,12 +1005,18 @@ export function WeekCalendar({
                       </div>
                       <p className="mt-1 min-h-[1.5rem] font-medium leading-snug">{cardTitle}</p>
                       <div className="mt-0 flex flex-wrap items-center gap-1">
-                        <span className="text-[11px] text-muted">{session.duration} min{state === "unmatched_upload" ? ` · logged ${uploadDateFormatter.format(new Date(`${session.created_at}`))}` : ""}</span>
-                        {state !== "unmatched_upload" ? (() => {
+                        <span className="text-[11px] text-muted">
+                          {isRaceCard && raceTotalMin !== null
+                            ? `${raceTotalMin} min total`
+                            : `${session.duration} min${state === "unmatched_upload" ? ` · logged ${uploadDateFormatter.format(new Date(`${session.created_at}`))}` : ""}`}
+                        </span>
+                        {isRaceCard && raceSubtitle ? (
+                          <span className="text-[11px] text-muted">· {raceSubtitle}</span>
+                        ) : state !== "unmatched_upload" ? (() => {
                           const target = extractTargetLine(session);
                           return target ? <span className="text-[11px] text-muted">· {target}</span> : null;
                         })() : null}
-                        {session.intentCategory && state !== "unmatched_upload" ? (
+                        {session.intentCategory && !isRaceCard && state !== "unmatched_upload" ? (
                           <span className={`rounded-full px-1.5 py-0.5 text-[9px] font-medium ${getIntentPillClass(session.intentCategory)}`}>
                             {getIntentLabel(session.intentCategory)}
                           </span>

--- a/app/(protected)/sessions/[sessionId]/components/race-segment-list.tsx
+++ b/app/(protected)/sessions/[sessionId]/components/race-segment-list.tsx
@@ -1,0 +1,134 @@
+import Link from "next/link";
+
+export type RaceSegmentSummary = {
+  activityId: string;
+  role: "swim" | "t1" | "bike" | "t2" | "run";
+  sport: string;
+  startTimeUtc: string;
+  durationSec: number;
+  distanceM: number | null;
+  avgHr: number | null;
+  avgPower: number | null;
+};
+
+const ROLE_LABELS: Record<RaceSegmentSummary["role"], string> = {
+  swim: "Swim",
+  t1: "T1",
+  bike: "Bike",
+  t2: "T2",
+  run: "Run"
+};
+
+const ROLE_ICONS: Record<RaceSegmentSummary["role"], string> = {
+  swim: "🏊",
+  t1: "⏱",
+  bike: "🚴",
+  t2: "⏱",
+  run: "🏃"
+};
+
+function formatDuration(sec: number): string {
+  const total = Math.max(0, Math.round(sec));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function formatDistance(meters: number | null, role: RaceSegmentSummary["role"]): string | null {
+  if (meters === null || meters === undefined) return null;
+  if (role === "swim") {
+    if (meters < 1000) return `${Math.round(meters)} m`;
+    return `${(meters / 1000).toFixed(2)} km`;
+  }
+  return `${(meters / 1000).toFixed(2)} km`;
+}
+
+function formatPace(role: RaceSegmentSummary["role"], durationSec: number, distanceM: number | null): string | null {
+  if (!distanceM || distanceM <= 0 || durationSec <= 0) return null;
+  if (role === "swim") {
+    const secPer100 = durationSec / (distanceM / 100);
+    const m = Math.floor(secPer100 / 60);
+    const s = Math.round(secPer100 % 60);
+    return `${m}:${String(s).padStart(2, "0")} /100m`;
+  }
+  if (role === "run") {
+    const secPerKm = durationSec / (distanceM / 1000);
+    const m = Math.floor(secPerKm / 60);
+    const s = Math.round(secPerKm % 60);
+    return `${m}:${String(s).padStart(2, "0")} /km`;
+  }
+  if (role === "bike") {
+    const kph = distanceM / 1000 / (durationSec / 3600);
+    return `${kph.toFixed(1)} kph`;
+  }
+  return null;
+}
+
+export function RaceSegmentList({ segments }: { segments: RaceSegmentSummary[] }) {
+  if (segments.length === 0) return null;
+
+  const totalSec = segments.reduce((sum, s) => sum + s.durationSec, 0);
+  const totalDistanceM = segments.reduce((sum, s) => sum + (s.distanceM ?? 0), 0);
+  const startedAt = segments[0].startTimeUtc;
+  const finishedAtMs = new Date(segments[segments.length - 1].startTimeUtc).getTime()
+    + Math.max(0, segments[segments.length - 1].durationSec) * 1000;
+  const finishedAt = new Date(finishedAtMs).toISOString();
+
+  const startTimeFormatter = new Intl.DateTimeFormat("en-US", {
+    hour: "numeric",
+    minute: "2-digit",
+    timeZone: "UTC"
+  });
+
+  return (
+    <article className="surface p-5">
+      <header className="flex flex-col gap-1 border-b border-[hsl(var(--border))] pb-3">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race segments</p>
+        <div className="flex flex-wrap items-baseline gap-x-3 gap-y-1 text-sm">
+          <span className="text-base font-semibold text-[rgba(255,255,255,0.92)]">{formatDuration(totalSec)}</span>
+          <span className="text-muted">total</span>
+          {totalDistanceM > 0 ? (
+            <>
+              <span className="text-tertiary">·</span>
+              <span className="text-muted">{(totalDistanceM / 1000).toFixed(2)} km</span>
+            </>
+          ) : null}
+          <span className="text-tertiary">·</span>
+          <span className="text-muted">{startTimeFormatter.format(new Date(startedAt))} → {startTimeFormatter.format(new Date(finishedAt))}</span>
+        </div>
+      </header>
+
+      <ul className="mt-3 space-y-2">
+        {segments.map((segment) => {
+          const distanceLabel = formatDistance(segment.distanceM, segment.role);
+          const paceLabel = formatPace(segment.role, segment.durationSec, segment.distanceM);
+          return (
+            <li key={segment.activityId}>
+              <Link
+                href={`/activities/${segment.activityId}`}
+                className="flex items-center gap-3 rounded-lg border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 transition hover:border-[rgba(255,255,255,0.18)] hover:bg-[rgba(255,255,255,0.04)]"
+              >
+                <span aria-hidden="true" className="text-lg leading-none">{ROLE_ICONS[segment.role]}</span>
+                <div className="flex min-w-0 flex-1 flex-col">
+                  <div className="flex items-baseline gap-2">
+                    <span className="text-sm font-medium text-[rgba(255,255,255,0.92)]">{ROLE_LABELS[segment.role]}</span>
+                    <span className="text-xs text-muted">{formatDuration(segment.durationSec)}</span>
+                  </div>
+                  <div className="flex flex-wrap gap-x-2 text-[11px] text-tertiary">
+                    {distanceLabel ? <span>{distanceLabel}</span> : null}
+                    {paceLabel ? <span>· {paceLabel}</span> : null}
+                    {segment.avgHr ? <span>· {segment.avgHr} bpm</span> : null}
+                    {segment.avgPower ? <span>· {segment.avgPower} W</span> : null}
+                  </div>
+                </div>
+                <span aria-hidden="true" className="text-tertiary">→</span>
+              </Link>
+            </li>
+          );
+        })}
+      </ul>
+    </article>
+  );
+}

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -12,6 +12,8 @@ import { FeelCaptureBanner } from "./components/feel-capture-banner";
 import { SessionVerdictCard } from "./components/session-verdict-card";
 import { ExtrasVerdictCard } from "./components/extras-verdict-card";
 import { SessionComparisonCard } from "./components/session-comparison-card";
+import { RaceSegmentList, type RaceSegmentSummary } from "./components/race-segment-list";
+import { isRaceSession } from "@/lib/training/race-session";
 import { DetailsAccordion } from "../../details-accordion";
 import { getMonday } from "../../week-context";
 
@@ -395,6 +397,49 @@ export default async function SessionReviewPage({ params, searchParams }: { para
 
   session.has_linked_activity = hasLinkedActivity;
 
+  // Race bundle: load all linked segments when this is a race session.
+  let raceSegmentList: RaceSegmentSummary[] | null = null;
+  if (!activityId && isRaceSession({ type: session.type, session_name: session.session_name })) {
+    try {
+      const { data: raceLinks } = await supabase
+        .from("session_activity_links")
+        .select("completed_activity_id,confirmation_status")
+        .eq("planned_session_id", session.id)
+        .eq("user_id", user.id);
+
+      const confirmedIds = (raceLinks ?? [])
+        .filter((row: any) => row.confirmation_status === "confirmed" || row.confirmation_status === null)
+        .map((row: any) => row.completed_activity_id as string);
+
+      if (confirmedIds.length >= 3) {
+        const { data: segmentRows } = await supabase
+          .from("completed_activities")
+          .select("id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,race_segment_role,race_segment_index")
+          .in("id", confirmedIds)
+          .eq("user_id", user.id);
+
+        const ordered = (segmentRows ?? [])
+          .filter((row: any) => row.race_segment_role)
+          .sort((a: any, b: any) => (a.race_segment_index ?? 0) - (b.race_segment_index ?? 0));
+
+        if (ordered.length >= 3) {
+          raceSegmentList = ordered.map((row: any) => ({
+            activityId: row.id as string,
+            role: row.race_segment_role as RaceSegmentSummary["role"],
+            sport: row.sport_type as string,
+            startTimeUtc: row.start_time_utc as string,
+            durationSec: Number(row.duration_sec ?? 0),
+            distanceM: row.distance_m !== null && row.distance_m !== undefined ? Number(row.distance_m) : null,
+            avgHr: row.avg_hr !== null && row.avg_hr !== undefined ? Number(row.avg_hr) : null,
+            avgPower: row.avg_power !== null && row.avg_power !== undefined ? Number(row.avg_power) : null
+          }));
+        }
+      }
+    } catch {
+      raceSegmentList = null;
+    }
+  }
+
   // Query session_feels for completed sessions (skip for activity-route synthetic sessions)
   let existingFeelData: {
     overall_feel: number | null;
@@ -671,6 +716,8 @@ export default async function SessionReviewPage({ params, searchParams }: { para
           </div>
         ) : null}
       </article>
+
+      {raceSegmentList ? <RaceSegmentList segments={raceSegmentList} /> : null}
 
       {showFeelCapture ? <FeelCaptureBanner sessionId={session.id} existingFeel={existingFeelData} /> : null}
 

--- a/app/api/race/backfill/route.ts
+++ b/app/api/race/backfill/route.ts
@@ -1,0 +1,70 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { isSameOrigin } from "@/lib/security/request";
+import { isRaceSession } from "@/lib/training/race-session";
+import { attemptRaceBundle } from "@/lib/workouts/race-bundle";
+
+/**
+ * POST /api/race/backfill
+ *
+ * Idempotent backfill: scans the current user's race-flagged planned sessions in
+ * the last 12 months and attempts to bundle same-day completed activities into
+ * a race bundle. Designed to be triggered manually after the race feature ships.
+ */
+export async function POST(request: Request) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: "Invalid request origin." }, { status: 403 });
+  }
+
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+
+  const today = new Date();
+  const horizon = new Date(today.getTime() - 365 * 24 * 60 * 60 * 1000);
+
+  const { data: sessions, error: sessionsError } = await supabase
+    .from("sessions")
+    .select("id,date,sport,type,session_name")
+    .eq("user_id", user.id)
+    .gte("date", horizon.toISOString().slice(0, 10))
+    .lte("date", today.toISOString().slice(0, 10));
+
+  if (sessionsError) {
+    return NextResponse.json({ error: sessionsError.message }, { status: 400 });
+  }
+
+  const raceDates: string[] = Array.from(
+    new Set<string>(
+      (sessions ?? [])
+        .filter((s: any) => isRaceSession({ type: s.type, session_name: s.session_name }))
+        .map((s: any) => String(s.date))
+    )
+  ).sort();
+
+  const summary: Array<{ date: string; status: string; reason?: string; bundleId?: string }> = [];
+  for (const date of raceDates) {
+    try {
+      const result = await attemptRaceBundle({
+        supabase,
+        userId: user.id,
+        date,
+        source: "strava_reconstructed"
+      });
+      if (result.status === "bundled") {
+        summary.push({ date, status: "bundled", bundleId: result.bundleId });
+      } else {
+        summary.push({ date, status: "skipped", reason: result.reason });
+      }
+    } catch (err) {
+      summary.push({
+        date,
+        status: "error",
+        reason: err instanceof Error ? err.message : "unknown_error"
+      });
+    }
+  }
+
+  const bundled = summary.filter((s) => s.status === "bundled").length;
+  return NextResponse.json({ scanned: raceDates.length, bundled, summary });
+}

--- a/app/api/uploads/activities/route.ts
+++ b/app/api/uploads/activities/route.ts
@@ -1,8 +1,16 @@
 import { Buffer } from "node:buffer";
 import { NextResponse } from "next/server";
 import { createClient } from "@/lib/supabase/server";
-import { parseFitFile, parseTcxFile, sha256Hex } from "@/lib/workouts/activity-parser";
+import {
+  isMultisportParseResult,
+  parseFitFile,
+  parseTcxFile,
+  sha256Hex,
+  type ParsedActivity,
+  type ParsedMultisportSegment
+} from "@/lib/workouts/activity-parser";
 import { pickBestSuggestion, suggestSessionMatches } from "@/lib/workouts/matching-service";
+import { persistMultisportBundle } from "@/lib/workouts/race-bundle";
 import { getClientIp, isSameOrigin } from "@/lib/security/request";
 import { checkRateLimit, rateLimitHeaders } from "@/lib/security/rate-limit";
 import { syncSessionLoad } from "@/lib/training/load-sync";
@@ -148,10 +156,8 @@ export async function POST(request: Request) {
     return NextResponse.json({ error: "Could not store upload." }, { status: 400 });
   }
 
-  try {
-    const parsed = extension === ".fit" ? await parseFitFile(bytes) : parseTcxFile(bytes.toString("utf8"));
-
-    const { data: createdActivity, error: activityError } = await supabase
+  const insertCompletedActivity = async (parsed: ParsedActivity) => {
+    return supabase
       .from("completed_activities")
       .insert({
         user_id: user.id,
@@ -186,6 +192,48 @@ export async function POST(request: Request) {
       })
       .select("id,start_time_utc,sport_type,duration_sec,distance_m")
       .single();
+  };
+
+  try {
+    const parsed = extension === ".fit" ? await parseFitFile(bytes) : parseTcxFile(bytes.toString("utf8"));
+
+    if (isMultisportParseResult(parsed)) {
+      const insertedSegments: Array<{ activityId: string; role: ParsedMultisportSegment["role"]; segmentIndex: number }> = [];
+      for (const segment of parsed.segments) {
+        const { data: row, error: segError } = await insertCompletedActivity(segment);
+        if (segError || !row) {
+          throw new Error(segError?.message ?? `Could not save segment ${segment.segmentIndex}`);
+        }
+        insertedSegments.push({
+          activityId: row.id as string,
+          role: segment.role,
+          segmentIndex: segment.segmentIndex
+        });
+      }
+
+      await supabase.from("activity_uploads").update({ status: "parsed" }).eq("id", upload.id).eq("user_id", user.id);
+
+      const linkResult = await persistMultisportBundle({
+        supabase,
+        userId: user.id,
+        uploadId: upload.id,
+        bundle: parsed.bundle,
+        segments: insertedSegments
+      });
+
+      const matchedSessionId = linkResult.status === "linked" ? linkResult.plannedSessionId : null;
+      const bundleId = linkResult.status === "linked" ? linkResult.bundleId : null;
+
+      return NextResponse.json({
+        uploadId: upload.id,
+        multisport: true,
+        bundleId,
+        segmentIds: insertedSegments.map((s) => s.activityId),
+        matchedSessionId
+      }, { headers: rateLimitHeaders(userRateLimit) });
+    }
+
+    const { data: createdActivity, error: activityError } = await insertCompletedActivity(parsed);
 
     if (activityError || !createdActivity) throw new Error(activityError?.message ?? "Could not save parsed activity");
 

--- a/lib/activities/completed-activities.ts
+++ b/lib/activities/completed-activities.ts
@@ -20,6 +20,9 @@ export type CompletedActivityRecord = {
   avg_power: number | null;
   schedule_status: "scheduled" | "unscheduled";
   is_unplanned: boolean;
+  race_bundle_id: string | null;
+  race_segment_role: "swim" | "t1" | "bike" | "t2" | "run" | null;
+  race_segment_index: number | null;
   metrics_v2?: Record<string, unknown> | null;
   created_at?: string;
   updated_at?: string;
@@ -56,7 +59,7 @@ export function localIsoDate(utcIso: string, timeZone: string) {
 
 export function isMissingCompletedActivityColumnError(error: { code?: string; message?: string } | null) {
   if (!error) return false;
-  return error.code === "42703" || /(schedule_status|is_unplanned|schema cache|column .* does not exist|42703)/i.test(error.message ?? "");
+  return error.code === "42703" || /(schedule_status|is_unplanned|race_bundle_id|race_segment_role|race_segment_index|schema cache|column .* does not exist|42703)/i.test(error.message ?? "");
 }
 
 export function hasConfirmedPlannedSessionLink(link: {
@@ -114,6 +117,12 @@ export function buildExtraCompletedActivities(params: {
 }
 
 const selectVariants = [
+  // Race-column-aware variants (most complete first). Each pair tries with then without updated_at.
+  "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned,race_bundle_id,race_segment_role,race_segment_index,metrics_v2,created_at,updated_at",
+  "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned,race_bundle_id,race_segment_role,race_segment_index,metrics_v2,created_at",
+  "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,is_unplanned,race_bundle_id,race_segment_role,race_segment_index,metrics_v2,created_at",
+  "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,race_bundle_id,race_segment_role,race_segment_index,metrics_v2,created_at",
+  // Pre-race-columns fallbacks (kept for envs where the migration hasn't landed).
   "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned,metrics_v2,created_at,updated_at",
   "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,is_unplanned,created_at,updated_at",
   "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,schedule_status,metrics_v2,created_at,updated_at",
@@ -132,8 +141,6 @@ const selectVariants = [
   "id,upload_id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,created_at"
 ] as const;
 
-let cachedSelectVariantIndex = 0;
-
 function mapActivityRow(activity: Record<string, unknown>): CompletedActivityRecord {
   return {
     id: String(activity.id),
@@ -146,6 +153,17 @@ function mapActivityRow(activity: Record<string, unknown>): CompletedActivityRec
     avg_power: typeof activity.avg_power === "number" ? activity.avg_power : null,
     schedule_status: activity.schedule_status === "scheduled" ? "scheduled" : "unscheduled",
     is_unplanned: typeof activity.is_unplanned === "boolean" ? activity.is_unplanned : false,
+    race_bundle_id: typeof activity.race_bundle_id === "string" ? activity.race_bundle_id : null,
+    race_segment_role:
+      activity.race_segment_role === "swim" ||
+      activity.race_segment_role === "t1" ||
+      activity.race_segment_role === "bike" ||
+      activity.race_segment_role === "t2" ||
+      activity.race_segment_role === "run"
+        ? activity.race_segment_role
+        : null,
+    race_segment_index:
+      typeof activity.race_segment_index === "number" ? activity.race_segment_index : null,
     metrics_v2:
       activity.metrics_v2 && typeof activity.metrics_v2 === "object" && !Array.isArray(activity.metrics_v2)
         ? activity.metrics_v2 as Record<string, unknown>
@@ -163,28 +181,15 @@ export const loadCompletedActivities = cache(async function loadCompletedActivit
 }): Promise<CompletedActivityRecord[]> {
   const { supabase, userId, rangeStart, rangeEnd } = params;
 
-  // Try the cached successful variant first to avoid retrying all 16 on every call
-  const cachedQuery = await supabase
-    .from("completed_activities")
-    .select(selectVariants[cachedSelectVariantIndex])
-    .eq("user_id", userId)
-    .gte("start_time_utc", rangeStart)
-    .lt("start_time_utc", rangeEnd);
-
-  if (!cachedQuery.error) {
-    return ((cachedQuery.data ?? []) as unknown as Array<Record<string, unknown>>).map(mapActivityRow);
-  }
-
-  if (!isMissingCompletedActivityColumnError(cachedQuery.error)) {
-    throw new Error(cachedQuery.error.message ?? "Failed to load completed activities.");
-  }
-
-  // Cached variant failed due to schema change — find new working variant
-  let lastError: { code?: string; message?: string } | null = cachedQuery.error;
+  // Always start at the most-complete variant (index 0). The module-level cache
+  // we used to keep here got poisoned when columns were added: it would pin a
+  // fallback variant that lacked the new column, then keep returning rows
+  // without that column even after the migration ran. The cost of always
+  // starting at 0 is at most one extra query per request when a column is
+  // genuinely missing, which is negligible.
+  let lastError: { code?: string; message?: string } | null = null;
 
   for (let i = 0; i < selectVariants.length; i++) {
-    if (i === cachedSelectVariantIndex) continue;
-
     const query = await supabase
       .from("completed_activities")
       .select(selectVariants[i])
@@ -193,7 +198,6 @@ export const loadCompletedActivities = cache(async function loadCompletedActivit
       .lt("start_time_utc", rangeEnd);
 
     if (!query.error) {
-      cachedSelectVariantIndex = i;
       return ((query.data ?? []) as unknown as Array<Record<string, unknown>>).map(mapActivityRow);
     }
 

--- a/lib/calendar/day-items.ts
+++ b/lib/calendar/day-items.ts
@@ -37,6 +37,17 @@ type CalendarActivityRecord = {
   schedule_status?: "scheduled" | "unscheduled" | null;
   is_unplanned?: boolean | null;
   notes?: string | null;
+  race_bundle_id?: string | null;
+  race_segment_role?: "swim" | "t1" | "bike" | "t2" | "run" | null;
+  race_segment_index?: number | null;
+};
+
+export type RaceSegmentDisplay = {
+  activityId: string;
+  role: "swim" | "t1" | "bike" | "t2" | "run";
+  sport: string;
+  durationMin: number;
+  distanceKm: number | null;
 };
 
 type CalendarLinkRecord = {
@@ -74,6 +85,7 @@ export type CalendarDisplayItem = {
   is_key: boolean;
   isUnplanned: boolean;
   displayType: "planned_session" | "completed_activity";
+  raceSegments: RaceSegmentDisplay[] | null;
 };
 
 type ActivityItem = {
@@ -87,10 +99,36 @@ type ActivityItem = {
   avg_power: number | null;
   is_unplanned: boolean;
   created_at: string;
+  race_bundle_id: string | null;
+  race_segment_role: "swim" | "t1" | "bike" | "t2" | "run" | null;
+  race_segment_index: number | null;
 };
 
 function isSkipped(notes: string | null) {
   return /\[skipped\s\d{4}-\d{2}-\d{2}\]/i.test(notes ?? "");
+}
+
+function buildRaceSegments(linked: ActivityItem[]): RaceSegmentDisplay[] | null {
+  if (linked.length < 3) return null;
+  const bundleId = linked[0].race_bundle_id;
+  if (!bundleId) return null;
+  if (!linked.every((item) => item.race_bundle_id === bundleId)) return null;
+  if (!linked.every((item) => item.race_segment_role !== null)) return null;
+
+  const ordered = [...linked].sort((a, b) => {
+    const ai = a.race_segment_index ?? 0;
+    const bi = b.race_segment_index ?? 0;
+    if (ai !== bi) return ai - bi;
+    return a.created_at.localeCompare(b.created_at);
+  });
+
+  return ordered.map((item) => ({
+    activityId: item.id,
+    role: item.race_segment_role as RaceSegmentDisplay["role"],
+    sport: item.sport,
+    durationMin: item.duration_min,
+    distanceKm: item.distance_km
+  }));
 }
 
 function dateInRange(date: string, start?: string, endExclusive?: string) {
@@ -151,7 +189,10 @@ export function buildCalendarDisplayItems(input: {
           isUnplanned: Boolean(activity.is_unplanned),
           links
         }) === "extra",
-        created_at: activity.start_time_utc
+        created_at: activity.start_time_utc,
+        race_bundle_id: activity.race_bundle_id ?? null,
+        race_segment_role: activity.race_segment_role ?? null,
+        race_segment_index: activity.race_segment_index ?? null
       }
     ])
   );
@@ -206,6 +247,8 @@ export function buildCalendarDisplayItems(input: {
         }
       : null;
 
+    const raceSegments = buildRaceSegments(linked);
+
     return {
       id: session.id,
       date: session.date,
@@ -229,7 +272,8 @@ export function buildCalendarDisplayItems(input: {
       unassignedSameDayCount: linked.length > 0 ? 0 : (unassignedByDate.get(session.date) ?? 0),
       is_key: Boolean(session.is_key),
       isUnplanned: false,
-      displayType: "planned_session"
+      displayType: "planned_session",
+      raceSegments
     };
   });
 
@@ -263,7 +307,8 @@ export function buildCalendarDisplayItems(input: {
       unassignedSameDayCount: 0,
       is_key: false,
       isUnplanned: item.is_unplanned,
-      displayType: "completed_activity"
+      displayType: "completed_activity",
+      raceSegments: null
     }));
 
   return [...plannedItems, ...unlinkedActivityItems].sort((a, b) => {

--- a/lib/integrations/ingestion-service.ts
+++ b/lib/integrations/ingestion-service.ts
@@ -11,6 +11,7 @@
 
 import { createClient as createSupabaseClient, type SupabaseClient } from "@supabase/supabase-js";
 import { insertActivityWithCompat } from "@/lib/supabase/schema-compat";
+import { attemptRaceBundle } from "@/lib/workouts/race-bundle";
 import { fetchActivity, fetchRecentActivitiesWithRateLimit } from "./providers/strava/client";
 import { shouldThrottle, type RateLimitInfo } from "./providers/strava/rate-limiter";
 import { normalizeStravaActivity } from "./providers/strava/normalizer";
@@ -315,6 +316,21 @@ export async function ingestStravaActivity(
     console.log(`[INGEST] NO_MATCH activityId=${externalId}`);
   }
 
+  // 7. Race bundling — idempotent. Each new activity may complete a same-day race shape.
+  try {
+    const bundleResult = await attemptRaceBundle({
+      supabase,
+      userId,
+      date: created.start_time_utc.slice(0, 10),
+      source: "strava_reconstructed"
+    });
+    if (bundleResult.status === "bundled") {
+      console.log(`[INGEST] RACE_BUNDLED activityId=${externalId} bundleId=${bundleResult.bundleId}`);
+    }
+  } catch (err) {
+    console.error(`[INGEST] RACE_BUNDLE_ERROR activityId=${externalId}:`, err);
+  }
+
   await logSyncEvent(userId, "strava", "activity_imported", externalId, "ok", { matched });
 
   return { status: "imported", activityId: created.id, matched };
@@ -448,6 +464,18 @@ export async function backfillRecentActivities(
 
         const matched = await matchActivity(supabase, userId, created);
         if (matched) result.matched++;
+
+        // Idempotent race bundle attempt — no-op until same-day race shape is complete.
+        try {
+          await attemptRaceBundle({
+            supabase,
+            userId,
+            date: created.start_time_utc.slice(0, 10),
+            source: "strava_reconstructed"
+          });
+        } catch (bundleErr) {
+          console.error(`[INGEST] BACKFILL_RACE_BUNDLE_ERROR activityId=${activity.id}:`, bundleErr);
+        }
       } catch (err) {
         console.error(`[INGEST] BACKFILL_ACTIVITY_ERROR activityId=${activity.id}:`, err);
         result.skipped++;

--- a/lib/training/race-session.test.ts
+++ b/lib/training/race-session.test.ts
@@ -1,0 +1,25 @@
+import { isRaceSession } from "./race-session";
+
+describe("isRaceSession", () => {
+  it("returns true when type contains the word race", () => {
+    expect(isRaceSession({ type: "Olympic (race)" })).toBe(true);
+    expect(isRaceSession({ type: "Race" })).toBe(true);
+    expect(isRaceSession({ type: "RACE" })).toBe(true);
+  });
+
+  it("returns true when session_name contains the word race", () => {
+    expect(isRaceSession({ type: "Other", session_name: "Joe Hannon Olympic (race)" })).toBe(true);
+  });
+
+  it("returns false for non-race sessions", () => {
+    expect(isRaceSession({ type: "Easy Run" })).toBe(false);
+    expect(isRaceSession({ type: "FTP", session_name: "Threshold" })).toBe(false);
+    expect(isRaceSession({})).toBe(false);
+    expect(isRaceSession(null)).toBe(false);
+  });
+
+  it("does not match substrings of other words", () => {
+    expect(isRaceSession({ type: "Embrace" })).toBe(false);
+    expect(isRaceSession({ session_name: "Tracer Drill" })).toBe(false);
+  });
+});

--- a/lib/training/race-session.ts
+++ b/lib/training/race-session.ts
@@ -1,0 +1,13 @@
+export type RaceSessionLike = {
+  type?: string | null;
+  session_name?: string | null;
+};
+
+const RACE_PATTERN = /\brace\b/i;
+
+export function isRaceSession(session: RaceSessionLike | null | undefined): boolean {
+  if (!session) return false;
+  if (session.type && RACE_PATTERN.test(session.type)) return true;
+  if (session.session_name && RACE_PATTERN.test(session.session_name)) return true;
+  return false;
+}

--- a/lib/workouts/activity-metrics-backfill.test.ts
+++ b/lib/workouts/activity-metrics-backfill.test.ts
@@ -1,6 +1,8 @@
 jest.mock("./activity-parser", () => ({
   parseFitFile: jest.fn(),
-  parseTcxFile: jest.fn()
+  parseTcxFile: jest.fn(),
+  isMultisportParseResult: (result: unknown) =>
+    typeof result === "object" && result !== null && (result as { kind?: string }).kind === "multisport"
 }));
 
 import { backfillActivityMetrics } from "./activity-metrics-backfill";

--- a/lib/workouts/activity-metrics-backfill.ts
+++ b/lib/workouts/activity-metrics-backfill.ts
@@ -1,6 +1,6 @@
 import { Buffer } from "node:buffer";
 import type { SupabaseClient } from "@supabase/supabase-js";
-import { parseFitFile, parseTcxFile } from "@/lib/workouts/activity-parser";
+import { isMultisportParseResult, parseFitFile, parseTcxFile } from "@/lib/workouts/activity-parser";
 import { asMetricsRecord, getNestedString, getNestedValue } from "@/lib/workouts/metrics-v2";
 
 type CompletedActivityBackfillRow = {
@@ -136,6 +136,14 @@ export async function backfillActivityMetrics(args: {
       const parsed = upload.file_type === "fit"
         ? await parseFitFile(bytes)
         : parseTcxFile(bytes.toString("utf8"));
+
+      if (isMultisportParseResult(parsed)) {
+        // Multisport uploads insert per-segment rows up-front; metrics-backfill
+        // would need to know which segment maps to this row. Skip for now —
+        // segment metrics are already populated at upload time.
+        skipped += 1;
+        continue;
+      }
 
       const metricsV2 = withBackfillWarning(parsed.metricsV2);
       const { error: updateError } = await args.supabase

--- a/lib/workouts/activity-parser.fit.test.ts
+++ b/lib/workouts/activity-parser.fit.test.ts
@@ -7,7 +7,16 @@ jest.mock("fit-file-parser", () => ({
   }))
 }));
 
-import { parseFitFile } from "./activity-parser";
+import type { ParsedActivity } from "./activity-parser";
+import { isMultisportParseResult, parseFitFile } from "./activity-parser";
+
+async function parseSingleFit(buffer: Buffer): Promise<ParsedActivity> {
+  const result = await parseFitFile(buffer);
+  if (isMultisportParseResult(result)) {
+    throw new Error("Expected single-session FIT, received multisport result");
+  }
+  return result;
+}
 
 describe("parseFitFile", () => {
   beforeEach(() => {
@@ -110,7 +119,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result).toMatchObject({
       sportType: "bike",
@@ -176,7 +185,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(3600);
     expect(result.elapsedDurationSec).toBe(3600);
@@ -200,7 +209,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(1800);
     expect(result.elapsedDurationSec).toBe(1800);
@@ -226,7 +235,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(1800);
   });
@@ -252,7 +261,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(3600);
     expect(result.elapsedDurationSec).toBe(3600);
@@ -271,7 +280,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(2700);
     expect(result.elapsedDurationSec).toBe(2700);
@@ -290,7 +299,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(1500);
     expect(result.elapsedDurationSec).toBe(1500);
@@ -323,7 +332,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(0);
     expect(result.movingDurationSec).toBeUndefined();
@@ -346,7 +355,7 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(3600);
     expect(result.elapsedDurationSec).toBe(3600);
@@ -387,10 +396,130 @@ describe("parseFitFile", () => {
       });
     });
 
-    const result = await parseFitFile(Buffer.from("fit"));
+    const result = await parseSingleFit(Buffer.from("fit"));
 
     expect(result.durationSec).toBe(2700);
     expect(result.movingDurationSec).toBe(2700);
     expect(result.elapsedDurationSec).toBe(2700);
+  });
+
+  test("returns a multisport result for an auto_multi_sport FIT (Olympic triathlon shape)", async () => {
+    parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
+      callback(null, {
+        activity: { type: "auto_multi_sport", num_sessions: 5 },
+        sessions: [
+          {
+            start_time: "2026-04-26T08:03:08.000Z",
+            sport: "swimming",
+            sub_sport: "lap_swimming",
+            total_elapsed_time: 1601,
+            total_timer_time: 1601,
+            total_distance: 600,
+            avg_heart_rate: 118,
+            max_heart_rate: 131
+          },
+          {
+            start_time: "2026-04-26T08:29:51.000Z",
+            sport: "transition",
+            sub_sport: "generic",
+            total_elapsed_time: 130,
+            total_timer_time: 130,
+            total_distance: 213,
+            avg_heart_rate: 164,
+            max_heart_rate: 180
+          },
+          {
+            start_time: "2026-04-26T08:32:01.000Z",
+            sport: "cycling",
+            sub_sport: "generic",
+            total_elapsed_time: 4619,
+            total_timer_time: 4619,
+            total_distance: 39966,
+            avg_heart_rate: 165,
+            max_heart_rate: 176
+          },
+          {
+            start_time: "2026-04-26T09:49:00.000Z",
+            sport: "transition",
+            sub_sport: "generic",
+            total_elapsed_time: 99,
+            total_timer_time: 99,
+            total_distance: 160,
+            avg_heart_rate: 160,
+            max_heart_rate: 169
+          },
+          {
+            start_time: "2026-04-26T09:50:39.000Z",
+            sport: "running",
+            sub_sport: "generic",
+            total_elapsed_time: 2641,
+            total_timer_time: 2641,
+            total_distance: 9368,
+            avg_heart_rate: 166,
+            max_heart_rate: 194
+          }
+        ],
+        laps: [],
+        events: [],
+        records: [],
+        time_in_zone: []
+      });
+    });
+
+    const result = await parseFitFile(Buffer.from("fit"));
+
+    if (!isMultisportParseResult(result)) throw new Error("expected multisport result");
+
+    expect(result.kind).toBe("multisport");
+    expect(result.bundle.source).toBe("garmin_multisport");
+    expect(result.bundle.startedAt).toBe("2026-04-26T08:03:08.000Z");
+    expect(result.bundle.totalDurationSec).toBe(1601 + 130 + 4619 + 99 + 2641);
+    expect(result.bundle.totalDistanceM).toBe(600 + 213 + 39966 + 160 + 9368);
+
+    expect(result.segments).toHaveLength(5);
+    expect(result.segments.map((s) => s.role)).toEqual(["swim", "t1", "bike", "t2", "run"]);
+    expect(result.segments.map((s) => s.segmentIndex)).toEqual([0, 1, 2, 3, 4]);
+
+    const [swim, t1, bike, t2, run] = result.segments;
+    expect(swim.sportType).toBe("swim");
+    expect(swim.durationSec).toBe(1601);
+    expect(swim.distanceM).toBe(600);
+    expect(t1.durationSec).toBe(130);
+    expect(bike.sportType).toBe("bike");
+    expect(bike.durationSec).toBe(4619);
+    expect(bike.distanceM).toBe(39966);
+    expect(t2.durationSec).toBe(99);
+    expect(run.sportType).toBe("run");
+    expect(run.durationSec).toBe(2641);
+  });
+
+  test("treats a sessions.length > 1 FIT (no auto_multi_sport flag) as multisport", async () => {
+    parseMock.mockImplementation((_buffer: Buffer, callback: (error: unknown, data: unknown) => void) => {
+      callback(null, {
+        activity: { type: "manual" },
+        sessions: [
+          {
+            start_time: "2026-04-26T08:00:00.000Z",
+            sport: "swimming",
+            total_elapsed_time: 1000,
+            total_timer_time: 1000,
+            total_distance: 500
+          },
+          {
+            start_time: "2026-04-26T08:20:00.000Z",
+            sport: "running",
+            total_elapsed_time: 2000,
+            total_timer_time: 2000,
+            total_distance: 6000
+          }
+        ],
+        laps: [],
+        events: [],
+        records: []
+      });
+    });
+
+    const result = await parseFitFile(Buffer.from("fit"));
+    expect(isMultisportParseResult(result)).toBe(true);
   });
 });

--- a/lib/workouts/activity-parser.ts
+++ b/lib/workouts/activity-parser.ts
@@ -2,7 +2,7 @@ import { createHash } from "crypto";
 import FitParser from "fit-file-parser";
 import { XMLParser } from "fast-xml-parser";
 
-type ParsedActivity = {
+export type ParsedActivity = {
   sportType: string;
   startTimeUtc: string;
   endTimeUtc: string;
@@ -30,6 +30,31 @@ type ParsedActivity = {
   metricsV2?: Record<string, unknown>;
   parseSummary?: Record<string, unknown>;
 };
+
+export type RaceSegmentRole = "swim" | "t1" | "bike" | "t2" | "run";
+
+export type ParsedMultisportSegment = ParsedActivity & {
+  role: RaceSegmentRole;
+  segmentIndex: number;
+};
+
+export type ParsedMultisportActivity = {
+  kind: "multisport";
+  bundle: {
+    startedAt: string;
+    endedAt: string;
+    totalDurationSec: number;
+    totalDistanceM: number;
+    source: "garmin_multisport";
+  };
+  segments: ParsedMultisportSegment[];
+};
+
+export type ParsedFitFile = ParsedActivity | ParsedMultisportActivity;
+
+export function isMultisportParseResult(result: ParsedFitFile): result is ParsedMultisportActivity {
+  return (result as ParsedMultisportActivity).kind === "multisport";
+}
 
 function buildPaceSummary(durationSec: number, distanceM: number) {
   if (durationSec <= 0 || distanceM <= 0) {
@@ -505,7 +530,7 @@ export function sha256Hex(content: Buffer | string) {
   return createHash("sha256").update(content).digest("hex");
 }
 
-export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
+export async function parseFitFile(buffer: Buffer): Promise<ParsedFitFile> {
   const parser = new FitParser({ force: true, speedUnit: "m/s", lengthUnit: "m", temperatureUnit: "celsius" });
 
   const fit = await new Promise<any>((resolve, reject) => {
@@ -515,11 +540,20 @@ export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
     });
   });
 
-  const session = fit?.sessions?.[0];
-  if (!session?.start_time) {
+  const sessions = Array.isArray(fit?.sessions) ? fit.sessions : [];
+  if (sessions.length === 0 || !sessions[0]?.start_time) {
     throw new Error("FIT file missing session start time.");
   }
 
+  const isMultisport = fit?.activity?.type === "auto_multi_sport" || sessions.length > 1;
+  if (isMultisport) {
+    return buildMultisportFromFit(fit, sessions);
+  }
+
+  return buildParsedActivityFromSession(sessions[0], fit);
+}
+
+function buildParsedActivityFromSession(session: any, fit: any): ParsedActivity {
   const start = new Date(session.start_time);
   const movingDurationSec = positiveInt(firstPositiveNumber([session.total_timer_time, session.total_moving_time]));
   const elapsedDurationSec =
@@ -814,6 +848,100 @@ export async function parseFitFile(buffer: Buffer): Promise<ParsedActivity> {
       laps: simplifiedLaps,
       ...buildPaceSummary(durationSec, distanceM)
     }
+  };
+}
+
+function sessionTimeWindow(session: any): { startMs: number; endMs: number } {
+  const startMs = new Date(session.start_time).getTime();
+  const elapsed = Number(
+    firstPositiveNumber([session.total_elapsed_time, session.total_timer_time]) ?? 0
+  );
+  const endMs = startMs + Math.max(0, elapsed) * 1000;
+  return { startMs, endMs };
+}
+
+function withinWindow(timestamp: unknown, startMs: number, endMs: number): boolean {
+  if (typeof timestamp !== "string" && !(timestamp instanceof Date)) return false;
+  const ms = new Date(timestamp as string | Date).getTime();
+  if (!Number.isFinite(ms)) return false;
+  return ms >= startMs && ms <= endMs;
+}
+
+function sliceFitForSession(fit: any, session: any, sessionIndex: number) {
+  const { startMs, endMs } = sessionTimeWindow(session);
+
+  const sliceByTimestamp = (rows: unknown) =>
+    Array.isArray(rows)
+      ? rows.filter((row) => {
+          const r = asRecord(row);
+          if (!r) return false;
+          return withinWindow(r.timestamp ?? r.start_time, startMs, endMs);
+        })
+      : [];
+
+  const allTimeInZone = Array.isArray(fit?.time_in_zone) ? fit.time_in_zone : [];
+  // Each `time_in_zone` entry corresponds to a session message; for multisport we pick
+  // the entry whose ordinal index matches this session.
+  const sessionTizEntries = allTimeInZone.filter((entry: unknown) => {
+    const r = asRecord(entry);
+    return r?.reference_mesg === 18 || r?.reference_mesg === "session";
+  });
+  const tizForSession = sessionTizEntries[sessionIndex] ?? sessionTizEntries[0] ?? null;
+
+  return {
+    laps: sliceByTimestamp(fit?.laps),
+    records: sliceByTimestamp(fit?.records),
+    events: sliceByTimestamp(fit?.events),
+    lengths: sliceByTimestamp(fit?.lengths),
+    time_in_zone: tizForSession ? [tizForSession] : [],
+    activity: fit?.activity,
+    activity_metrics: fit?.activity_metrics
+  };
+}
+
+function determineSegmentRole(sportRaw: unknown, transitionsSoFar: number): RaceSegmentRole {
+  const sport = `${sportRaw ?? ""}`.toLowerCase();
+  if (sport.includes("swim")) return "swim";
+  if (sport.includes("cycl") || sport.includes("bike")) return "bike";
+  if (sport.includes("run")) return "run";
+  if (sport === "transition") return transitionsSoFar === 0 ? "t1" : "t2";
+  // Fallback for unexpected sports inside a multisport file: treat as a transition slot.
+  return transitionsSoFar === 0 ? "t1" : "t2";
+}
+
+function buildMultisportFromFit(fit: any, sessions: any[]): ParsedMultisportActivity {
+  const segments: ParsedMultisportSegment[] = [];
+  let transitionsSeen = 0;
+
+  for (let i = 0; i < sessions.length; i += 1) {
+    const session = sessions[i];
+    if (!session?.start_time) {
+      throw new Error(`FIT multisport session ${i} missing start time.`);
+    }
+    const slicedFit = sliceFitForSession(fit, session, i);
+    const parsed = buildParsedActivityFromSession(session, slicedFit);
+    const role = determineSegmentRole(session.sport, transitionsSeen);
+    if (`${session.sport ?? ""}`.toLowerCase() === "transition") transitionsSeen += 1;
+    segments.push({ ...parsed, role, segmentIndex: i });
+  }
+
+  segments.sort((a, b) => a.segmentIndex - b.segmentIndex);
+
+  const startedAt = segments[0].startTimeUtc;
+  const endedAt = segments[segments.length - 1].endTimeUtc;
+  const totalDurationSec = segments.reduce((sum, s) => sum + (s.durationSec || 0), 0);
+  const totalDistanceM = segments.reduce((sum, s) => sum + (s.distanceM || 0), 0);
+
+  return {
+    kind: "multisport",
+    bundle: {
+      startedAt,
+      endedAt,
+      totalDurationSec,
+      totalDistanceM,
+      source: "garmin_multisport"
+    },
+    segments
   };
 }
 

--- a/lib/workouts/race-bundle.test.ts
+++ b/lib/workouts/race-bundle.test.ts
@@ -1,0 +1,268 @@
+import { attemptRaceBundle } from "./race-bundle";
+
+type Row = Record<string, unknown>;
+
+function makeBuilder(behaviors: { [key: string]: unknown }) {
+  // Simple Supabase chain mock — every call records to behaviors.calls and
+  // resolves with what the test sets up via behaviors.responses[key].
+  const builder: any = {};
+  builder.from = (table: string) => {
+    behaviors.lastTable = table;
+    return builder;
+  };
+  builder.select = () => builder;
+  builder.insert = (rows: unknown) => {
+    (behaviors.inserts as any[]).push({ table: behaviors.lastTable, rows });
+    if (behaviors.lastTable === "race_bundles") {
+      return {
+        select: () => ({
+          single: async () => ({ data: { id: "bundle-1" }, error: null })
+        })
+      };
+    }
+    return Promise.resolve({ error: null });
+  };
+  builder.update = (patch: Row) => {
+    return {
+      eq: (..._args: unknown[]) => ({
+        eq: async (..._inner: unknown[]) => {
+          (behaviors.updates as any[]).push({ table: behaviors.lastTable, patch });
+          return { error: null };
+        }
+      })
+    };
+  };
+  builder.delete = () => ({
+    eq: () => ({ in: async () => ({ error: null }) })
+  });
+  builder.eq = () => builder;
+  builder.in = () => builder;
+  builder.gte = () => builder;
+  builder.lte = () => builder;
+  builder.order = () => Promise.resolve({ data: behaviors.activities, error: null });
+  return builder;
+}
+
+describe("attemptRaceBundle", () => {
+  function buildSupabase(opts: {
+    sameDaySessions: Row[];
+    activities: Row[];
+    existingLinks?: Row[];
+  }) {
+    const behaviors: any = {
+      inserts: [],
+      updates: [],
+      activities: opts.activities,
+      lastTable: ""
+    };
+
+    // Custom from() that branches per table.
+    const supabase: any = {};
+    supabase.from = (table: string) => {
+      if (table === "sessions") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => Promise.resolve({ data: opts.sameDaySessions, error: null })
+            })
+          })
+        };
+      }
+      if (table === "completed_activities") {
+        return {
+          select: () => ({
+            eq: () => ({
+              gte: () => ({
+                lte: () => ({
+                  order: () => Promise.resolve({ data: opts.activities, error: null })
+                })
+              })
+            })
+          }),
+          update: (patch: Row) => ({
+            eq: () => ({
+              eq: async () => {
+                behaviors.updates.push({ patch });
+                return { error: null };
+              }
+            })
+          })
+        };
+      }
+      if (table === "session_activity_links") {
+        const chainable: any = {};
+        chainable.eq = () => chainable;
+        chainable.in = () => Promise.resolve({ error: null });
+        return {
+          select: () => ({
+            eq: () => ({
+              in: () => Promise.resolve({ data: opts.existingLinks ?? [], error: null })
+            })
+          }),
+          insert: (rows: unknown) => {
+            behaviors.inserts.push({ table, rows });
+            return Promise.resolve({ error: null });
+          },
+          delete: () => chainable
+        };
+      }
+      if (table === "race_bundles") {
+        return {
+          insert: (rows: unknown) => {
+            behaviors.inserts.push({ table, rows });
+            return {
+              select: () => ({
+                single: async () => ({ data: { id: "bundle-1" }, error: null })
+              })
+            };
+          }
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    };
+
+    return { supabase, behaviors };
+  }
+
+  it("bundles 5 same-day activities into the planned race session", async () => {
+    const baseStart = new Date("2026-04-26T08:03:08.000Z").getTime();
+    const at = (offsetSec: number, sport: string, durationSec: number, distance: number, id: string) => ({
+      id,
+      sport_type: sport,
+      start_time_utc: new Date(baseStart + offsetSec * 1000).toISOString(),
+      duration_sec: durationSec,
+      distance_m: distance
+    });
+
+    const { supabase, behaviors } = buildSupabase({
+      sameDaySessions: [
+        {
+          id: "session-race",
+          date: "2026-04-26",
+          sport: "other",
+          type: "Olympic (race)",
+          session_name: "Joe Hannon Olympic",
+          duration_minutes: 150
+        }
+      ],
+      activities: [
+        at(0, "swim", 1601, 600, "act-swim"),
+        at(1605, "strength", 130, 213, "act-t1"),
+        at(1740, "bike", 4619, 39966, "act-bike"),
+        at(6361, "strength", 99, 160, "act-t2"),
+        at(6462, "run", 2641, 9368, "act-run")
+      ],
+      existingLinks: []
+    });
+
+    const result = await attemptRaceBundle({
+      supabase,
+      userId: "user-1",
+      date: "2026-04-26",
+      source: "strava_reconstructed"
+    });
+
+    expect(result.status).toBe("bundled");
+    if (result.status !== "bundled") return;
+    expect(result.plannedSessionId).toBe("session-race");
+    expect(result.segmentIds).toEqual(["act-swim", "act-t1", "act-bike", "act-t2", "act-run"]);
+
+    const bundleInsert = behaviors.inserts.find((i: any) => i.table === "race_bundles");
+    expect(bundleInsert).toBeTruthy();
+    expect(bundleInsert.rows.source).toBe("strava_reconstructed");
+    expect(bundleInsert.rows.user_id).toBe("user-1");
+
+    const linkInsert = behaviors.inserts.find((i: any) => i.table === "session_activity_links");
+    expect(linkInsert).toBeTruthy();
+    expect((linkInsert.rows as Row[]).length).toBe(5);
+    expect((linkInsert.rows as Row[])[0]).toMatchObject({
+      planned_session_id: "session-race",
+      completed_activity_id: "act-swim",
+      confirmation_status: "confirmed",
+      match_method: "race_bundle"
+    });
+
+    expect(behaviors.updates.length).toBe(5);
+    const roles = behaviors.updates.map((u: any) => u.patch.race_segment_role);
+    expect(roles).toEqual(["swim", "t1", "bike", "t2", "run"]);
+  });
+
+  it("skips when no race-flagged session exists that day", async () => {
+    const { supabase } = buildSupabase({
+      sameDaySessions: [
+        { id: "s1", type: "Easy Run", session_name: "Easy Run", duration_minutes: 45 }
+      ],
+      activities: [{ id: "a1", sport_type: "swim", start_time_utc: "2026-04-26T08:00:00Z", duration_sec: 1500, distance_m: 600 }]
+    });
+
+    const result = await attemptRaceBundle({
+      supabase,
+      userId: "user-1",
+      date: "2026-04-26",
+      source: "strava_reconstructed"
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "no_race_session" });
+  });
+
+  it("self-heals when bundle + roles are present but links failed previously", async () => {
+    const { supabase, behaviors } = buildSupabase({
+      sameDaySessions: [
+        { id: "session-race", type: "Race", session_name: "Race", duration_minutes: 150 }
+      ],
+      activities: [
+        { id: "a1", sport_type: "swim", start_time_utc: "2026-04-26T08:00:00Z", duration_sec: 1500, race_bundle_id: "existing-bundle", race_segment_role: "swim", race_segment_index: 0 },
+        { id: "a2", sport_type: "bike", start_time_utc: "2026-04-26T08:30:00Z", duration_sec: 4500, race_bundle_id: "existing-bundle", race_segment_role: "bike", race_segment_index: 1 },
+        { id: "a3", sport_type: "run", start_time_utc: "2026-04-26T09:50:00Z", duration_sec: 2400, race_bundle_id: "existing-bundle", race_segment_role: "run", race_segment_index: 2 }
+      ],
+      existingLinks: []
+    });
+
+    const result = await attemptRaceBundle({
+      supabase,
+      userId: "user-1",
+      date: "2026-04-26",
+      source: "strava_reconstructed"
+    });
+
+    expect(result.status).toBe("bundled");
+    if (result.status !== "bundled") return;
+    expect(result.bundleId).toBe("existing-bundle");
+    expect(result.plannedSessionId).toBe("session-race");
+    expect(result.segmentIds).toEqual(["a1", "a2", "a3"]);
+
+    const linkInsert = behaviors.inserts.find((i: any) => i.table === "session_activity_links");
+    expect(linkInsert).toBeTruthy();
+    expect((linkInsert.rows as Row[]).length).toBe(3);
+    expect((linkInsert.rows as Row[])[0]).toMatchObject({
+      match_method: "race_bundle",
+      match_reason: expect.objectContaining({ recovered: true })
+    });
+
+    // Crucially the bundler did NOT insert another race_bundles row — it reused.
+    const bundleInsert = behaviors.inserts.find((i: any) => i.table === "race_bundles");
+    expect(bundleInsert).toBeUndefined();
+  });
+
+  it("bails on partial bundle state (some bundled, some not)", async () => {
+    const { supabase } = buildSupabase({
+      sameDaySessions: [
+        { id: "s1", type: "Race", session_name: "Race", duration_minutes: 150 }
+      ],
+      activities: [
+        { id: "a1", sport_type: "swim", start_time_utc: "2026-04-26T08:00:00Z", duration_sec: 1500, race_bundle_id: "existing-bundle" },
+        { id: "a2", sport_type: "bike", start_time_utc: "2026-04-26T08:30:00Z", duration_sec: 4500 }, // not bundled
+        { id: "a3", sport_type: "run", start_time_utc: "2026-04-26T09:50:00Z", duration_sec: 2400, race_bundle_id: "existing-bundle" }
+      ]
+    });
+
+    const result = await attemptRaceBundle({
+      supabase,
+      userId: "user-1",
+      date: "2026-04-26",
+      source: "strava_reconstructed"
+    });
+
+    expect(result).toEqual({ status: "skipped", reason: "partial_bundle_state" });
+  });
+});

--- a/lib/workouts/race-bundle.ts
+++ b/lib/workouts/race-bundle.ts
@@ -1,0 +1,393 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { isRaceSession } from "@/lib/training/race-session";
+import { detectRaceBundle, type RaceCandidate } from "@/lib/workouts/race-detection";
+import type { RaceSegmentRole } from "@/lib/workouts/activity-parser";
+
+export type PersistMultisportBundleArgs = {
+  supabase: SupabaseClient;
+  userId: string;
+  uploadId: string;
+  bundle: {
+    startedAt: string;
+    endedAt: string;
+    totalDurationSec: number;
+    totalDistanceM: number;
+  };
+  /**
+   * Activity rows already inserted into completed_activities, in segment order.
+   * Each must include the resolved id, sport_type, start_time_utc, duration_sec,
+   * plus the role assigned at parse time.
+   */
+  segments: Array<{
+    activityId: string;
+    role: RaceSegmentRole;
+    segmentIndex: number;
+  }>;
+};
+
+export type PersistMultisportBundleResult =
+  | { status: "linked"; bundleId: string; plannedSessionId: string | null }
+  | { status: "error"; reason: string };
+
+/**
+ * Persists a Garmin auto_multi_sport bundle: creates the race_bundles row,
+ * stamps each child activity with bundle metadata, and (when a planned race
+ * session is present same-day) creates confirmed session_activity_links.
+ */
+export async function persistMultisportBundle(
+  args: PersistMultisportBundleArgs
+): Promise<PersistMultisportBundleResult> {
+  const { supabase, userId, uploadId, bundle, segments } = args;
+
+  if (segments.length === 0) {
+    return { status: "error", reason: "no_segments" };
+  }
+
+  const { data: createdBundle, error: bundleError } = await supabase
+    .from("race_bundles")
+    .insert({
+      user_id: userId,
+      started_at: bundle.startedAt,
+      ended_at: bundle.endedAt,
+      total_duration_sec: Math.round(bundle.totalDurationSec),
+      total_distance_m: bundle.totalDistanceM || null,
+      source: "garmin_multisport",
+      upload_id: uploadId
+    })
+    .select("id")
+    .single();
+
+  if (bundleError || !createdBundle) {
+    return { status: "error", reason: `bundle_insert_failed:${bundleError?.message}` };
+  }
+  const bundleId = createdBundle.id as string;
+
+  for (const segment of segments) {
+    const { error: updateError } = await supabase
+      .from("completed_activities")
+      .update({
+        race_bundle_id: bundleId,
+        race_segment_role: segment.role,
+        race_segment_index: segment.segmentIndex
+      })
+      .eq("user_id", userId)
+      .eq("id", segment.activityId);
+    if (updateError) {
+      console.error("[race-bundle] segment update failed", { id: segment.activityId, err: updateError.message });
+    }
+  }
+
+  // Find a planned race session for the same local date.
+  const startDate = bundle.startedAt.slice(0, 10);
+  const { data: sameDaySessions } = await supabase
+    .from("sessions")
+    .select("id,sport,type,session_name")
+    .eq("user_id", userId)
+    .eq("date", startDate);
+
+  const raceSessions = (sameDaySessions ?? []).filter((s: any) =>
+    isRaceSession({ type: s.type, session_name: s.session_name })
+  );
+
+  if (raceSessions.length !== 1) {
+    return { status: "linked", bundleId, plannedSessionId: null };
+  }
+  const plannedSessionId = raceSessions[0].id as string;
+
+  const linkRows = segments.map((segment) => ({
+    user_id: userId,
+    planned_session_id: plannedSessionId,
+    completed_activity_id: segment.activityId,
+    link_type: "auto" as const,
+    confidence: 1,
+    confirmation_status: "confirmed" as const,
+    match_method: "race_bundle" as const,
+    match_reason: { kind: "race_bundle", role: segment.role, segmentIndex: segment.segmentIndex, source: "garmin_multisport" }
+  }));
+
+  const { error: linkError } = await supabase.from("session_activity_links").insert(linkRows);
+  if (linkError) {
+    console.error("[race-bundle] link insert failed", linkError.message);
+    return { status: "error", reason: `link_insert_failed:${linkError.message}` };
+  }
+
+  return { status: "linked", bundleId, plannedSessionId };
+}
+
+export type AttemptRaceBundleArgs = {
+  supabase: SupabaseClient;
+  userId: string;
+  /** Local-date (YYYY-MM-DD) to scan for a race shape. */
+  date: string;
+  /** How the bundle was produced. */
+  source: "garmin_multisport" | "strava_reconstructed" | "manual";
+  /** Optional originating upload (used for source=garmin_multisport). */
+  uploadId?: string | null;
+};
+
+export type AttemptRaceBundleResult =
+  | { status: "skipped"; reason: string }
+  | {
+      status: "bundled";
+      bundleId: string;
+      plannedSessionId: string;
+      segmentIds: string[];
+    };
+
+function startOfDayIso(date: string): string {
+  return `${date}T00:00:00.000Z`;
+}
+
+function endOfDayIso(date: string): string {
+  return `${date}T23:59:59.999Z`;
+}
+
+/**
+ * Detect and persist a race bundle for a single user/day.
+ *
+ * Idempotent: bails if any candidate is already part of a bundle, or if a race
+ * shape isn't present, or if there isn't exactly one planned race session that day.
+ */
+export async function attemptRaceBundle(
+  args: AttemptRaceBundleArgs
+): Promise<AttemptRaceBundleResult> {
+  const { supabase, userId, date, source, uploadId } = args;
+
+  const { data: sameDaySessions, error: sessionsError } = await supabase
+    .from("sessions")
+    .select("id,date,sport,type,session_name,duration_minutes")
+    .eq("user_id", userId)
+    .eq("date", date);
+
+  if (sessionsError) {
+    return { status: "skipped", reason: `sessions_query_failed:${sessionsError.message}` };
+  }
+
+  const raceSessions = (sameDaySessions ?? []).filter((s: any) =>
+    isRaceSession({ type: s.type, session_name: s.session_name })
+  );
+
+  if (raceSessions.length === 0) return { status: "skipped", reason: "no_race_session" };
+  if (raceSessions.length > 1) return { status: "skipped", reason: "multiple_race_sessions" };
+  const plannedSession = raceSessions[0];
+
+  const { data: activities, error: activitiesError } = await supabase
+    .from("completed_activities")
+    .select("id,sport_type,start_time_utc,duration_sec,distance_m,race_bundle_id,race_segment_role,race_segment_index")
+    .eq("user_id", userId)
+    .gte("start_time_utc", startOfDayIso(date))
+    .lte("start_time_utc", endOfDayIso(date))
+    .order("start_time_utc", { ascending: true });
+
+  if (activitiesError) {
+    return { status: "skipped", reason: `activities_query_failed:${activitiesError.message}` };
+  }
+
+  const activityRows = activities ?? [];
+  if (activityRows.length < 3) {
+    return { status: "skipped", reason: "fewer_than_three_activities" };
+  }
+
+  const { data: existingLinks } = await supabase
+    .from("session_activity_links")
+    .select("completed_activity_id,planned_session_id,confirmation_status,match_method")
+    .eq("user_id", userId)
+    .in("completed_activity_id", activityRows.map((a: any) => a.id as string));
+
+  // Self-heal: a previous run may have created the bundle + stamped activities
+  // but failed before inserting links. If every activity is already in the same
+  // bundle (with role/index), just create the missing links.
+  const bundledActivities = activityRows.filter((a: any) => a.race_bundle_id);
+  if (bundledActivities.length > 0) {
+    const allBundled = bundledActivities.length === activityRows.length;
+    const sameBundle = allBundled
+      && activityRows.every((a: any) => a.race_bundle_id === bundledActivities[0].race_bundle_id);
+    const allRolesPresent = sameBundle
+      && activityRows.every((a: any) => a.race_segment_role && a.race_segment_index !== null);
+
+    if (sameBundle && allRolesPresent) {
+      const bundleId = bundledActivities[0].race_bundle_id as string;
+      const confirmedForThisSession = (existingLinks ?? []).filter((l: any) =>
+        l.planned_session_id === plannedSession.id
+        && (l.confirmation_status === "confirmed" || l.confirmation_status === null)
+      );
+      if (confirmedForThisSession.length === activityRows.length) {
+        return { status: "skipped", reason: "already_bundled_and_linked" };
+      }
+
+      // Drop any stale links pointing at other planned sessions for these activities.
+      const linkedActivityIdsToReplace = (existingLinks ?? [])
+        .filter((l: any) => l.planned_session_id !== plannedSession.id)
+        .map((l: any) => l.completed_activity_id as string);
+      if (linkedActivityIdsToReplace.length > 0) {
+        await supabase
+          .from("session_activity_links")
+          .delete()
+          .eq("user_id", userId)
+          .in("completed_activity_id", linkedActivityIdsToReplace);
+      }
+
+      // Drop any partial confirmed-for-this-session links so we can re-insert cleanly.
+      await supabase
+        .from("session_activity_links")
+        .delete()
+        .eq("user_id", userId)
+        .eq("planned_session_id", plannedSession.id)
+        .in("completed_activity_id", activityRows.map((a: any) => a.id as string));
+
+      const orderedRows = [...activityRows].sort(
+        (a: any, b: any) => (a.race_segment_index ?? 0) - (b.race_segment_index ?? 0)
+      );
+
+      const linkRows = orderedRows.map((row: any) => ({
+        user_id: userId,
+        planned_session_id: plannedSession.id,
+        completed_activity_id: row.id,
+        link_type: "auto" as const,
+        confidence: 1,
+        confirmation_status: "confirmed" as const,
+        match_method: "race_bundle" as const,
+        match_reason: {
+          kind: "race_bundle",
+          role: row.race_segment_role,
+          segmentIndex: row.race_segment_index,
+          source,
+          recovered: true
+        }
+      }));
+
+      const { error: linkError } = await supabase.from("session_activity_links").insert(linkRows);
+      if (linkError) {
+        return { status: "skipped", reason: `link_insert_failed:${linkError.message}` };
+      }
+
+      return {
+        status: "bundled",
+        bundleId,
+        plannedSessionId: plannedSession.id,
+        segmentIds: orderedRows.map((row: any) => row.id as string)
+      };
+    }
+
+    // Mixed state: some bundled, some not — bail rather than guess.
+    return { status: "skipped", reason: "partial_bundle_state" };
+  }
+
+  const linkedConfirmedIds = new Set(
+    (existingLinks ?? [])
+      .filter((l: any) => l.confirmation_status === "confirmed")
+      .map((l: any) => l.completed_activity_id as string)
+  );
+  const linkedSuggestedIds = new Set(
+    (existingLinks ?? [])
+      .filter((l: any) => l.confirmation_status !== "confirmed")
+      .map((l: any) => l.completed_activity_id as string)
+  );
+
+  // Confirmed links must be cleared before re-bundling. We don't auto-blow them away.
+  if (activityRows.some((a: any) => linkedConfirmedIds.has(a.id))) {
+    return { status: "skipped", reason: "confirmed_links_exist" };
+  }
+
+  const candidates: RaceCandidate[] = activityRows.map((a: any) => ({
+    id: a.id as string,
+    sport: a.sport_type as string,
+    startUtc: a.start_time_utc as string,
+    durationSec: Number(a.duration_sec) || 0
+  }));
+
+  const detection = detectRaceBundle(candidates, {
+    plannedDurationMin: plannedSession.duration_minutes ?? null
+  });
+
+  if (!detection.matched) {
+    return { status: "skipped", reason: detection.reason };
+  }
+
+  const segments = detection.orderedSegments;
+  const segmentIds = segments.map((s) => s.id);
+
+  // Bundle window from first to last segment.
+  const startedAt = segments[0].startUtc;
+  const lastSeg = segments[segments.length - 1];
+  const endedAt = new Date(
+    new Date(lastSeg.startUtc).getTime() + Math.max(0, lastSeg.durationSec) * 1000
+  ).toISOString();
+  const totalDurationSec = segments.reduce((sum, s) => sum + s.durationSec, 0);
+
+  // Sum distances from rows (detection only carries duration).
+  const distanceById = new Map(
+    activityRows.map((a: any) => [a.id as string, Number(a.distance_m ?? 0) || 0])
+  );
+  const totalDistanceM = segmentIds.reduce((sum, id) => sum + (distanceById.get(id) ?? 0), 0);
+
+  const { data: createdBundle, error: bundleError } = await supabase
+    .from("race_bundles")
+    .insert({
+      user_id: userId,
+      started_at: startedAt,
+      ended_at: endedAt,
+      total_duration_sec: Math.round(totalDurationSec),
+      total_distance_m: totalDistanceM || null,
+      source,
+      upload_id: uploadId ?? null
+    })
+    .select("id")
+    .single();
+
+  if (bundleError || !createdBundle) {
+    return { status: "skipped", reason: `bundle_insert_failed:${bundleError?.message}` };
+  }
+  const bundleId = createdBundle.id as string;
+
+  // Update child activities one-by-one with their role + index.
+  for (const segment of segments) {
+    const { error: updateError } = await supabase
+      .from("completed_activities")
+      .update({
+        race_bundle_id: bundleId,
+        race_segment_role: segment.role,
+        race_segment_index: segment.index
+      })
+      .eq("user_id", userId)
+      .eq("id", segment.id);
+
+    if (updateError) {
+      console.error("[race-bundle] segment update failed", { id: segment.id, err: updateError.message });
+    }
+  }
+
+  // Clear suggested-only links so we can replace them with confirmed bundle links.
+  if (linkedSuggestedIds.size > 0) {
+    await supabase
+      .from("session_activity_links")
+      .delete()
+      .eq("user_id", userId)
+      .in("completed_activity_id", [...linkedSuggestedIds]);
+  }
+
+  // Create confirmed links for every segment → planned race session.
+  const linkRows = segments.map((segment) => ({
+    user_id: userId,
+    planned_session_id: plannedSession.id,
+    completed_activity_id: segment.id,
+    link_type: "auto" as const,
+    confidence: 1,
+    confirmation_status: "confirmed" as const,
+    match_method: "race_bundle" as const,
+    match_reason: { kind: "race_bundle", role: segment.role, segmentIndex: segment.index, source }
+  }));
+
+  const { error: linkError } = await supabase.from("session_activity_links").insert(linkRows);
+  if (linkError) {
+    console.error("[race-bundle] link insert failed", linkError.message);
+    return { status: "skipped", reason: `link_insert_failed:${linkError.message}` };
+  }
+
+  return {
+    status: "bundled",
+    bundleId,
+    plannedSessionId: plannedSession.id,
+    segmentIds
+  };
+}

--- a/lib/workouts/race-detection.test.ts
+++ b/lib/workouts/race-detection.test.ts
@@ -1,0 +1,118 @@
+import { detectRaceBundle, type RaceCandidate } from "./race-detection";
+
+const baseStart = new Date("2026-04-26T08:03:08.000Z").getTime();
+
+function at(offsetSec: number, durationSec: number, sport: string, id?: string): RaceCandidate {
+  return {
+    id: id ?? `${sport}-${offsetSec}`,
+    sport,
+    durationSec,
+    startUtc: new Date(baseStart + offsetSec * 1000).toISOString()
+  };
+}
+
+describe("detectRaceBundle", () => {
+  it("matches a full 5-segment Olympic shape (swim, t1, bike, t2, run)", () => {
+    const candidates: RaceCandidate[] = [
+      at(0, 1601, "swim"),
+      at(1601 + 2, 130, "transition"),
+      at(1601 + 132 + 2, 4619, "cycling"),
+      at(1601 + 132 + 4621 + 2, 99, "transition"),
+      at(1601 + 132 + 4621 + 101 + 2, 2641, "running")
+    ];
+    const result = detectRaceBundle(candidates, { plannedDurationMin: 150 });
+    expect(result.matched).toBe(true);
+    if (!result.matched) return;
+    expect(result.orderedSegments.map((s) => s.role)).toEqual(["swim", "t1", "bike", "t2", "run"]);
+    expect(result.orderedSegments.map((s) => s.index)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it("matches a 3-segment shape with no transitions recorded", () => {
+    const candidates: RaceCandidate[] = [
+      at(0, 1500, "swim"),
+      at(1500 + 60, 4500, "bike"),
+      at(1500 + 60 + 4500 + 60, 2400, "run")
+    ];
+    const result = detectRaceBundle(candidates);
+    expect(result.matched).toBe(true);
+    if (!result.matched) return;
+    expect(result.orderedSegments.map((s) => s.role)).toEqual(["swim", "bike", "run"]);
+  });
+
+  it("treats short Strava-style strength activities as transitions", () => {
+    const candidates: RaceCandidate[] = [
+      at(0, 1601, "swim"),
+      at(1605, 130, "strength"),
+      at(1740, 4619, "bike"),
+      at(6361, 99, "workout"),
+      at(6462, 2641, "run")
+    ];
+    const result = detectRaceBundle(candidates);
+    expect(result.matched).toBe(true);
+    if (!result.matched) return;
+    expect(result.orderedSegments.find((s) => s.role === "t1")?.id).toBe("strength-1605");
+    expect(result.orderedSegments.find((s) => s.role === "t2")?.id).toBe("workout-6361");
+  });
+
+  it("rejects when no swim is present", () => {
+    const result = detectRaceBundle([
+      at(0, 4500, "bike"),
+      at(4500 + 60, 2400, "run"),
+      at(7000, 100, "transition")
+    ]);
+    expect(result).toEqual({ matched: false, reason: "no_swim" });
+  });
+
+  it("rejects when run comes before bike (wrong order)", () => {
+    const result = detectRaceBundle([
+      at(0, 1500, "swim"),
+      at(1600, 2400, "running"),
+      at(4100, 4500, "cycling")
+    ]);
+    expect(result.matched).toBe(false);
+    if (result.matched) return;
+    expect(result.reason).toBe("no_run_after_bike");
+  });
+
+  it("rejects when adjacent gap exceeds threshold", () => {
+    const candidates: RaceCandidate[] = [
+      at(0, 1500, "swim"),
+      at(1500 + 3600, 4500, "bike"), // 1 hour gap before bike
+      at(1500 + 3600 + 4500 + 60, 2400, "run")
+    ];
+    const result = detectRaceBundle(candidates);
+    expect(result.matched).toBe(false);
+    if (result.matched) return;
+    expect(result.reason).toBe("gap_too_long");
+  });
+
+  it("rejects when an inferred transition is too long", () => {
+    const candidates: RaceCandidate[] = [
+      at(0, 1500, "swim"),
+      at(1505, 1200, "strength"), // 20 min "transition"
+      at(2705 + 5, 4500, "bike"),
+      at(2705 + 5 + 4500 + 60, 2400, "run")
+    ];
+    const result = detectRaceBundle(candidates);
+    expect(result.matched).toBe(false);
+    if (result.matched) return;
+    expect(result.reason).toBe("transition_too_long");
+  });
+
+  it("rejects when total duration is far from the planned race", () => {
+    const candidates: RaceCandidate[] = [
+      at(0, 60, "swim"),
+      at(120, 60, "bike"),
+      at(240, 60, "run")
+    ];
+    const result = detectRaceBundle(candidates, { plannedDurationMin: 150 });
+    expect(result.matched).toBe(false);
+    if (result.matched) return;
+    expect(result.reason).toBe("duration_out_of_range");
+  });
+
+  it("rejects when fewer than three candidates are supplied", () => {
+    const result = detectRaceBundle([at(0, 1500, "swim"), at(1600, 4500, "bike")]);
+    expect(result).toEqual({ matched: false, reason: "fewer_than_three_candidates" });
+  });
+});

--- a/lib/workouts/race-detection.ts
+++ b/lib/workouts/race-detection.ts
@@ -1,0 +1,137 @@
+import type { RaceSegmentRole } from "./activity-parser";
+
+export type RaceCandidate = {
+  id: string;
+  sport: string;
+  startUtc: string;
+  durationSec: number;
+};
+
+type DisciplineRole = "swim" | "bike" | "run";
+
+export type RaceDetectionResult =
+  | {
+      matched: true;
+      orderedSegments: Array<{
+        id: string;
+        role: RaceSegmentRole;
+        startUtc: string;
+        durationSec: number;
+        index: number;
+      }>;
+    }
+  | {
+      matched: false;
+      reason: string;
+    };
+
+export type RaceDetectionOptions = {
+  /** Maximum gap (seconds) between adjacent segments. Default 600 (10 min). */
+  maxGapSec?: number;
+  /** Maximum duration of an inferred transition. Default 600 (10 min). */
+  maxTransitionDurationSec?: number;
+  /** Optional planned-session duration in minutes — total within ±50% if provided. */
+  plannedDurationMin?: number | null;
+};
+
+const DEFAULTS = {
+  maxGapSec: 600,
+  maxTransitionDurationSec: 600
+} as const;
+
+const TRANSITION_SPORT_TOKENS = ["transition", "other", "strength", "workout", "weight"];
+
+function classifyDiscipline(sport: string): DisciplineRole | null {
+  const s = sport.toLowerCase();
+  if (s.includes("swim")) return "swim";
+  if (s.includes("cycl") || s.includes("bike") || s.includes("ride")) return "bike";
+  if (s.includes("run")) return "run";
+  return null;
+}
+
+function looksLikeTransition(sport: string): boolean {
+  const s = sport.toLowerCase();
+  if (s === "transition") return true;
+  return TRANSITION_SPORT_TOKENS.some((token) => s.includes(token));
+}
+
+function endMs(c: RaceCandidate): number {
+  return new Date(c.startUtc).getTime() + Math.max(0, c.durationSec) * 1000;
+}
+
+export function detectRaceBundle(
+  candidates: RaceCandidate[],
+  options: RaceDetectionOptions = {}
+): RaceDetectionResult {
+  const opts = { ...DEFAULTS, ...options };
+
+  if (candidates.length < 3) {
+    return { matched: false, reason: "fewer_than_three_candidates" };
+  }
+
+  const sorted = [...candidates].sort(
+    (a, b) => new Date(a.startUtc).getTime() - new Date(b.startUtc).getTime()
+  );
+
+  // Find first swim, the bike that follows it, and the run that follows the bike.
+  const swimIdx = sorted.findIndex((c) => classifyDiscipline(c.sport) === "swim");
+  if (swimIdx === -1) return { matched: false, reason: "no_swim" };
+
+  const bikeIdx = sorted.findIndex(
+    (c, i) => i > swimIdx && classifyDiscipline(c.sport) === "bike"
+  );
+  if (bikeIdx === -1) return { matched: false, reason: "no_bike_after_swim" };
+
+  const runIdx = sorted.findIndex(
+    (c, i) => i > bikeIdx && classifyDiscipline(c.sport) === "run"
+  );
+  if (runIdx === -1) return { matched: false, reason: "no_run_after_bike" };
+
+  // Items between disciplines must be plausible transitions.
+  const t1Slice = sorted.slice(swimIdx + 1, bikeIdx);
+  const t2Slice = sorted.slice(bikeIdx + 1, runIdx);
+
+  for (const t of [...t1Slice, ...t2Slice]) {
+    if (!looksLikeTransition(t.sport)) {
+      return { matched: false, reason: `unexpected_segment_${t.sport}` };
+    }
+    if (t.durationSec > opts.maxTransitionDurationSec) {
+      return { matched: false, reason: "transition_too_long" };
+    }
+  }
+
+  // Gap checks between adjacent included segments (swim → ...t1... → bike → ...t2... → run).
+  const path = [sorted[swimIdx], ...t1Slice, sorted[bikeIdx], ...t2Slice, sorted[runIdx]];
+  for (let i = 1; i < path.length; i += 1) {
+    const gapSec = (new Date(path[i].startUtc).getTime() - endMs(path[i - 1])) / 1000;
+    if (gapSec > opts.maxGapSec) {
+      return { matched: false, reason: "gap_too_long" };
+    }
+  }
+
+  // Optional: total duration within ±50% of planned.
+  if (typeof opts.plannedDurationMin === "number" && opts.plannedDurationMin > 0) {
+    const totalSec = path.reduce((sum, c) => sum + Math.max(0, c.durationSec), 0);
+    const plannedSec = opts.plannedDurationMin * 60;
+    const ratio = totalSec / plannedSec;
+    if (ratio < 0.5 || ratio > 1.5) {
+      return { matched: false, reason: "duration_out_of_range" };
+    }
+  }
+
+  // Assign roles.
+  const orderedSegments: Array<{ id: string; role: RaceSegmentRole; startUtc: string; durationSec: number; index: number }> = [];
+  let nextIndex = 0;
+  const push = (c: RaceCandidate, role: RaceSegmentRole) => {
+    orderedSegments.push({ id: c.id, role, startUtc: c.startUtc, durationSec: c.durationSec, index: nextIndex });
+    nextIndex += 1;
+  };
+
+  push(sorted[swimIdx], "swim");
+  for (const t of t1Slice) push(t, "t1");
+  push(sorted[bikeIdx], "bike");
+  for (const t of t2Slice) push(t, "t2");
+  push(sorted[runIdx], "run");
+
+  return { matched: true, orderedSegments };
+}

--- a/supabase/migrations/202604280001_create_race_bundles.sql
+++ b/supabase/migrations/202604280001_create_race_bundles.sql
@@ -1,0 +1,60 @@
+-- Race bundles: groups multiple completed_activities (swim/T1/bike/T2/run) into a single race entity.
+-- Created either at parse time from a Garmin auto_multi_sport FIT file, or reconstructed from
+-- multiple Strava activities arriving on the same day in race shape.
+
+create table if not exists public.race_bundles (
+  id uuid primary key default gen_random_uuid(),
+  user_id uuid not null references auth.users(id) on delete cascade,
+  started_at timestamptz not null,
+  ended_at timestamptz,
+  total_duration_sec integer not null default 0 check (total_duration_sec >= 0),
+  total_distance_m numeric(12, 2),
+  source text not null check (source in ('garmin_multisport', 'strava_reconstructed', 'manual')),
+  upload_id uuid references public.activity_uploads(id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index if not exists race_bundles_user_started_idx
+  on public.race_bundles(user_id, started_at desc);
+
+alter table public.race_bundles enable row level security;
+
+create policy "race_bundles_select_own" on public.race_bundles
+  for select using (auth.uid() = user_id);
+create policy "race_bundles_insert_own" on public.race_bundles
+  for insert with check (auth.uid() = user_id);
+create policy "race_bundles_update_own" on public.race_bundles
+  for update using (auth.uid() = user_id) with check (auth.uid() = user_id);
+create policy "race_bundles_delete_own" on public.race_bundles
+  for delete using (auth.uid() = user_id);
+
+create or replace function public.set_race_bundles_updated_at()
+returns trigger as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$ language plpgsql;
+
+drop trigger if exists race_bundles_updated_at on public.race_bundles;
+create trigger race_bundles_updated_at
+  before update on public.race_bundles
+  for each row execute function public.set_race_bundles_updated_at();
+
+-- Per-segment columns on completed_activities. race_bundle_id binds a child to its bundle;
+-- race_segment_role tags it as swim/T1/bike/T2/run; race_segment_index orders chronologically.
+
+alter table public.completed_activities
+  add column if not exists race_bundle_id uuid references public.race_bundles(id) on delete set null;
+
+alter table public.completed_activities
+  add column if not exists race_segment_role text
+    check (race_segment_role in ('swim', 't1', 'bike', 't2', 'run'));
+
+alter table public.completed_activities
+  add column if not exists race_segment_index smallint;
+
+create index if not exists completed_activities_race_bundle_idx
+  on public.completed_activities(race_bundle_id, race_segment_index)
+  where race_bundle_id is not null;

--- a/supabase/migrations/202604280002_allow_race_bundle_match_method.sql
+++ b/supabase/migrations/202604280002_allow_race_bundle_match_method.sql
@@ -1,0 +1,16 @@
+-- Race-bundled segments link to a planned race session via session_activity_links
+-- with match_method = 'race_bundle'. Extend the existing CHECK to permit it.
+
+alter table public.session_activity_links
+  drop constraint if exists session_activity_links_match_method_check;
+
+alter table public.session_activity_links
+  add constraint session_activity_links_match_method_check
+  check (match_method in (
+    'tolerance_auto',
+    'coach_confirmed',
+    'athlete_confirmed',
+    'manual_override',
+    'unmatched',
+    'race_bundle'
+  ));


### PR DESCRIPTION
## Summary

- **Multisport FIT parsing**: Garmin `auto_multi_sport` files now emit per-leg segments + a bundle (was silently dropping 4 of 5 sessions).
- **Strava reconstruction**: same-day shape detector (swim → bike → run, optional short transitions) bundles split activities into one race entity. Hooked into the webhook + backfill paths.
- **Calendar + detail UX**: race-aware card variant (stacked 🏊 🚴 🏃 + "Race" badge + segment subtitle) and a per-segment detail view that links each leg to its activity page.
- **Schema**: new `race_bundles` table, plus `race_bundle_id` / `race_segment_role` / `race_segment_index` columns on `completed_activities`. `session_activity_links.match_method` widened to allow `'race_bundle'`.
- **`POST /api/race/backfill`**: idempotent one-shot endpoint to retroactively bundle existing same-day activities. Self-heals partial states (bundle written, links missing).

Activity loader fix: dropped the module-level cached select-variant index (it got pinned to a fallback variant when columns were added, then silently kept returning rows without the new columns even after migration) and reordered `selectVariants` so race-column-aware queries try first.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test` — 995/995 passing, including new tests for race detection (9 cases), race bundler (4 cases), multisport FIT parser (2 cases)
- [x] **Garmin path**: confirmed `22664022836_ACTIVITY.fit` parses into 5 segments with correct roles + sport-mapped metrics
- [x] **Strava path**: backfill endpoint successfully bundled the existing Apr 26 race (5 individual Strava activities → 1 `race_bundles` row + 5 confirmed `session_activity_links`)
- [x] **Calendar render**: Sun Apr 26 collapses from 5 "Needs review" cards into a single Joe Hannon Olympic race card with `152 min total · Swim 27m · Bike 77m · Run 44m`
- [x] **Detail page**: 5 collapsible segment cards in chronological order, each linking to `/activities/[id]` with full metrics (HR/power/pace/distance per leg)
- [ ] Reviewer: confirm migrations apply cleanly in your environment (`supabase db push`)
- [ ] Reviewer: spot-check that the existing single-session FIT upload path still works (regression risk in `parseFitFile`)

## Out of scope (v2)

- Ad-hoc race bundling (no planned race session)
- Race-specific AI narrative comparing splits to `race_profiles.course_profile`
- `sessions.race_profile_id` FK + "This is a race" toggle in session editor
- Manual re-bundling / undoing a bundle from the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)