### PR TITLE
feat(race-review): phase 1A data foundation

### DIFF
--- a/app/(protected)/activities/[activityId]/activity-linking-card.tsx
+++ b/app/(protected)/activities/[activityId]/activity-linking-card.tsx
@@ -1,9 +1,19 @@
 "use client";
 
-import { useState, useTransition } from "react";
+import { useMemo, useState, useTransition } from "react";
 import { useRouter } from "next/navigation";
 import type { SessionCandidate } from "@/lib/workouts/activity-details";
 import { deleteActivityAction, linkActivityAction, markUnplannedAction, toggleRaceAction, unlinkActivityAction, updateActivityNotesAction } from "./actions";
+
+type StitchCandidate = {
+  id: string;
+  sportType: string;
+  startTimeUtc: string;
+  durationSec: number;
+  distanceM: number | null;
+};
+
+type SegmentRole = "swim" | "t1" | "bike" | "t2" | "run";
 
 export function ActivityLinkingCard({
   activityId,
@@ -13,7 +23,9 @@ export function ActivityLinkingCard({
   initialNotes,
   isUnplanned,
   source,
-  externalProvider
+  externalProvider,
+  activityBundleId,
+  stitchCandidates
 }: {
   activityId: string;
   linkedSession: SessionCandidate | null;
@@ -23,12 +35,17 @@ export function ActivityLinkingCard({
   isUnplanned: boolean;
   source: string;
   externalProvider: string | null;
+  activityBundleId: string | null;
+  stitchCandidates: StitchCandidate[];
 }) {
   const router = useRouter();
   const [selectedSessionId, setSelectedSessionId] = useState(candidates[0]?.id ?? "");
   const [notes, setNotes] = useState(initialNotes ?? "");
   const [message, setMessage] = useState("");
   const [pending, startTransition] = useTransition();
+  const [stitchOpen, setStitchOpen] = useState(false);
+
+  const canStitch = isRace && activityBundleId === null && stitchCandidates.length >= 3;
 
   return (
     <div className="space-y-4">
@@ -110,9 +127,16 @@ export function ActivityLinkingCard({
             Add note
           </button>
         </div>
-        <button className="btn-secondary mt-3 text-xs" disabled={pending} onClick={() => startTransition(async () => void toggleRaceAction(activityId, !isRace))}>
-          {isRace ? "Unmark race" : "Mark as race"}
-        </button>
+        <div className="mt-3 flex flex-wrap gap-2">
+          <button className="btn-secondary text-xs" disabled={pending} onClick={() => startTransition(async () => void toggleRaceAction(activityId, !isRace))}>
+            {isRace ? "Unmark race" : "Mark as race"}
+          </button>
+          {canStitch ? (
+            <button className="btn-secondary text-xs" disabled={pending} onClick={() => setStitchOpen(true)}>
+              Stitch into race
+            </button>
+          ) : null}
+        </div>
         {message ? <p className="mt-2 text-xs text-muted">{message}</p> : null}
         <div className="mt-4 border-t border-white/10 pt-3">
           <button
@@ -137,6 +161,144 @@ export function ActivityLinkingCard({
           </button>
         </div>
       </article>
+
+      {stitchOpen ? (
+        <RaceStitchPicker
+          currentActivityId={activityId}
+          stitchCandidates={stitchCandidates}
+          onClose={() => setStitchOpen(false)}
+          onSuccess={(bundleId) => router.push(`/races/${bundleId}`)}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+const ROLE_OPTIONS: SegmentRole[] = ["swim", "t1", "bike", "t2", "run"];
+
+function defaultRoleForSport(sport: string): SegmentRole {
+  if (sport === "swim") return "swim";
+  if (sport === "bike") return "bike";
+  if (sport === "run") return "run";
+  return "bike";
+}
+
+function RaceStitchPicker({
+  currentActivityId,
+  stitchCandidates,
+  onClose,
+  onSuccess
+}: {
+  currentActivityId: string;
+  stitchCandidates: StitchCandidate[];
+  onClose: () => void;
+  onSuccess: (bundleId: string) => void;
+}) {
+  const [selected, setSelected] = useState<Record<string, SegmentRole | "">>(() => {
+    const initial: Record<string, SegmentRole | ""> = {};
+    for (const candidate of stitchCandidates) {
+      initial[candidate.id] = candidate.id === currentActivityId ? defaultRoleForSport(candidate.sportType) : "";
+    }
+    return initial;
+  });
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const orderedCandidates = useMemo(
+    () => [...stitchCandidates].sort((a, b) => new Date(a.startTimeUtc).getTime() - new Date(b.startTimeUtc).getTime()),
+    [stitchCandidates]
+  );
+
+  function setRole(id: string, role: SegmentRole | "") {
+    setSelected((prev) => ({ ...prev, [id]: role }));
+  }
+
+  async function submit() {
+    const segments: Array<{ activityId: string; role: SegmentRole; index: number }> = [];
+    let i = 0;
+    for (const candidate of orderedCandidates) {
+      const role = selected[candidate.id];
+      if (!role) continue;
+      segments.push({ activityId: candidate.id, role: role as SegmentRole, index: i });
+      i += 1;
+    }
+    if (segments.length < 3) {
+      setError("Pick at least three segments (swim, bike, run).");
+      return;
+    }
+
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/races/manual-stitch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ segments })
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setError((body as { error?: string }).error ?? "Failed to stitch race.");
+        setSubmitting(false);
+        return;
+      }
+      onSuccess((body as { bundleId: string }).bundleId);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to stitch race.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" role="dialog" aria-modal="true">
+      <div className="surface w-full max-w-lg p-5">
+        <div className="flex items-center justify-between gap-2 border-b border-[hsl(var(--border))] pb-2">
+          <h3 className="text-sm font-semibold">Stitch into race</h3>
+          <button className="text-xs text-tertiary" onClick={onClose} type="button">Close</button>
+        </div>
+        <p className="mt-2 text-xs text-muted">
+          Assign a role to the same-day activities you want to bundle as a race. Activities are listed in start-time order.
+        </p>
+
+        <ul className="mt-3 space-y-2">
+          {orderedCandidates.map((candidate) => {
+            const start = new Date(candidate.startTimeUtc).toLocaleTimeString(undefined, { hour: "2-digit", minute: "2-digit" });
+            return (
+              <li key={candidate.id} className="surface-subtle flex items-center gap-3 rounded-lg p-2.5 text-sm">
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium capitalize">{candidate.sportType}</p>
+                  <p className="text-xs text-muted">
+                    {start} · {Math.round(candidate.durationSec / 60)} min
+                    {candidate.distanceM ? ` · ${(candidate.distanceM / 1000).toFixed(2)} km` : ""}
+                  </p>
+                </div>
+                <select
+                  value={selected[candidate.id] ?? ""}
+                  onChange={(e) => setRole(candidate.id, e.target.value as SegmentRole | "")}
+                  className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-1 text-xs"
+                >
+                  <option value="">Skip</option>
+                  {ROLE_OPTIONS.map((role) => (
+                    <option key={role} value={role}>
+                      {role.toUpperCase()}
+                    </option>
+                  ))}
+                </select>
+              </li>
+            );
+          })}
+        </ul>
+
+        {error ? <p className="mt-3 text-xs text-rose-400">{error}</p> : null}
+
+        <div className="mt-4 flex items-center justify-end gap-2">
+          <button className="btn-secondary text-xs" type="button" onClick={onClose} disabled={submitting}>
+            Cancel
+          </button>
+          <button className="btn-primary text-xs" type="button" onClick={submit} disabled={submitting}>
+            {submitting ? "Stitching…" : "Stitch race"}
+          </button>
+        </div>
+      </div>
     </div>
   );
 }

--- a/app/(protected)/activities/[activityId]/page.tsx
+++ b/app/(protected)/activities/[activityId]/page.tsx
@@ -100,6 +100,39 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
   if (!payload) notFound();
 
   const { activity, linkedSession, candidates } = payload;
+
+  // Race-stitching context: same-day sibling activities + this activity's
+  // current bundle id (so the stitch CTA only renders when this activity
+  // is marked as a race AND not already part of a bundle).
+  const dayIso = activity.start_time_utc.slice(0, 10);
+  const dayStart = `${dayIso}T00:00:00.000Z`;
+  const dayEnd = `${dayIso}T23:59:59.999Z`;
+
+  const { data: stitchSelfRow } = await supabase
+    .from("completed_activities")
+    .select("race_bundle_id")
+    .eq("id", activity.id)
+    .eq("user_id", user.id)
+    .maybeSingle();
+  const activityBundleId = (stitchSelfRow?.race_bundle_id as string | null | undefined) ?? null;
+
+  const { data: stitchSiblings } = await supabase
+    .from("completed_activities")
+    .select("id,sport_type,start_time_utc,duration_sec,distance_m,race_bundle_id")
+    .eq("user_id", user.id)
+    .gte("start_time_utc", dayStart)
+    .lte("start_time_utc", dayEnd)
+    .order("start_time_utc", { ascending: true });
+
+  const stitchCandidates = (stitchSiblings ?? [])
+    .filter((row: any) => !row.race_bundle_id)
+    .map((row: any) => ({
+      id: row.id as string,
+      sportType: row.sport_type as string,
+      startTimeUtc: row.start_time_utc as string,
+      durationSec: Number(row.duration_sec ?? 0),
+      distanceM: row.distance_m != null ? Number(row.distance_m) : null
+    }));
   const dateLabel = new Date(activity.start_time_utc).toLocaleString(undefined, {
     weekday: "short",
     month: "short",
@@ -265,6 +298,8 @@ export default async function ActivityDetailsPage({ params }: { params: { activi
           isUnplanned={activity.is_unplanned}
           source={activity.source}
           externalProvider={activity.external_provider}
+          activityBundleId={activityBundleId}
+          stitchCandidates={stitchCandidates}
         />
       </div>
     </section>

--- a/app/(protected)/races/[bundleId]/notes/page.tsx
+++ b/app/(protected)/races/[bundleId]/notes/page.tsx
@@ -1,0 +1,53 @@
+import { notFound, redirect } from "next/navigation";
+import Link from "next/link";
+import { createClient } from "@/lib/supabase/server";
+import { loadRaceBundleSummary } from "@/lib/race/bundle-helpers";
+import { SubjectiveForm } from "./subjective-form";
+
+export const dynamic = "force-dynamic";
+
+export default async function RaceNotesPage({ params }: { params: Promise<{ bundleId: string }> }) {
+  const { bundleId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/auth/sign-in?redirectTo=${encodeURIComponent(`/races/${bundleId}/notes`)}`);
+  }
+
+  const summary = await loadRaceBundleSummary(supabase, user.id, bundleId);
+  if (!summary) notFound();
+
+  const isEditing = Boolean(summary.bundle.subjective_captured_at);
+  const title = summary.raceProfile?.name ?? `Race on ${summary.bundle.started_at.slice(0, 10)}`;
+
+  return (
+    <div className="mx-auto flex w-full max-w-2xl flex-col gap-5 p-4 md:p-6">
+      <header className="flex flex-col gap-1">
+        <Link href={`/races/${bundleId}`} className="text-xs text-tertiary underline-offset-2 hover:underline">
+          ← Back to race
+        </Link>
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race notes</p>
+        <h1 className="text-2xl font-semibold text-[rgba(255,255,255,0.92)]">{title}</h1>
+        <p className="text-sm text-muted">
+          {isEditing
+            ? "Edit your subjective inputs from race day."
+            : "Capture your subjective experience while it's still fresh."}
+        </p>
+      </header>
+
+      <SubjectiveForm
+        bundleId={bundleId}
+        defaults={{
+          athleteRating: summary.bundle.athlete_rating,
+          athleteNotes: summary.bundle.athlete_notes,
+          issuesFlagged: summary.bundle.issues_flagged,
+          finishPosition: summary.bundle.finish_position,
+          ageGroupPosition: summary.bundle.age_group_position
+        }}
+      />
+    </div>
+  );
+}

--- a/app/(protected)/races/[bundleId]/notes/subjective-form.tsx
+++ b/app/(protected)/races/[bundleId]/notes/subjective-form.tsx
@@ -1,0 +1,182 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import { SUBJECTIVE_ISSUE_TAGS, type SubjectiveIssueTag } from "@/lib/race/subjective-input";
+
+const ISSUE_LABELS: Record<SubjectiveIssueTag, string> = {
+  nutrition: "Nutrition",
+  mechanical: "Mechanical",
+  illness: "Illness",
+  navigation: "Navigation",
+  pacing: "Pacing",
+  mental: "Mental",
+  weather: "Weather"
+};
+
+type Defaults = {
+  athleteRating: number | null;
+  athleteNotes: string | null;
+  issuesFlagged: string[];
+  finishPosition: number | null;
+  ageGroupPosition: number | null;
+};
+
+export function SubjectiveForm({ bundleId, defaults }: { bundleId: string; defaults: Defaults }) {
+  const router = useRouter();
+  const [rating, setRating] = useState<number>(defaults.athleteRating ?? 0);
+  const [notes, setNotes] = useState<string>(defaults.athleteNotes ?? "");
+  const [issues, setIssues] = useState<Set<SubjectiveIssueTag>>(
+    new Set((defaults.issuesFlagged ?? []).filter((tag): tag is SubjectiveIssueTag => SUBJECTIVE_ISSUE_TAGS.includes(tag as SubjectiveIssueTag)))
+  );
+  const [finishPosition, setFinishPosition] = useState<string>(
+    defaults.finishPosition != null ? String(defaults.finishPosition) : ""
+  );
+  const [agPosition, setAgPosition] = useState<string>(
+    defaults.ageGroupPosition != null ? String(defaults.ageGroupPosition) : ""
+  );
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  function toggleIssue(tag: SubjectiveIssueTag) {
+    setIssues((prev) => {
+      const next = new Set(prev);
+      if (next.has(tag)) next.delete(tag);
+      else next.add(tag);
+      return next;
+    });
+  }
+
+  async function handleSubmit(event: React.FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (submitting) return;
+    if (rating < 1 || rating > 5) {
+      setError("Please choose a rating from 1 to 5.");
+      return;
+    }
+    setSubmitting(true);
+    setError(null);
+
+    const payload = {
+      athleteRating: rating,
+      athleteNotes: notes.trim() ? notes : null,
+      issuesFlagged: Array.from(issues),
+      finishPosition: finishPosition.trim() ? Number(finishPosition) : null,
+      ageGroupPosition: agPosition.trim() ? Number(agPosition) : null
+    };
+
+    try {
+      const res = await fetch(`/api/races/${bundleId}/subjective`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(payload)
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        setError((body as { error?: string }).error ?? "Failed to save race notes.");
+        setSubmitting(false);
+        return;
+      }
+      router.push(`/races/${bundleId}`);
+      router.refresh();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Failed to save race notes.");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form onSubmit={handleSubmit} className="surface flex flex-col gap-5 p-5">
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-medium text-[rgba(255,255,255,0.92)]">How was the race?</legend>
+        <div className="flex items-center gap-2">
+          {[1, 2, 3, 4, 5].map((value) => (
+            <button
+              key={value}
+              type="button"
+              aria-label={`${value} out of 5`}
+              onClick={() => setRating(value)}
+              className={`text-2xl transition ${value <= rating ? "text-amber-300" : "text-[hsl(var(--surface-subtle))] hover:text-amber-300/60"}`}
+            >
+              ★
+            </button>
+          ))}
+          <span className="ml-2 text-xs text-tertiary">{rating > 0 ? `${rating} / 5` : "Select a rating"}</span>
+        </div>
+      </fieldset>
+
+      <fieldset className="flex flex-col gap-2">
+        <legend className="text-sm font-medium text-[rgba(255,255,255,0.92)]">Anything go wrong?</legend>
+        <div className="flex flex-wrap gap-2">
+          {SUBJECTIVE_ISSUE_TAGS.map((tag) => {
+            const active = issues.has(tag);
+            return (
+              <button
+                key={tag}
+                type="button"
+                onClick={() => toggleIssue(tag)}
+                className={`rounded-full border px-3 py-1 text-xs transition ${
+                  active
+                    ? "border-amber-500/40 bg-amber-500/15 text-amber-200"
+                    : "border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] text-tertiary hover:border-[rgba(255,255,255,0.18)]"
+                }`}
+              >
+                {ISSUE_LABELS[tag]}
+              </button>
+            );
+          })}
+        </div>
+      </fieldset>
+
+      <label className="flex flex-col gap-1.5 text-sm">
+        <span className="font-medium text-[rgba(255,255,255,0.92)]">Notes</span>
+        <textarea
+          value={notes}
+          onChange={(e) => setNotes(e.target.value)}
+          maxLength={4000}
+          rows={6}
+          placeholder="What stood out? What would you change?"
+          className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-sm text-[rgba(255,255,255,0.92)] placeholder:text-tertiary focus:border-[rgba(255,255,255,0.32)] focus:outline-none"
+        />
+        <span className="text-[10px] text-tertiary">{notes.length} / 4000</span>
+      </label>
+
+      <div className="grid grid-cols-1 gap-3 sm:grid-cols-2">
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium text-[rgba(255,255,255,0.92)]">Overall finish</span>
+          <input
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={finishPosition}
+            onChange={(e) => setFinishPosition(e.target.value)}
+            className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-sm text-[rgba(255,255,255,0.92)] focus:border-[rgba(255,255,255,0.32)] focus:outline-none"
+          />
+        </label>
+        <label className="flex flex-col gap-1.5 text-sm">
+          <span className="font-medium text-[rgba(255,255,255,0.92)]">Age group finish</span>
+          <input
+            type="number"
+            min={1}
+            inputMode="numeric"
+            value={agPosition}
+            onChange={(e) => setAgPosition(e.target.value)}
+            className="rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-2 text-sm text-[rgba(255,255,255,0.92)] focus:border-[rgba(255,255,255,0.32)] focus:outline-none"
+          />
+        </label>
+      </div>
+
+      {error ? <p className="text-sm text-red-400">{error}</p> : null}
+
+      <div className="flex items-center justify-end gap-3">
+        <button
+          type="submit"
+          disabled={submitting || rating < 1}
+          className="rounded-md border border-emerald-500/40 bg-emerald-500/15 px-4 py-1.5 text-sm font-medium text-emerald-200 transition hover:bg-emerald-500/25 disabled:cursor-not-allowed disabled:opacity-50"
+        >
+          {submitting ? "Saving…" : "Save race notes"}
+        </button>
+      </div>
+    </form>
+  );
+}

--- a/app/(protected)/races/[bundleId]/page.tsx
+++ b/app/(protected)/races/[bundleId]/page.tsx
@@ -1,0 +1,403 @@
+import Link from "next/link";
+import { notFound, redirect } from "next/navigation";
+import { createClient } from "@/lib/supabase/server";
+import { loadRaceBundleSummary, type RaceBundleSummary } from "@/lib/race/bundle-helpers";
+import { RaceSegmentList } from "../../sessions/[sessionId]/components/race-segment-list";
+
+export const dynamic = "force-dynamic";
+
+const READINESS_BADGE: Record<
+  NonNullable<RaceBundleSummary["bundle"]["pre_race_tsb_state"]>,
+  { label: string; color: string; bg: string; border: string }
+> = {
+  fresh: { label: "Fresh", color: "rgb(52, 211, 153)", bg: "rgba(52, 211, 153, 0.08)", border: "rgba(52, 211, 153, 0.25)" },
+  absorbing: { label: "Absorbing", color: "rgb(251, 191, 36)", bg: "rgba(251, 191, 36, 0.08)", border: "rgba(251, 191, 36, 0.25)" },
+  fatigued: { label: "Fatigued", color: "rgb(251, 146, 60)", bg: "rgba(251, 146, 60, 0.08)", border: "rgba(251, 146, 60, 0.25)" },
+  overreaching: { label: "Overreaching", color: "rgb(248, 113, 113)", bg: "rgba(248, 113, 113, 0.08)", border: "rgba(248, 113, 113, 0.25)" }
+};
+
+const ISSUE_LABELS: Record<string, string> = {
+  nutrition: "Nutrition",
+  mechanical: "Mechanical",
+  illness: "Illness",
+  navigation: "Navigation",
+  pacing: "Pacing",
+  mental: "Mental",
+  weather: "Weather"
+};
+
+function formatDuration(sec: number): string {
+  const total = Math.max(0, Math.round(sec));
+  const h = Math.floor(total / 3600);
+  const m = Math.floor((total % 3600) / 60);
+  const s = total % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, "0")}:${String(s).padStart(2, "0")}`;
+  return `${m}:${String(s).padStart(2, "0")}`;
+}
+
+function formatSignedDuration(sec: number): string {
+  const sign = sec < 0 ? "−" : "+";
+  return `${sign}${formatDuration(Math.abs(sec))}`;
+}
+
+function formatRaceDate(dateStr: string): string {
+  return new Intl.DateTimeFormat("en-US", {
+    weekday: "short",
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+    timeZone: "UTC"
+  }).format(new Date(`${dateStr}T00:00:00.000Z`));
+}
+
+function disciplineSplitFromSegments(segments: RaceBundleSummary["segments"]): Array<{ key: string; label: string; pct: number }> {
+  const total = segments.reduce((sum, s) => sum + s.durationSec, 0);
+  if (total === 0) return [];
+
+  // Bucket transitions into the discipline that follows them (T1 → bike, T2 → run).
+  const buckets: Record<string, number> = { swim: 0, bike: 0, run: 0 };
+  for (const seg of segments) {
+    if (seg.role === "swim") buckets.swim += seg.durationSec;
+    else if (seg.role === "t1" || seg.role === "bike") buckets.bike += seg.durationSec;
+    else if (seg.role === "t2" || seg.role === "run") buckets.run += seg.durationSec;
+  }
+
+  return [
+    { key: "swim", label: "Swim", pct: buckets.swim / total },
+    { key: "bike", label: "Bike + T1", pct: buckets.bike / total },
+    { key: "run", label: "Run + T2", pct: buckets.run / total }
+  ];
+}
+
+function disciplineSplitFromReview(review: NonNullable<RaceBundleSummary["review"]>): Array<{ key: string; label: string; pct: number }> {
+  const dist = review.discipline_distribution_actual ?? {};
+  const swim = Number(dist.swim ?? 0);
+  const t1 = Number(dist.t1 ?? 0);
+  const bike = Number(dist.bike ?? 0);
+  const t2 = Number(dist.t2 ?? 0);
+  const run = Number(dist.run ?? 0);
+  return [
+    { key: "swim", label: "Swim", pct: swim },
+    { key: "bike", label: "Bike + T1", pct: bike + t1 },
+    { key: "run", label: "Run + T2", pct: run + t2 }
+  ];
+}
+
+export default async function RaceBundlePage({ params }: { params: Promise<{ bundleId: string }> }) {
+  const { bundleId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect(`/auth/sign-in?redirectTo=${encodeURIComponent(`/races/${bundleId}`)}`);
+  }
+
+  const summary = await loadRaceBundleSummary(supabase, user.id, bundleId);
+  if (!summary) notFound();
+
+  const { bundle, raceProfile, segments, review } = summary;
+
+  const heroDate = bundle.started_at.slice(0, 10);
+  const title = raceProfile?.name ?? `Race on ${formatRaceDate(heroDate)}`;
+  const finishSec = bundle.total_duration_sec;
+  const goalSec = bundle.goal_time_sec;
+  const goalDelta = goalSec != null ? finishSec - goalSec : null;
+
+  const distanceLabel = bundle.total_distance_m != null
+    ? `${(bundle.total_distance_m / 1000).toFixed(2)} km`
+    : null;
+
+  const tsbState = bundle.pre_race_tsb_state;
+  const tsbBadge = tsbState ? READINESS_BADGE[tsbState] : null;
+
+  const split = review && review.discipline_distribution_actual
+    ? disciplineSplitFromReview(review)
+    : disciplineSplitFromSegments(segments);
+
+  return (
+    <div className="mx-auto flex w-full max-w-4xl flex-col gap-5 p-4 md:p-6">
+      <header className="flex flex-col gap-1">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race summary</p>
+        <h1 className="text-2xl font-semibold text-[rgba(255,255,255,0.92)]">{title}</h1>
+        <p className="text-sm text-muted">
+          {formatRaceDate(heroDate)}
+          {raceProfile?.distance_type ? <> · <span className="capitalize">{raceProfile.distance_type}</span></> : null}
+          {distanceLabel ? <> · {distanceLabel}</> : null}
+        </p>
+        <div className="mt-2 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+          <span className="font-mono text-3xl font-semibold text-[rgba(255,255,255,0.96)]">{formatDuration(finishSec)}</span>
+          <span className="text-xs uppercase tracking-[0.12em] text-tertiary">finish time</span>
+          {goalSec != null && goalDelta != null ? (
+            <span
+              className={`rounded-full border px-2 py-0.5 font-mono text-xs ${
+                goalDelta <= 0
+                  ? "border-emerald-500/30 bg-emerald-500/10 text-emerald-300"
+                  : "border-orange-500/30 bg-orange-500/10 text-orange-300"
+              }`}
+            >
+              {formatSignedDuration(goalDelta)} vs goal {formatDuration(goalSec)}
+            </span>
+          ) : null}
+          {bundle.inferred_transitions ? (
+            <span className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-[10px] uppercase tracking-[0.1em] text-tertiary">
+              Stitched
+            </span>
+          ) : null}
+        </div>
+      </header>
+
+      <PreRaceStateStrip bundle={bundle} tsbBadge={tsbBadge} />
+
+      <DisciplineSplit split={split} inferredTransitions={bundle.inferred_transitions} />
+
+      <RaceSegmentList segments={segments} />
+
+      <SubjectiveSection bundle={bundle} bundleId={bundleId} />
+
+      <AiPlaceholder review={review} bundleId={bundleId} />
+    </div>
+  );
+}
+
+function PreRaceStateStrip({
+  bundle,
+  tsbBadge
+}: {
+  bundle: RaceBundleSummary["bundle"];
+  tsbBadge: { label: string; color: string; bg: string; border: string } | null;
+}) {
+  const status = bundle.pre_race_snapshot_status;
+
+  if (status === "unavailable" || status === "pending") {
+    return (
+      <article className="surface p-5">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Pre-race state</p>
+        <p className="mt-2 text-sm text-muted">
+          Pre-race state unavailable — fitness model had no data for this date.
+        </p>
+      </article>
+    );
+  }
+
+  return (
+    <article className="surface p-5">
+      <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--border))] pb-3">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Pre-race state</p>
+        {tsbBadge ? (
+          <span
+            className="rounded-full border px-2 py-0.5 text-xs"
+            style={{ color: tsbBadge.color, backgroundColor: tsbBadge.bg, borderColor: tsbBadge.border }}
+          >
+            {tsbBadge.label}
+          </span>
+        ) : null}
+      </div>
+      <dl className="mt-3 grid grid-cols-2 gap-3 text-sm md:grid-cols-4">
+        <Metric label="CTL" value={bundle.pre_race_ctl} fallback="—" />
+        <Metric label="ATL" value={bundle.pre_race_atl} fallback="—" />
+        <Metric label="TSB" value={bundle.pre_race_tsb} fallback="—" sign />
+        <Metric
+          label="Taper"
+          value={bundle.taper_compliance_score != null ? Math.round(bundle.taper_compliance_score * 100) : null}
+          fallback="—"
+          unit="%"
+        />
+      </dl>
+      {bundle.taper_compliance_summary ? (
+        <p className="mt-2 text-xs text-tertiary">{bundle.taper_compliance_summary}</p>
+      ) : null}
+    </article>
+  );
+}
+
+function Metric({
+  label,
+  value,
+  fallback,
+  unit,
+  sign
+}: {
+  label: string;
+  value: number | null;
+  fallback: string;
+  unit?: string;
+  sign?: boolean;
+}) {
+  const display =
+    value == null
+      ? fallback
+      : `${sign && value > 0 ? "+" : ""}${typeof value === "number" ? value : Number(value)}${unit ?? ""}`;
+  return (
+    <div className="flex flex-col">
+      <dt className="text-[10px] uppercase tracking-[0.12em] text-tertiary">{label}</dt>
+      <dd className="font-mono text-base text-[rgba(255,255,255,0.92)]">{display}</dd>
+    </div>
+  );
+}
+
+function DisciplineSplit({
+  split,
+  inferredTransitions
+}: {
+  split: Array<{ key: string; label: string; pct: number }>;
+  inferredTransitions: boolean;
+}) {
+  if (split.length === 0) return null;
+
+  return (
+    <article className="surface p-5">
+      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Discipline split</p>
+      <div className="mt-3 flex h-3 overflow-hidden rounded-full border border-[hsl(var(--border))]">
+        {split.map((row) => (
+          <div
+            key={row.key}
+            style={{ width: `${Math.max(0, Math.min(100, row.pct * 100))}%` }}
+            className={
+              row.key === "swim"
+                ? "bg-cyan-500/70"
+                : row.key === "bike"
+                ? "bg-amber-500/70"
+                : "bg-emerald-500/70"
+            }
+          />
+        ))}
+      </div>
+      <dl className="mt-3 grid grid-cols-3 gap-3 text-xs">
+        {split.map((row) => (
+          <div key={row.key} className="flex flex-col">
+            <dt className="uppercase tracking-[0.12em] text-tertiary">{row.label}</dt>
+            <dd className="font-mono text-sm text-[rgba(255,255,255,0.92)]">{Math.round(row.pct * 100)}%</dd>
+          </div>
+        ))}
+      </dl>
+      {inferredTransitions ? (
+        <p className="mt-2 text-xs text-tertiary">Transitions inferred from gaps between activities.</p>
+      ) : null}
+    </article>
+  );
+}
+
+function SubjectiveSection({
+  bundle,
+  bundleId
+}: {
+  bundle: RaceBundleSummary["bundle"];
+  bundleId: string;
+}) {
+  if (!bundle.subjective_captured_at) {
+    return (
+      <article className="surface p-5">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race notes</p>
+        <p className="mt-1 text-sm text-muted">
+          Add your rating, notes, and any issues so the next race review has the full picture.
+        </p>
+        <Link
+          href={`/races/${bundleId}/notes`}
+          className="mt-3 inline-flex items-center gap-2 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-3 py-1.5 text-sm text-[rgba(255,255,255,0.92)] transition hover:border-[rgba(255,255,255,0.18)]"
+        >
+          Add race notes →
+        </Link>
+      </article>
+    );
+  }
+
+  const rating = bundle.athlete_rating;
+  const issues = bundle.issues_flagged ?? [];
+
+  return (
+    <article className="surface p-5">
+      <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--border))] pb-3">
+        <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race notes</p>
+        <Link href={`/races/${bundleId}/notes`} className="text-xs text-tertiary underline-offset-2 hover:underline">
+          Edit
+        </Link>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-3">
+        {rating != null ? (
+          <div className="flex items-center gap-2 text-sm">
+            <span className="text-tertiary">Rating</span>
+            <span aria-label={`${rating} out of 5`} className="text-amber-300">
+              {"★".repeat(rating)}
+              <span className="text-[hsl(var(--surface-subtle))]">{"★".repeat(5 - rating)}</span>
+            </span>
+          </div>
+        ) : null}
+
+        {issues.length > 0 ? (
+          <div className="flex flex-wrap gap-1.5">
+            {issues.map((issue) => (
+              <span
+                key={issue}
+                className="rounded-full border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] px-2 py-0.5 text-xs text-[rgba(255,255,255,0.86)]"
+              >
+                {ISSUE_LABELS[issue] ?? issue}
+              </span>
+            ))}
+          </div>
+        ) : null}
+
+        {bundle.athlete_notes ? (
+          <p className="whitespace-pre-wrap text-sm text-[rgba(255,255,255,0.86)]">{bundle.athlete_notes}</p>
+        ) : null}
+
+        {(bundle.finish_position != null || bundle.age_group_position != null) ? (
+          <div className="flex flex-wrap gap-3 text-xs text-tertiary">
+            {bundle.finish_position != null ? <span>Overall: {bundle.finish_position}</span> : null}
+            {bundle.age_group_position != null ? <span>Age group: {bundle.age_group_position}</span> : null}
+          </div>
+        ) : null}
+      </div>
+    </article>
+  );
+}
+
+function AiPlaceholder({
+  review,
+  bundleId
+}: {
+  review: RaceBundleSummary["review"];
+  bundleId: string;
+}) {
+  if (review && review.headline) {
+    return (
+      <article className="surface p-5">
+        <div className="flex items-center justify-between gap-3 border-b border-[hsl(var(--border))] pb-3">
+          <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race review</p>
+          {review.is_provisional ? (
+            <span className="rounded-full border border-amber-500/30 bg-amber-500/10 px-2 py-0.5 text-[10px] uppercase tracking-[0.12em] text-amber-300">
+              Provisional
+            </span>
+          ) : null}
+        </div>
+        <h2 className="mt-3 text-base font-semibold text-[rgba(255,255,255,0.92)]">{review.headline}</h2>
+        {review.narrative ? (
+          <p className="mt-2 whitespace-pre-wrap text-sm text-[rgba(255,255,255,0.78)]">{review.narrative}</p>
+        ) : null}
+        {review.coach_take ? (
+          <div className="mt-3 rounded-md border border-[hsl(var(--border))] bg-[hsl(var(--surface-subtle))] p-3">
+            <p className="text-[10px] uppercase tracking-[0.12em] text-tertiary">Coach take</p>
+            <p className="mt-1 whitespace-pre-wrap text-sm text-[rgba(255,255,255,0.86)]">{review.coach_take}</p>
+          </div>
+        ) : null}
+      </article>
+    );
+  }
+
+  return (
+    <article className="surface p-5">
+      <p className="text-[11px] font-medium uppercase tracking-[0.14em] text-tertiary">Race review</p>
+      <p className="mt-2 text-sm text-muted">
+        Race review will appear here once you&apos;ve added your race notes.
+      </p>
+      <Link
+        href={`/races/${bundleId}/notes`}
+        className="mt-3 inline-flex items-center gap-2 text-xs text-tertiary underline-offset-2 hover:underline"
+      >
+        Add race notes →
+      </Link>
+    </article>
+  );
+}

--- a/app/(protected)/sessions/[sessionId]/page.tsx
+++ b/app/(protected)/sessions/[sessionId]/page.tsx
@@ -780,6 +780,17 @@ export default async function SessionReviewPage({ params, searchParams }: { para
         <RaceReviewPlaceholder bundleId={raceBundleId} />
       ) : null}
 
+      {raceSegmentList && raceBundleId ? (
+        <div className="flex justify-end">
+          <Link
+            href={`/races/${raceBundleId}`}
+            className="inline-flex items-center gap-2 text-xs text-tertiary underline-offset-2 hover:underline"
+          >
+            View race summary →
+          </Link>
+        </div>
+      ) : null}
+
       {raceSegmentList ? <RaceSegmentList segments={raceSegmentList} /> : null}
 
       {showFeelCapture ? <FeelCaptureBanner sessionId={session.id} existingFeel={existingFeelData} /> : null}

--- a/app/api/races/[bundleId]/regenerate-snapshot/route.ts
+++ b/app/api/races/[bundleId]/regenerate-snapshot/route.ts
@@ -1,0 +1,62 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { isSameOrigin } from "@/lib/security/request";
+import { createClient } from "@/lib/supabase/server";
+import { snapshotPreRaceState } from "@/lib/race/snapshot-pre-race-state";
+
+/**
+ * Dev-only: resets `pre_race_snapshot_status = 'pending'` and re-runs the
+ * snapshot. Useful when fitness backfill changes after a race has already
+ * been ingested. Disabled in production.
+ */
+export async function POST(request: Request, context: { params: Promise<{ bundleId: string }> }) {
+  if (process.env.NODE_ENV === "production") {
+    return NextResponse.json({ error: "Not available in production." }, { status: 404 });
+  }
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: "Invalid request origin." }, { status: 403 });
+  }
+
+  const { bundleId } = await context.params;
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const { data: bundleRow } = await supabase
+    .from("race_bundles")
+    .select("id, started_at")
+    .eq("id", bundleId)
+    .eq("user_id", user.id)
+    .maybeSingle();
+
+  if (!bundleRow) {
+    return NextResponse.json({ error: "Race bundle not found." }, { status: 404 });
+  }
+
+  await supabase
+    .from("race_bundles")
+    .update({
+      pre_race_snapshot_status: "pending",
+      pre_race_ctl: null,
+      pre_race_atl: null,
+      pre_race_tsb: null,
+      pre_race_tsb_state: null,
+      pre_race_ramp_rate: null,
+      pre_race_snapshot_at: null,
+      taper_compliance_score: null,
+      taper_compliance_summary: null
+    })
+    .eq("id", bundleId)
+    .eq("user_id", user.id);
+
+  const raceDate = (bundleRow.started_at as string).slice(0, 10);
+  const result = await snapshotPreRaceState({ supabase, userId: user.id, bundleId, raceDate });
+
+  revalidatePath(`/races/${bundleId}`);
+  return NextResponse.json({ ok: true, result });
+}

--- a/app/api/races/[bundleId]/route.ts
+++ b/app/api/races/[bundleId]/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+import { createClient } from "@/lib/supabase/server";
+import { loadRaceBundleSummary } from "@/lib/race/bundle-helpers";
+
+export async function GET(_request: Request, context: { params: Promise<{ bundleId: string }> }) {
+  const { bundleId } = await context.params;
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const summary = await loadRaceBundleSummary(supabase, user.id, bundleId);
+  if (!summary) {
+    return NextResponse.json({ error: "Race bundle not found." }, { status: 404 });
+  }
+
+  return NextResponse.json({ ok: true, ...summary });
+}

--- a/app/api/races/[bundleId]/subjective/route.ts
+++ b/app/api/races/[bundleId]/subjective/route.ts
@@ -1,0 +1,52 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { isSameOrigin } from "@/lib/security/request";
+import { createClient } from "@/lib/supabase/server";
+import {
+  persistSubjectiveInput,
+  subjectiveInputSchema
+} from "@/lib/race/subjective-input";
+
+export async function POST(request: Request, context: { params: Promise<{ bundleId: string }> }) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: "Invalid request origin." }, { status: 403 });
+  }
+
+  const { bundleId } = await context.params;
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const parsed = subjectiveInputSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid subjective input.", issues: parsed.error.flatten() }, { status: 422 });
+  }
+
+  const result = await persistSubjectiveInput({
+    supabase,
+    userId: user.id,
+    bundleId,
+    input: parsed.data
+  });
+
+  if (result.status === "error") {
+    const httpStatus = result.reason === "bundle_not_found" ? 404 : 500;
+    return NextResponse.json({ error: result.reason }, { status: httpStatus });
+  }
+
+  revalidatePath(`/races/${bundleId}`);
+  revalidatePath(`/races/${bundleId}/notes`);
+  return NextResponse.json({ ok: true, bundleId });
+}

--- a/app/api/races/manual-stitch/route.ts
+++ b/app/api/races/manual-stitch/route.ts
@@ -1,0 +1,66 @@
+import { revalidatePath } from "next/cache";
+import { NextResponse } from "next/server";
+import { z } from "zod";
+import { isSameOrigin } from "@/lib/security/request";
+import { createClient } from "@/lib/supabase/server";
+import { manualStitchRaceBundle } from "@/lib/race/manual-stitch";
+
+const manualStitchSchema = z.object({
+  segments: z
+    .array(
+      z.object({
+        activityId: z.string().uuid(),
+        role: z.enum(["swim", "t1", "bike", "t2", "run"]),
+        index: z.number().int().min(0)
+      })
+    )
+    .min(3)
+    .max(5)
+});
+
+export async function POST(request: Request) {
+  if (!isSameOrigin(request)) {
+    return NextResponse.json({ error: "Invalid request origin." }, { status: 403 });
+  }
+
+  const supabase = await createClient();
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+
+  const parsed = manualStitchSchema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json({ error: "Invalid manual-stitch payload.", issues: parsed.error.flatten() }, { status: 422 });
+  }
+
+  const result = await manualStitchRaceBundle({
+    supabase,
+    userId: user.id,
+    segments: parsed.data.segments
+  });
+
+  if (result.status === "error") {
+    const httpStatus = result.reason === "activity_ownership_mismatch" ? 403
+      : result.reason === "activity_already_in_bundle" ? 409
+      : 422;
+    return NextResponse.json({ error: result.reason }, { status: httpStatus });
+  }
+
+  revalidatePath("/dashboard");
+  if (result.plannedSessionId) {
+    revalidatePath(`/sessions/${result.plannedSessionId}`);
+  }
+  revalidatePath(`/races/${result.bundleId}`);
+  return NextResponse.json({ ok: true, bundleId: result.bundleId, plannedSessionId: result.plannedSessionId });
+}

--- a/lib/agent-preview/data.ts
+++ b/lib/agent-preview/data.ts
@@ -2111,6 +2111,38 @@ export function createPreviewDatabase(): PreviewDatabase {
           total_distance_m: 1500 + 213 + 39966 + 160 + 9368,
           source: "strava_reconstructed",
           upload_id: PREVIEW_UPLOAD_ID,
+          // Phase 1A: goal anchor + pre-race snapshot + subjective inputs
+          race_profile_id: PREVIEW_RACE_PROFILE_ID,
+          goal_time_sec: 10800,
+          goal_strategy_summary:
+            "Negative-split bike, hold 4:15/km on the first 5k, push final 2k if HR caps at 170.",
+          course_profile_snapshot: {
+            swim_distance_m: 1500,
+            bike_distance_km: 40,
+            run_distance_km: 10,
+            bike_elevation_m: 320,
+            course_type: "rolling",
+            expected_conditions: "cool"
+          },
+          conditions_snapshot: {},
+          pre_race_ctl: 78.4,
+          pre_race_atl: 62.1,
+          pre_race_tsb: 16.3,
+          pre_race_tsb_state: "fresh",
+          pre_race_ramp_rate: 1.4,
+          pre_race_snapshot_at: new Date().toISOString(),
+          pre_race_snapshot_status: "captured",
+          taper_compliance_score: 0.857,
+          taper_compliance_summary: "6 of 7 taper sessions on target",
+          athlete_rating: 4,
+          athlete_notes:
+            "Felt strong off the bike, slight nutrition wobble at km 8 of the run but recovered fast.",
+          issues_flagged: ["nutrition"],
+          finish_position: 18,
+          age_group_position: 4,
+          subjective_captured_at: new Date().toISOString(),
+          status: "reviewed",
+          inferred_transitions: true,
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
         }
@@ -2136,6 +2168,9 @@ export function createPreviewDatabase(): PreviewDatabase {
             expected_conditions: "cool"
           },
           ideal_discipline_distribution: { swim: 0.18, bike: 0.55, run: 0.27 },
+          goal_time_sec: 10800,
+          goal_strategy_summary:
+            "Negative-split bike, hold 4:15/km on the first 5k, push final 2k if HR caps at 170.",
           notes: "B-race rehearsal slotted before Galway 70.3.",
           created_at: new Date().toISOString(),
           updated_at: new Date().toISOString()
@@ -2187,7 +2222,7 @@ export function createPreviewDatabase(): PreviewDatabase {
 const globalKey = "__tri_preview_database__" as const;
 const globalVersionKey = "__tri_preview_database_version__" as const;
 // Bump this when the seed schema changes (new tables, new columns, etc.)
-const PREVIEW_DATABASE_VERSION = 7;
+const PREVIEW_DATABASE_VERSION = 8;
 
 function getOrCreateDatabase(): PreviewDatabase {
   const existing = (globalThis as Record<string, unknown>)[globalKey] as PreviewDatabase | undefined;

--- a/lib/race/bundle-helpers.ts
+++ b/lib/race/bundle-helpers.ts
@@ -1,0 +1,235 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { RaceSegmentSummary } from "@/app/(protected)/sessions/[sessionId]/components/race-segment-list";
+
+export type RaceProfileSnapshotInput = {
+  id: string;
+  name: string | null;
+  date: string;
+  distance_type: string | null;
+  priority: string | null;
+  goal_time_sec: number | null;
+  goal_strategy_summary: string | null;
+  course_profile: Record<string, unknown> | null;
+  notes: string | null;
+};
+
+export type FrozenGoalSnapshot = {
+  race_profile_id: string;
+  goal_time_sec: number | null;
+  goal_strategy_summary: string | null;
+  course_profile_snapshot: Record<string, unknown>;
+};
+
+/**
+ * Look up the same-day `race_profiles` row for a bundle. Mirrors the
+ * date-based lookup pattern in attemptRaceBundle. Returns null when there is
+ * no profile (or more than one — caller should not guess).
+ */
+export async function resolveRaceProfileForBundle(
+  supabase: SupabaseClient,
+  userId: string,
+  bundleStartDateLocal: string
+): Promise<RaceProfileSnapshotInput | null> {
+  const { data, error } = await supabase
+    .from("race_profiles")
+    .select("id, name, date, distance_type, priority, goal_time_sec, goal_strategy_summary, course_profile, notes")
+    .eq("user_id", userId)
+    .eq("date", bundleStartDateLocal);
+
+  if (error || !data || data.length !== 1) return null;
+  const row = data[0] as RaceProfileSnapshotInput;
+  return row;
+}
+
+/**
+ * Build the immutable goal snapshot from a race profile. Used at insert time
+ * (and once during self-heal) so that future edits to the race profile do not
+ * silently mutate a race that's already been raced.
+ */
+export function freezeGoalSnapshot(profile: RaceProfileSnapshotInput): FrozenGoalSnapshot {
+  return {
+    race_profile_id: profile.id,
+    goal_time_sec: profile.goal_time_sec ?? null,
+    goal_strategy_summary: profile.goal_strategy_summary ?? null,
+    course_profile_snapshot: (profile.course_profile ?? {}) as Record<string, unknown>
+  };
+}
+
+export type RaceBundleSummary = {
+  bundle: {
+    id: string;
+    user_id: string;
+    started_at: string;
+    ended_at: string | null;
+    total_duration_sec: number;
+    total_distance_m: number | null;
+    source: "garmin_multisport" | "strava_reconstructed" | "manual";
+    race_profile_id: string | null;
+    goal_time_sec: number | null;
+    goal_strategy_summary: string | null;
+    course_profile_snapshot: Record<string, unknown>;
+    pre_race_ctl: number | null;
+    pre_race_atl: number | null;
+    pre_race_tsb: number | null;
+    pre_race_tsb_state: "fresh" | "absorbing" | "fatigued" | "overreaching" | null;
+    pre_race_ramp_rate: number | null;
+    pre_race_snapshot_at: string | null;
+    pre_race_snapshot_status: "pending" | "captured" | "partial" | "unavailable";
+    taper_compliance_score: number | null;
+    taper_compliance_summary: string | null;
+    athlete_rating: number | null;
+    athlete_notes: string | null;
+    issues_flagged: string[];
+    finish_position: number | null;
+    age_group_position: number | null;
+    subjective_captured_at: string | null;
+    status: "imported" | "reviewed" | "archived";
+    inferred_transitions: boolean;
+  };
+  raceProfile: {
+    id: string;
+    name: string;
+    date: string;
+    distance_type: string | null;
+  } | null;
+  segments: RaceSegmentSummary[];
+  review: {
+    headline: string | null;
+    narrative: string | null;
+    coach_take: string | null;
+    transition_notes: string | null;
+    pacing_notes: unknown;
+    discipline_distribution_actual: Record<string, number> | null;
+    discipline_distribution_delta: Record<string, number> | null;
+    is_provisional: boolean;
+    generated_at: string | null;
+  } | null;
+};
+
+const BUNDLE_COLUMNS =
+  "id,user_id,started_at,ended_at,total_duration_sec,total_distance_m,source," +
+  "race_profile_id,goal_time_sec,goal_strategy_summary,course_profile_snapshot," +
+  "pre_race_ctl,pre_race_atl,pre_race_tsb,pre_race_tsb_state,pre_race_ramp_rate," +
+  "pre_race_snapshot_at,pre_race_snapshot_status,taper_compliance_score,taper_compliance_summary," +
+  "athlete_rating,athlete_notes,issues_flagged,finish_position,age_group_position,subjective_captured_at," +
+  "status,inferred_transitions";
+
+/**
+ * Single source of truth for the AI-free race summary route. Returns the
+ * bundle row, the (optional) linked race profile, ordered segments, and the
+ * (optional) AI race review for the embed slot. Returns null when the bundle
+ * is missing or not owned by `userId`.
+ */
+export async function loadRaceBundleSummary(
+  supabase: SupabaseClient,
+  userId: string,
+  bundleId: string
+): Promise<RaceBundleSummary | null> {
+  const { data: bundleRow, error: bundleError } = await supabase
+    .from("race_bundles")
+    .select(BUNDLE_COLUMNS)
+    .eq("id", bundleId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (bundleError || !bundleRow) return null;
+
+  const bundle = normalizeBundleRow(bundleRow as unknown as Record<string, unknown>);
+
+  let raceProfile: RaceBundleSummary["raceProfile"] = null;
+  if (bundle.race_profile_id) {
+    const { data: profileRow } = await supabase
+      .from("race_profiles")
+      .select("id, name, date, distance_type")
+      .eq("id", bundle.race_profile_id)
+      .eq("user_id", userId)
+      .maybeSingle();
+    if (profileRow) {
+      raceProfile = {
+        id: profileRow.id as string,
+        name: profileRow.name as string,
+        date: profileRow.date as string,
+        distance_type: (profileRow.distance_type as string | null) ?? null
+      };
+    }
+  }
+
+  const { data: segmentRows } = await supabase
+    .from("completed_activities")
+    .select("id,sport_type,start_time_utc,duration_sec,distance_m,avg_hr,avg_power,race_segment_role,race_segment_index")
+    .eq("user_id", userId)
+    .eq("race_bundle_id", bundleId)
+    .order("race_segment_index", { ascending: true });
+
+  const segments: RaceSegmentSummary[] = (segmentRows ?? [])
+    .filter((row: any) => row.race_segment_role)
+    .map((row: any) => ({
+      activityId: row.id as string,
+      role: row.race_segment_role as RaceSegmentSummary["role"],
+      sport: row.sport_type as string,
+      startTimeUtc: row.start_time_utc as string,
+      durationSec: Number(row.duration_sec ?? 0),
+      distanceM: row.distance_m !== null && row.distance_m !== undefined ? Number(row.distance_m) : null,
+      avgHr: row.avg_hr !== null && row.avg_hr !== undefined ? Number(row.avg_hr) : null,
+      avgPower: row.avg_power !== null && row.avg_power !== undefined ? Number(row.avg_power) : null
+    }));
+
+  const { data: reviewRow } = await supabase
+    .from("race_reviews")
+    .select("headline,narrative,coach_take,transition_notes,pacing_notes,discipline_distribution_actual,discipline_distribution_delta,is_provisional,generated_at")
+    .eq("race_bundle_id", bundleId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  const review: RaceBundleSummary["review"] = reviewRow
+    ? {
+        headline: (reviewRow.headline as string | null) ?? null,
+        narrative: (reviewRow.narrative as string | null) ?? null,
+        coach_take: (reviewRow.coach_take as string | null) ?? null,
+        transition_notes: (reviewRow.transition_notes as string | null) ?? null,
+        pacing_notes: reviewRow.pacing_notes ?? null,
+        discipline_distribution_actual:
+          (reviewRow.discipline_distribution_actual as Record<string, number> | null) ?? null,
+        discipline_distribution_delta:
+          (reviewRow.discipline_distribution_delta as Record<string, number> | null) ?? null,
+        is_provisional: Boolean(reviewRow.is_provisional),
+        generated_at: (reviewRow.generated_at as string | null) ?? null
+      }
+    : null;
+
+  return { bundle, raceProfile, segments, review };
+}
+
+function normalizeBundleRow(row: Record<string, unknown>): RaceBundleSummary["bundle"] {
+  return {
+    id: row.id as string,
+    user_id: row.user_id as string,
+    started_at: row.started_at as string,
+    ended_at: (row.ended_at as string | null) ?? null,
+    total_duration_sec: Number(row.total_duration_sec ?? 0),
+    total_distance_m: row.total_distance_m != null ? Number(row.total_distance_m) : null,
+    source: row.source as "garmin_multisport" | "strava_reconstructed" | "manual",
+    race_profile_id: (row.race_profile_id as string | null) ?? null,
+    goal_time_sec: row.goal_time_sec != null ? Number(row.goal_time_sec) : null,
+    goal_strategy_summary: (row.goal_strategy_summary as string | null) ?? null,
+    course_profile_snapshot: (row.course_profile_snapshot as Record<string, unknown> | null) ?? {},
+    pre_race_ctl: row.pre_race_ctl != null ? Number(row.pre_race_ctl) : null,
+    pre_race_atl: row.pre_race_atl != null ? Number(row.pre_race_atl) : null,
+    pre_race_tsb: row.pre_race_tsb != null ? Number(row.pre_race_tsb) : null,
+    pre_race_tsb_state: (row.pre_race_tsb_state as "fresh" | "absorbing" | "fatigued" | "overreaching" | null) ?? null,
+    pre_race_ramp_rate: row.pre_race_ramp_rate != null ? Number(row.pre_race_ramp_rate) : null,
+    pre_race_snapshot_at: (row.pre_race_snapshot_at as string | null) ?? null,
+    pre_race_snapshot_status:
+      (row.pre_race_snapshot_status as "pending" | "captured" | "partial" | "unavailable" | null) ?? "pending",
+    taper_compliance_score: row.taper_compliance_score != null ? Number(row.taper_compliance_score) : null,
+    taper_compliance_summary: (row.taper_compliance_summary as string | null) ?? null,
+    athlete_rating: row.athlete_rating != null ? Number(row.athlete_rating) : null,
+    athlete_notes: (row.athlete_notes as string | null) ?? null,
+    issues_flagged: Array.isArray(row.issues_flagged) ? (row.issues_flagged as string[]) : [],
+    finish_position: row.finish_position != null ? Number(row.finish_position) : null,
+    age_group_position: row.age_group_position != null ? Number(row.age_group_position) : null,
+    subjective_captured_at: (row.subjective_captured_at as string | null) ?? null,
+    status: (row.status as "imported" | "reviewed" | "archived" | null) ?? "imported",
+    inferred_transitions: Boolean(row.inferred_transitions)
+  };
+}

--- a/lib/race/manual-stitch.test.ts
+++ b/lib/race/manual-stitch.test.ts
@@ -1,0 +1,171 @@
+import { manualStitchRaceBundle } from "./manual-stitch";
+
+function makeSupabase(opts: {
+  activities: Array<Record<string, unknown>>;
+  raceProfiles?: Array<Record<string, unknown>>;
+  sameDaySessions?: Array<Record<string, unknown>>;
+}) {
+  const inserts: Array<{ table: string; rows: unknown }> = [];
+  const updates: Array<{ table: string; patch: unknown }> = [];
+  const bundleUpdates: Array<Record<string, unknown>> = [];
+
+  const supabase: any = {
+    from: (table: string) => {
+      if (table === "completed_activities") {
+        return {
+          select: () => ({
+            in: () => ({
+              eq: async () => ({ data: opts.activities, error: null })
+            })
+          }),
+          update: (patch: Record<string, unknown>) => {
+            updates.push({ table, patch });
+            return {
+              eq: () => ({
+                eq: async () => ({ error: null })
+              })
+            };
+          }
+        };
+      }
+      if (table === "race_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: async () => ({ data: opts.raceProfiles ?? [], error: null })
+            })
+          })
+        };
+      }
+      if (table === "race_bundles") {
+        return {
+          insert: (rows: unknown) => {
+            inserts.push({ table, rows });
+            return {
+              select: () => ({
+                single: async () => ({ data: { id: "bundle-1" }, error: null })
+              })
+            };
+          },
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({
+                  data: { id: "bundle-1", pre_race_snapshot_status: "pending" },
+                  error: null
+                })
+              })
+            })
+          }),
+          update: (patch: Record<string, unknown>) => {
+            bundleUpdates.push(patch);
+            return {
+              eq: () => ({
+                eq: async () => ({ error: null })
+              })
+            };
+          }
+        };
+      }
+      if (table === "sessions") {
+        const taperChain: any = {
+          eq: () => taperChain,
+          gte: () => taperChain,
+          lt: () => taperChain,
+          then: (resolve: any) => resolve({ data: opts.sameDaySessions ?? [], error: null })
+        };
+        return { select: () => taperChain };
+      }
+      if (table === "session_activity_links") {
+        return {
+          insert: (rows: unknown) => {
+            inserts.push({ table, rows });
+            return Promise.resolve({ error: null });
+          }
+        };
+      }
+      if (table === "athlete_fitness") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                lte: () => ({
+                  order: () => ({
+                    limit: () => ({
+                      maybeSingle: async () => ({ data: null, error: null })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    }
+  };
+  return { supabase, inserts, updates, bundleUpdates };
+}
+
+describe("manualStitchRaceBundle", () => {
+  it("rejects when fewer than three segments are provided", async () => {
+    const { supabase } = makeSupabase({ activities: [] });
+    const result = await manualStitchRaceBundle({
+      supabase,
+      userId: "user-1",
+      segments: [
+        { activityId: "a", role: "swim", index: 0 },
+        { activityId: "b", role: "bike", index: 1 }
+      ]
+    });
+    expect(result).toEqual({ status: "error", reason: "fewer_than_three_segments" });
+  });
+
+  it("rejects when any activity already belongs to a bundle", async () => {
+    const { supabase } = makeSupabase({
+      activities: [
+        { id: "a", sport_type: "swim", start_time_utc: "2026-04-29T08:00:00Z", duration_sec: 1500, distance_m: 1500, race_bundle_id: "existing", user_id: "user-1" },
+        { id: "b", sport_type: "bike", start_time_utc: "2026-04-29T08:30:00Z", duration_sec: 4500, distance_m: 40000, race_bundle_id: null, user_id: "user-1" },
+        { id: "c", sport_type: "run", start_time_utc: "2026-04-29T09:50:00Z", duration_sec: 2400, distance_m: 10000, race_bundle_id: null, user_id: "user-1" }
+      ]
+    });
+    const result = await manualStitchRaceBundle({
+      supabase,
+      userId: "user-1",
+      segments: [
+        { activityId: "a", role: "swim", index: 0 },
+        { activityId: "b", role: "bike", index: 1 },
+        { activityId: "c", role: "run", index: 2 }
+      ]
+    });
+    expect(result).toEqual({ status: "error", reason: "activity_already_in_bundle" });
+  });
+
+  it("creates a manual race bundle and stamps inferred_transitions=true", async () => {
+    const { supabase, inserts } = makeSupabase({
+      activities: [
+        { id: "a", sport_type: "swim", start_time_utc: "2026-04-29T08:00:00Z", duration_sec: 1500, distance_m: 1500, race_bundle_id: null, user_id: "user-1" },
+        { id: "b", sport_type: "bike", start_time_utc: "2026-04-29T08:30:00Z", duration_sec: 4500, distance_m: 40000, race_bundle_id: null, user_id: "user-1" },
+        { id: "c", sport_type: "run", start_time_utc: "2026-04-29T09:50:00Z", duration_sec: 2400, distance_m: 10000, race_bundle_id: null, user_id: "user-1" }
+      ]
+    });
+    const result = await manualStitchRaceBundle({
+      supabase,
+      userId: "user-1",
+      segments: [
+        { activityId: "a", role: "swim", index: 0 },
+        { activityId: "b", role: "bike", index: 1 },
+        { activityId: "c", role: "run", index: 2 }
+      ]
+    });
+    expect(result).toMatchObject({ status: "stitched", bundleId: "bundle-1" });
+
+    const bundleInsert = inserts.find((i) => i.table === "race_bundles");
+    expect(bundleInsert).toBeTruthy();
+    expect(bundleInsert!.rows).toMatchObject({
+      source: "manual",
+      inferred_transitions: true,
+      user_id: "user-1"
+    });
+  });
+});

--- a/lib/race/manual-stitch.ts
+++ b/lib/race/manual-stitch.ts
@@ -1,0 +1,164 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { RaceSegmentRole } from "@/lib/workouts/activity-parser";
+import { isRaceSession } from "@/lib/training/race-session";
+import { triggerRaceReviewBackground } from "@/lib/race-review";
+import { snapshotPreRaceState } from "@/lib/race/snapshot-pre-race-state";
+import { freezeGoalSnapshot, resolveRaceProfileForBundle } from "@/lib/race/bundle-helpers";
+
+export type ManualStitchSegment = {
+  activityId: string;
+  role: RaceSegmentRole;
+  index: number;
+};
+
+export type ManualStitchRaceBundleArgs = {
+  supabase: SupabaseClient;
+  userId: string;
+  segments: ManualStitchSegment[];
+};
+
+export type ManualStitchRaceBundleResult =
+  | { status: "error"; reason: string }
+  | { status: "stitched"; bundleId: string; plannedSessionId: string | null };
+
+/**
+ * Manual Strava-stitch path. Skips the `detectRaceBundle` confidence check
+ * (the athlete has confirmed) but still validates ownership of every activity
+ * and short-circuits if any segment is already part of a bundle. Stamps the
+ * bundle with `source = 'manual'`, `inferred_transitions = true`, and runs the
+ * same goal-freeze + pre-race snapshot pipeline as the auto path.
+ */
+export async function manualStitchRaceBundle(
+  args: ManualStitchRaceBundleArgs
+): Promise<ManualStitchRaceBundleResult> {
+  const { supabase, userId, segments } = args;
+
+  if (segments.length < 3) {
+    return { status: "error", reason: "fewer_than_three_segments" };
+  }
+
+  const activityIds = segments.map((s) => s.activityId);
+
+  const { data: activityRows, error: activityError } = await supabase
+    .from("completed_activities")
+    .select("id,sport_type,start_time_utc,duration_sec,distance_m,race_bundle_id,user_id")
+    .in("id", activityIds)
+    .eq("user_id", userId);
+
+  if (activityError) {
+    return { status: "error", reason: `activities_query_failed:${activityError.message}` };
+  }
+  if (!activityRows || activityRows.length !== segments.length) {
+    return { status: "error", reason: "activity_ownership_mismatch" };
+  }
+  if (activityRows.some((row: any) => row.race_bundle_id)) {
+    return { status: "error", reason: "activity_already_in_bundle" };
+  }
+
+  const ordered = segments
+    .slice()
+    .sort((a, b) => a.index - b.index)
+    .map((segment) => {
+      const row = activityRows.find((r: any) => r.id === segment.activityId);
+      if (!row) throw new Error("activity_lookup_failed");
+      return {
+        ...segment,
+        startUtc: row.start_time_utc as string,
+        durationSec: Number(row.duration_sec ?? 0),
+        distanceM: row.distance_m != null ? Number(row.distance_m) : 0
+      };
+    });
+
+  const startedAt = ordered[0].startUtc;
+  const last = ordered[ordered.length - 1];
+  const endedAt = new Date(new Date(last.startUtc).getTime() + last.durationSec * 1000).toISOString();
+  const totalDurationSec = ordered.reduce((sum, s) => sum + s.durationSec, 0);
+  const totalDistanceM = ordered.reduce((sum, s) => sum + s.distanceM, 0);
+  const startDate = startedAt.slice(0, 10);
+
+  const profile = await resolveRaceProfileForBundle(supabase, userId, startDate);
+  const goalSnapshot = profile ? freezeGoalSnapshot(profile) : null;
+
+  const insertPayload: Record<string, unknown> = {
+    user_id: userId,
+    started_at: startedAt,
+    ended_at: endedAt,
+    total_duration_sec: Math.round(totalDurationSec),
+    total_distance_m: totalDistanceM || null,
+    source: "manual",
+    inferred_transitions: true
+  };
+  if (goalSnapshot) {
+    insertPayload.race_profile_id = goalSnapshot.race_profile_id;
+    insertPayload.goal_time_sec = goalSnapshot.goal_time_sec;
+    insertPayload.goal_strategy_summary = goalSnapshot.goal_strategy_summary;
+    insertPayload.course_profile_snapshot = goalSnapshot.course_profile_snapshot;
+  }
+
+  const { data: createdBundle, error: bundleError } = await supabase
+    .from("race_bundles")
+    .insert(insertPayload)
+    .select("id")
+    .single();
+
+  if (bundleError || !createdBundle) {
+    return { status: "error", reason: `bundle_insert_failed:${bundleError?.message}` };
+  }
+  const bundleId = createdBundle.id as string;
+
+  for (const segment of ordered) {
+    const { error: updateError } = await supabase
+      .from("completed_activities")
+      .update({
+        race_bundle_id: bundleId,
+        race_segment_role: segment.role,
+        race_segment_index: segment.index
+      })
+      .eq("user_id", userId)
+      .eq("id", segment.activityId);
+
+    if (updateError) {
+      console.error("[manual-stitch] segment update failed", { id: segment.activityId, err: updateError.message });
+    }
+  }
+
+  // Best-effort link to a planned race session on the same date.
+  const { data: sameDaySessions } = await supabase
+    .from("sessions")
+    .select("id,sport,type,session_name")
+    .eq("user_id", userId)
+    .eq("date", startDate);
+
+  const raceSessions = (sameDaySessions ?? []).filter((s: any) =>
+    isRaceSession({ type: s.type, session_name: s.session_name })
+  );
+
+  let plannedSessionId: string | null = null;
+  if (raceSessions.length === 1) {
+    plannedSessionId = raceSessions[0].id as string;
+
+    const linkRows = ordered.map((segment) => ({
+      user_id: userId,
+      planned_session_id: plannedSessionId,
+      completed_activity_id: segment.activityId,
+      link_type: "auto" as const,
+      confidence: 1,
+      confirmation_status: "confirmed" as const,
+      match_method: "race_bundle" as const,
+      match_reason: { kind: "race_bundle", role: segment.role, segmentIndex: segment.index, source: "manual" }
+    }));
+
+    const { error: linkError } = await supabase.from("session_activity_links").insert(linkRows);
+    if (linkError) {
+      console.error("[manual-stitch] link insert failed", linkError.message);
+    }
+  }
+
+  await snapshotPreRaceState({ supabase, userId, bundleId, raceDate: startDate });
+
+  if (plannedSessionId) {
+    triggerRaceReviewBackground({ supabase, userId, bundleId });
+  }
+
+  return { status: "stitched", bundleId, plannedSessionId };
+}

--- a/lib/race/snapshot-pre-race-state.test.ts
+++ b/lib/race/snapshot-pre-race-state.test.ts
@@ -1,0 +1,140 @@
+import { snapshotPreRaceState } from "./snapshot-pre-race-state";
+
+type FitnessRow = { date: string; ctl: number; atl: number; tsb: number; ramp_rate: number | null };
+
+function makeSupabase(opts: {
+  bundle: { pre_race_snapshot_status: string } | null;
+  fitness: FitnessRow | null;
+  taperRows?: Array<{ execution_result?: unknown }>;
+}) {
+  const updates: Record<string, unknown>[] = [];
+
+  const supabase: any = {
+    from: (table: string) => {
+      if (table === "race_bundles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({ data: opts.bundle, error: null })
+              })
+            })
+          }),
+          update: (patch: Record<string, unknown>) => {
+            updates.push(patch);
+            return {
+              eq: () => ({
+                eq: async () => ({ error: null })
+              })
+            };
+          }
+        };
+      }
+      if (table === "athlete_fitness") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                lte: () => ({
+                  order: () => ({
+                    limit: () => ({
+                      maybeSingle: async () => ({ data: opts.fitness ?? null, error: null })
+                    })
+                  })
+                })
+              })
+            })
+          })
+        };
+      }
+      if (table === "sessions") {
+        const chain: any = {
+          eq: () => chain,
+          gte: () => chain,
+          lt: () => chain,
+          then: (resolve: any) => resolve({ data: opts.taperRows ?? [], error: null })
+        };
+        return { select: () => chain };
+      }
+      throw new Error(`Unexpected table: ${table}`);
+    }
+  };
+  return { supabase, updates };
+}
+
+describe("snapshotPreRaceState", () => {
+  it("is a no-op when status is already captured", async () => {
+    const { supabase, updates } = makeSupabase({
+      bundle: { pre_race_snapshot_status: "captured" },
+      fitness: null
+    });
+    const result = await snapshotPreRaceState({
+      supabase,
+      userId: "user-1",
+      bundleId: "b1",
+      raceDate: "2026-04-29"
+    });
+    expect(result).toEqual({ status: "noop", reason: "already_captured" });
+    expect(updates).toHaveLength(0);
+  });
+
+  it("marks unavailable when there is no fitness row on or before the race date", async () => {
+    const { supabase, updates } = makeSupabase({
+      bundle: { pre_race_snapshot_status: "pending" },
+      fitness: null
+    });
+    const result = await snapshotPreRaceState({
+      supabase,
+      userId: "user-1",
+      bundleId: "b1",
+      raceDate: "2026-04-29"
+    });
+    expect(result).toEqual({ status: "unavailable", bundleId: "b1" });
+    expect(updates[0]).toMatchObject({ pre_race_snapshot_status: "unavailable" });
+  });
+
+  it("captures fitness + taper compliance when both available", async () => {
+    const { supabase, updates } = makeSupabase({
+      bundle: { pre_race_snapshot_status: "pending" },
+      fitness: { date: "2026-04-28", ctl: 78.4, atl: 62.1, tsb: 16.3, ramp_rate: 1.4 },
+      taperRows: [
+        { execution_result: { intentMatch: "on_target" } },
+        { execution_result: { intentMatch: "on_target" } },
+        { execution_result: { intentMatch: "partial" } }
+      ]
+    });
+    const result = await snapshotPreRaceState({
+      supabase,
+      userId: "user-1",
+      bundleId: "b1",
+      raceDate: "2026-04-29"
+    });
+    expect(result).toEqual({ status: "captured", bundleId: "b1" });
+    expect(updates[0]).toMatchObject({
+      pre_race_ctl: 78.4,
+      pre_race_atl: 62.1,
+      pre_race_tsb: 16.3,
+      pre_race_tsb_state: "fresh",
+      pre_race_ramp_rate: 1.4,
+      pre_race_snapshot_status: "captured"
+    });
+    expect(typeof updates[0].taper_compliance_score).toBe("number");
+  });
+
+  it("transitions to partial when fitness exists but taper has no scoreable sessions", async () => {
+    const { supabase, updates } = makeSupabase({
+      bundle: { pre_race_snapshot_status: "pending" },
+      fitness: { date: "2026-04-28", ctl: 50, atl: 50, tsb: 0, ramp_rate: null },
+      taperRows: []
+    });
+    const result = await snapshotPreRaceState({
+      supabase,
+      userId: "user-1",
+      bundleId: "b1",
+      raceDate: "2026-04-29"
+    });
+    expect(result).toEqual({ status: "partial", bundleId: "b1" });
+    expect(updates[0]).toMatchObject({ pre_race_snapshot_status: "partial" });
+    expect(updates[0].taper_compliance_score).toBeNull();
+  });
+});

--- a/lib/race/snapshot-pre-race-state.ts
+++ b/lib/race/snapshot-pre-race-state.ts
@@ -1,0 +1,96 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+import { getReadinessState } from "@/lib/training/fitness-model";
+import { getFitnessOnDate } from "@/lib/training/fitness-on-date";
+import { computeTaperCompliance } from "@/lib/race/taper-compliance";
+
+export type SnapshotPreRaceStateArgs = {
+  supabase: SupabaseClient;
+  userId: string;
+  bundleId: string;
+  /** Local race date (YYYY-MM-DD). Pre-race snapshot is read AS OF this date. */
+  raceDate: string;
+};
+
+export type SnapshotPreRaceStateResult =
+  | { status: "noop"; reason: string }
+  | { status: "captured" | "partial" | "unavailable"; bundleId: string };
+
+/**
+ * Idempotent: returns `{ status: 'noop' }` when the bundle's snapshot status is
+ * already anything other than 'pending'. Reads `athlete_fitness` for the most
+ * recent row at or before `raceDate`, derives readiness state via
+ * `getReadinessState`, computes taper compliance from the prior 14 days, and
+ * writes the snapshot row in a single update.
+ *
+ * Status transitions:
+ *   pending → captured   — fitness row found AND taper compliance non-null
+ *   pending → partial    — fitness row found, taper compliance null
+ *   pending → unavailable — no fitness row on or before raceDate
+ */
+export async function snapshotPreRaceState(
+  args: SnapshotPreRaceStateArgs
+): Promise<SnapshotPreRaceStateResult> {
+  const { supabase, userId, bundleId, raceDate } = args;
+
+  const { data: bundleRow, error: bundleError } = await supabase
+    .from("race_bundles")
+    .select("id, pre_race_snapshot_status")
+    .eq("id", bundleId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (bundleError || !bundleRow) {
+    return { status: "noop", reason: `bundle_not_found:${bundleError?.message ?? ""}` };
+  }
+  if (bundleRow.pre_race_snapshot_status && bundleRow.pre_race_snapshot_status !== "pending") {
+    return { status: "noop", reason: `already_${bundleRow.pre_race_snapshot_status}` };
+  }
+
+  const fitness = await getFitnessOnDate(supabase, userId, raceDate, "total");
+
+  if (!fitness) {
+    const { error: updateError } = await supabase
+      .from("race_bundles")
+      .update({
+        pre_race_snapshot_status: "unavailable",
+        pre_race_snapshot_at: new Date().toISOString()
+      })
+      .eq("id", bundleId)
+      .eq("user_id", userId);
+
+    if (updateError) {
+      return { status: "noop", reason: `update_failed:${updateError.message}` };
+    }
+    return { status: "unavailable", bundleId };
+  }
+
+  const taper = await computeTaperCompliance(supabase, userId, raceDate);
+  const tsbState = getReadinessState(fitness.tsb);
+  const finalStatus: "captured" | "partial" = taper.score === null ? "partial" : "captured";
+
+  const { error: updateError } = await supabase
+    .from("race_bundles")
+    .update({
+      pre_race_ctl: round2(fitness.ctl),
+      pre_race_atl: round2(fitness.atl),
+      pre_race_tsb: round2(fitness.tsb),
+      pre_race_tsb_state: tsbState,
+      pre_race_ramp_rate: fitness.rampRate != null ? round2(fitness.rampRate) : null,
+      pre_race_snapshot_at: new Date().toISOString(),
+      pre_race_snapshot_status: finalStatus,
+      taper_compliance_score: taper.score,
+      taper_compliance_summary: taper.summary
+    })
+    .eq("id", bundleId)
+    .eq("user_id", userId);
+
+  if (updateError) {
+    return { status: "noop", reason: `update_failed:${updateError.message}` };
+  }
+
+  return { status: finalStatus, bundleId };
+}
+
+function round2(value: number): number {
+  return Math.round(value * 100) / 100;
+}

--- a/lib/race/subjective-input.test.ts
+++ b/lib/race/subjective-input.test.ts
@@ -1,0 +1,119 @@
+import {
+  persistSubjectiveInput,
+  subjectiveInputSchema
+} from "./subjective-input";
+
+describe("subjectiveInputSchema", () => {
+  it("accepts a complete payload", () => {
+    const result = subjectiveInputSchema.safeParse({
+      athleteRating: 4,
+      athleteNotes: "Felt strong off the bike.",
+      issuesFlagged: ["nutrition", "pacing"],
+      finishPosition: 18,
+      ageGroupPosition: 4
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it("rejects ratings outside 1-5", () => {
+    expect(subjectiveInputSchema.safeParse({ athleteRating: 0 }).success).toBe(false);
+    expect(subjectiveInputSchema.safeParse({ athleteRating: 6 }).success).toBe(false);
+  });
+
+  it("rejects unknown issue tags", () => {
+    const result = subjectiveInputSchema.safeParse({
+      athleteRating: 3,
+      issuesFlagged: ["nutrition", "rocketship"]
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("caps notes at 4000 chars", () => {
+    const longNotes = "x".repeat(4001);
+    const result = subjectiveInputSchema.safeParse({
+      athleteRating: 3,
+      athleteNotes: longNotes
+    });
+    expect(result.success).toBe(false);
+  });
+});
+
+describe("persistSubjectiveInput", () => {
+  function buildSupabase(opts: { existing: Record<string, unknown> | null }) {
+    const updates: Record<string, unknown>[] = [];
+    const supabase: any = {
+      from: (_table: string) => ({
+        select: () => ({
+          eq: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({ data: opts.existing, error: null })
+            })
+          })
+        }),
+        update: (patch: Record<string, unknown>) => {
+          updates.push(patch);
+          return {
+            eq: () => ({
+              eq: async () => ({ error: null })
+            })
+          };
+        }
+      })
+    };
+    return { supabase, updates };
+  }
+
+  it("flips status from imported to reviewed on first save", async () => {
+    const { supabase, updates } = buildSupabase({
+      existing: { id: "b1", status: "imported" }
+    });
+    const result = await persistSubjectiveInput({
+      supabase,
+      userId: "user-1",
+      bundleId: "b1",
+      input: {
+        athleteRating: 4,
+        athleteNotes: "Solid race.",
+        issuesFlagged: ["nutrition", "nutrition"],
+        finishPosition: 18,
+        ageGroupPosition: 4
+      }
+    });
+    expect(result).toEqual({ status: "ok", bundleId: "b1" });
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      athlete_rating: 4,
+      athlete_notes: "Solid race.",
+      finish_position: 18,
+      age_group_position: 4,
+      status: "reviewed"
+    });
+    // Issues are deduped.
+    expect(updates[0].issues_flagged).toEqual(["nutrition"]);
+    expect(updates[0].subjective_captured_at).toBeTruthy();
+  });
+
+  it("does not flip status on subsequent edits", async () => {
+    const { supabase, updates } = buildSupabase({
+      existing: { id: "b1", status: "reviewed" }
+    });
+    await persistSubjectiveInput({
+      supabase,
+      userId: "user-1",
+      bundleId: "b1",
+      input: { athleteRating: 5, issuesFlagged: [] }
+    });
+    expect(updates[0]).not.toHaveProperty("status");
+  });
+
+  it("returns bundle_not_found when bundle is missing", async () => {
+    const { supabase } = buildSupabase({ existing: null });
+    const result = await persistSubjectiveInput({
+      supabase,
+      userId: "user-1",
+      bundleId: "missing",
+      input: { athleteRating: 3, issuesFlagged: [] }
+    });
+    expect(result).toEqual({ status: "error", reason: "bundle_not_found" });
+  });
+});

--- a/lib/race/subjective-input.ts
+++ b/lib/race/subjective-input.ts
@@ -1,0 +1,84 @@
+import { z } from "zod";
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export const SUBJECTIVE_ISSUE_TAGS = [
+  "nutrition",
+  "mechanical",
+  "illness",
+  "navigation",
+  "pacing",
+  "mental",
+  "weather"
+] as const;
+
+export type SubjectiveIssueTag = (typeof SUBJECTIVE_ISSUE_TAGS)[number];
+
+export const subjectiveInputSchema = z.object({
+  athleteRating: z.number().int().min(1).max(5),
+  athleteNotes: z.string().max(4000).nullable().optional(),
+  issuesFlagged: z.array(z.enum(SUBJECTIVE_ISSUE_TAGS)).max(SUBJECTIVE_ISSUE_TAGS.length).default([]),
+  finishPosition: z.number().int().positive().nullable().optional(),
+  ageGroupPosition: z.number().int().positive().nullable().optional()
+});
+
+export type SubjectiveInput = z.infer<typeof subjectiveInputSchema>;
+
+export type PersistSubjectiveInputArgs = {
+  supabase: SupabaseClient;
+  userId: string;
+  bundleId: string;
+  input: SubjectiveInput;
+};
+
+export type PersistSubjectiveInputResult =
+  | { status: "ok"; bundleId: string }
+  | { status: "error"; reason: string };
+
+/**
+ * Persist subjective inputs against a race bundle. Sets
+ * `subjective_captured_at = now()` and flips `status` from 'imported' to
+ * 'reviewed' the first time inputs are captured. Re-saves are idempotent.
+ */
+export async function persistSubjectiveInput(
+  args: PersistSubjectiveInputArgs
+): Promise<PersistSubjectiveInputResult> {
+  const { supabase, userId, bundleId, input } = args;
+
+  const { data: existing, error: existingError } = await supabase
+    .from("race_bundles")
+    .select("id, status")
+    .eq("id", bundleId)
+    .eq("user_id", userId)
+    .maybeSingle();
+
+  if (existingError || !existing) {
+    return { status: "error", reason: "bundle_not_found" };
+  }
+
+  const dedupedIssues = Array.from(new Set(input.issuesFlagged));
+
+  const update: Record<string, unknown> = {
+    athlete_rating: input.athleteRating,
+    athlete_notes: input.athleteNotes ?? null,
+    issues_flagged: dedupedIssues,
+    finish_position: input.finishPosition ?? null,
+    age_group_position: input.ageGroupPosition ?? null,
+    subjective_captured_at: new Date().toISOString()
+  };
+
+  if (existing.status === "imported") {
+    update.status = "reviewed";
+  }
+
+  const { error: updateError } = await supabase
+    .from("race_bundles")
+    .update(update)
+    .eq("id", bundleId)
+    .eq("user_id", userId);
+
+  if (updateError) {
+    return { status: "error", reason: `update_failed:${updateError.message}` };
+  }
+
+  return { status: "ok", bundleId };
+}

--- a/lib/race/taper-compliance.test.ts
+++ b/lib/race/taper-compliance.test.ts
@@ -1,0 +1,49 @@
+import { computeTaperCompliance } from "./taper-compliance";
+
+function makeSupabase(rows: Array<{ execution_result?: unknown }>) {
+  const chain: any = {
+    eq: () => chain,
+    gte: () => chain,
+    lt: () => chain,
+    then: (resolve: (value: { data: unknown; error: null }) => void) => {
+      resolve({ data: rows, error: null });
+    }
+  };
+  return {
+    from: () => ({ select: () => chain })
+  } as any;
+}
+
+describe("computeTaperCompliance", () => {
+  it("returns null when no sessions have execution_result", async () => {
+    const supabase = makeSupabase([
+      { execution_result: null },
+      { execution_result: null }
+    ]);
+    const result = await computeTaperCompliance(supabase, "user-1", "2026-04-29");
+    expect(result).toEqual({ score: null, summary: null });
+  });
+
+  it("scores on_target=1, partial=0.5, missed=0", async () => {
+    const supabase = makeSupabase([
+      { execution_result: { intentMatch: "on_target" } },
+      { execution_result: { intentMatch: "on_target" } },
+      { execution_result: { intentMatch: "partial" } },
+      { execution_result: { intentMatch: "missed" } }
+    ]);
+    const result = await computeTaperCompliance(supabase, "user-1", "2026-04-29");
+    expect(result.score).toBeCloseTo((2 + 0.5) / 4);
+    expect(result.summary).toBe("2 of 4 taper sessions on target");
+  });
+
+  it("excludes sessions without execution_result from numerator and denominator", async () => {
+    const supabase = makeSupabase([
+      { execution_result: { intentMatch: "on_target" } },
+      { execution_result: null },
+      { execution_result: { intentMatch: "missed" } }
+    ]);
+    const result = await computeTaperCompliance(supabase, "user-1", "2026-04-29");
+    expect(result.score).toBeCloseTo(1 / 2);
+    expect(result.summary).toBe("1 of 2 taper sessions on target");
+  });
+});

--- a/lib/race/taper-compliance.ts
+++ b/lib/race/taper-compliance.ts
@@ -1,0 +1,72 @@
+import type { SupabaseClient } from "@supabase/supabase-js";
+
+export type TaperComplianceResult = {
+  score: number | null;
+  summary: string | null;
+};
+
+/**
+ * Score how cleanly the athlete executed the 14 days of training that preceded
+ * the race. Reads `sessions.execution_result` (set by the regular execution
+ * review pipeline) and weights `on_target` = 1, `partial` = 0.5, `missed` = 0.
+ *
+ * Sessions without an `execution_result` (rest days, planned-but-uncompleted,
+ * sessions still pending review) are excluded from both numerator and
+ * denominator so a heavy taper week with rest days is not artificially
+ * penalised. Returns `{ null, null }` when the window has zero scored sessions.
+ */
+export async function computeTaperCompliance(
+  supabase: SupabaseClient,
+  userId: string,
+  raceDate: string
+): Promise<TaperComplianceResult> {
+  const windowStart = isoDateOffset(raceDate, -14);
+
+  const { data: rows, error } = await supabase
+    .from("sessions")
+    .select("id, date, type, session_name, execution_result")
+    .eq("user_id", userId)
+    .gte("date", windowStart)
+    .lt("date", raceDate);
+
+  if (error || !rows) {
+    return { score: null, summary: null };
+  }
+
+  let onTarget = 0;
+  let partial = 0;
+  let missed = 0;
+
+  for (const row of rows) {
+    const intentMatch = readIntentMatch(row.execution_result);
+    if (intentMatch === "on_target") onTarget += 1;
+    else if (intentMatch === "partial") partial += 1;
+    else if (intentMatch === "missed") missed += 1;
+  }
+
+  const total = onTarget + partial + missed;
+  if (total === 0) {
+    return { score: null, summary: null };
+  }
+
+  const score = (onTarget + 0.5 * partial) / total;
+  const summary = `${onTarget} of ${total} taper sessions on target`;
+
+  return {
+    score: Math.round(score * 1000) / 1000,
+    summary
+  };
+}
+
+function readIntentMatch(executionResult: unknown): "on_target" | "partial" | "missed" | null {
+  if (!executionResult || typeof executionResult !== "object") return null;
+  const value = (executionResult as Record<string, unknown>).intentMatch;
+  if (value === "on_target" || value === "partial" || value === "missed") return value;
+  return null;
+}
+
+function isoDateOffset(date: string, offsetDays: number): string {
+  const d = new Date(`${date}T00:00:00.000Z`);
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}

--- a/lib/training/fitness-on-date.ts
+++ b/lib/training/fitness-on-date.ts
@@ -1,0 +1,46 @@
+/**
+ * Read-only fitness lookups anchored to a specific historical date.
+ *
+ * Sibling of getLatestFitness in fitness-model.ts, but does NOT forward-project
+ * to today — used for race-day pre-race snapshots, where we need the value as
+ * it stood on the morning of the race, not what it would be today.
+ */
+
+import type { SupabaseClient } from "@supabase/supabase-js";
+import type { FitnessSnapshot, FitnessSport } from "@/lib/training/fitness-model";
+
+export type FitnessOnDateResult = FitnessSnapshot & {
+  /** The actual date the snapshot was sourced from (may be earlier than `asOf`). */
+  sourceDate: string;
+};
+
+/**
+ * Returns the most recent fitness snapshot on or before `asOf` for a sport.
+ * Null when the user has no fitness rows on or before that date.
+ */
+export async function getFitnessOnDate(
+  supabase: SupabaseClient,
+  userId: string,
+  asOf: string,
+  sport: FitnessSport = "total"
+): Promise<FitnessOnDateResult | null> {
+  const { data: row } = await supabase
+    .from("athlete_fitness")
+    .select("date, ctl, atl, tsb, ramp_rate")
+    .eq("user_id", userId)
+    .eq("sport", sport)
+    .lte("date", asOf)
+    .order("date", { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (!row) return null;
+
+  return {
+    ctl: Number(row.ctl) || 0,
+    atl: Number(row.atl) || 0,
+    tsb: Number(row.tsb) || 0,
+    rampRate: row.ramp_rate != null ? Number(row.ramp_rate) : null,
+    sourceDate: row.date as string
+  };
+}

--- a/lib/workouts/race-bundle.test.ts
+++ b/lib/workouts/race-bundle.test.ts
@@ -48,10 +48,14 @@ describe("attemptRaceBundle", () => {
     sameDaySessions: Row[];
     activities: Row[];
     existingLinks?: Row[];
+    raceProfiles?: Row[];
+    fitnessRow?: Row | null;
+    bundleRow?: Row | null;
   }) {
     const behaviors: any = {
       inserts: [],
       updates: [],
+      bundleUpdates: [],
       activities: opts.activities,
       lastTable: ""
     };
@@ -60,12 +64,18 @@ describe("attemptRaceBundle", () => {
     const supabase: any = {};
     supabase.from = (table: string) => {
       if (table === "sessions") {
+        // attemptRaceBundle uses .select().eq().eq() (sessions same-day query).
+        // computeTaperCompliance uses .select().eq().gte().lt() (taper window).
+        // Make every chain step thenable so both shapes resolve to the same data.
+        const resolveSessions = () => Promise.resolve({ data: opts.sameDaySessions, error: null });
+        const taperChain: any = {
+          eq: () => taperChain,
+          gte: () => taperChain,
+          lt: () => taperChain,
+          then: (resolve: any) => resolveSessions().then(resolve)
+        };
         return {
-          select: () => ({
-            eq: () => ({
-              eq: () => Promise.resolve({ data: opts.sameDaySessions, error: null })
-            })
-          })
+          select: () => taperChain
         };
       }
       if (table === "completed_activities") {
@@ -115,7 +125,52 @@ describe("attemptRaceBundle", () => {
                 single: async () => ({ data: { id: "bundle-1" }, error: null })
               })
             };
+          },
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => ({
+                  data: behaviors.bundleRow ?? { id: "bundle-1", pre_race_snapshot_status: "pending", race_profile_id: null, inferred_transitions: false },
+                  error: null
+                })
+              })
+            })
+          }),
+          update: (patch: Row) => {
+            behaviors.bundleUpdates.push(patch);
+            return {
+              eq: () => ({
+                eq: async () => ({ error: null })
+              })
+            };
           }
+        };
+      }
+      if (table === "race_profiles") {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: async () => ({ data: opts.raceProfiles ?? [], error: null })
+            })
+          })
+        };
+      }
+      if (table === "athlete_fitness") {
+        const finalChain = {
+          maybeSingle: async () => ({ data: opts.fitnessRow ?? null, error: null })
+        };
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                lte: () => ({
+                  order: () => ({
+                    limit: () => finalChain
+                  })
+                })
+              })
+            })
+          })
         };
       }
       throw new Error(`Unexpected table: ${table}`);

--- a/lib/workouts/race-bundle.ts
+++ b/lib/workouts/race-bundle.ts
@@ -3,6 +3,8 @@ import { isRaceSession } from "@/lib/training/race-session";
 import { detectRaceBundle, type RaceCandidate } from "@/lib/workouts/race-detection";
 import type { RaceSegmentRole } from "@/lib/workouts/activity-parser";
 import { triggerRaceReviewBackground } from "@/lib/race-review";
+import { freezeGoalSnapshot, resolveRaceProfileForBundle } from "@/lib/race/bundle-helpers";
+import { snapshotPreRaceState } from "@/lib/race/snapshot-pre-race-state";
 
 export type PersistMultisportBundleArgs = {
   supabase: SupabaseClient;
@@ -44,17 +46,30 @@ export async function persistMultisportBundle(
     return { status: "error", reason: "no_segments" };
   }
 
+  const startDate = bundle.startedAt.slice(0, 10);
+  const profile = await resolveRaceProfileForBundle(supabase, userId, startDate);
+  const goalSnapshot = profile ? freezeGoalSnapshot(profile) : null;
+
+  const bundleInsertPayload: Record<string, unknown> = {
+    user_id: userId,
+    started_at: bundle.startedAt,
+    ended_at: bundle.endedAt,
+    total_duration_sec: Math.round(bundle.totalDurationSec),
+    total_distance_m: bundle.totalDistanceM || null,
+    source: "garmin_multisport",
+    upload_id: uploadId,
+    inferred_transitions: false
+  };
+  if (goalSnapshot) {
+    bundleInsertPayload.race_profile_id = goalSnapshot.race_profile_id;
+    bundleInsertPayload.goal_time_sec = goalSnapshot.goal_time_sec;
+    bundleInsertPayload.goal_strategy_summary = goalSnapshot.goal_strategy_summary;
+    bundleInsertPayload.course_profile_snapshot = goalSnapshot.course_profile_snapshot;
+  }
+
   const { data: createdBundle, error: bundleError } = await supabase
     .from("race_bundles")
-    .insert({
-      user_id: userId,
-      started_at: bundle.startedAt,
-      ended_at: bundle.endedAt,
-      total_duration_sec: Math.round(bundle.totalDurationSec),
-      total_distance_m: bundle.totalDistanceM || null,
-      source: "garmin_multisport",
-      upload_id: uploadId
-    })
+    .insert(bundleInsertPayload)
     .select("id")
     .single();
 
@@ -79,7 +94,6 @@ export async function persistMultisportBundle(
   }
 
   // Find a planned race session for the same local date.
-  const startDate = bundle.startedAt.slice(0, 10);
   const { data: sameDaySessions } = await supabase
     .from("sessions")
     .select("id,sport,type,session_name")
@@ -111,6 +125,8 @@ export async function persistMultisportBundle(
     console.error("[race-bundle] link insert failed", linkError.message);
     return { status: "error", reason: `link_insert_failed:${linkError.message}` };
   }
+
+  await snapshotPreRaceState({ supabase, userId, bundleId, raceDate: startDate });
 
   // Only fire the race-review generator when the bundle is attached to a
   // planned race session — ad-hoc bundles without a planned target are out
@@ -268,6 +284,36 @@ export async function attemptRaceBundle(
         return { status: "skipped", reason: `link_insert_failed:${linkError.message}` };
       }
 
+      // Backfill goal snapshot if the existing bundle predates Phase 1A
+      // (or was inserted without a same-day race profile). Only writes
+      // when goal columns are still null to avoid overwriting an immutable
+      // snapshot.
+      const { data: existingBundleRow } = await supabase
+        .from("race_bundles")
+        .select("race_profile_id, inferred_transitions")
+        .eq("id", bundleId)
+        .eq("user_id", userId)
+        .maybeSingle();
+
+      if (existingBundleRow && !existingBundleRow.race_profile_id) {
+        const profile = await resolveRaceProfileForBundle(supabase, userId, date);
+        if (profile) {
+          const snapshot = freezeGoalSnapshot(profile);
+          await supabase
+            .from("race_bundles")
+            .update({
+              race_profile_id: snapshot.race_profile_id,
+              goal_time_sec: snapshot.goal_time_sec,
+              goal_strategy_summary: snapshot.goal_strategy_summary,
+              course_profile_snapshot: snapshot.course_profile_snapshot
+            })
+            .eq("id", bundleId)
+            .eq("user_id", userId);
+        }
+      }
+
+      await snapshotPreRaceState({ supabase, userId, bundleId, raceDate: date });
+
       triggerRaceReviewBackground({ supabase, userId, bundleId });
       return {
         status: "bundled",
@@ -329,17 +375,29 @@ export async function attemptRaceBundle(
   );
   const totalDistanceM = segmentIds.reduce((sum, id) => sum + (distanceById.get(id) ?? 0), 0);
 
+  const profile = await resolveRaceProfileForBundle(supabase, userId, date);
+  const goalSnapshot = profile ? freezeGoalSnapshot(profile) : null;
+
+  const newBundlePayload: Record<string, unknown> = {
+    user_id: userId,
+    started_at: startedAt,
+    ended_at: endedAt,
+    total_duration_sec: Math.round(totalDurationSec),
+    total_distance_m: totalDistanceM || null,
+    source,
+    upload_id: uploadId ?? null,
+    inferred_transitions: source === "strava_reconstructed" || source === "manual"
+  };
+  if (goalSnapshot) {
+    newBundlePayload.race_profile_id = goalSnapshot.race_profile_id;
+    newBundlePayload.goal_time_sec = goalSnapshot.goal_time_sec;
+    newBundlePayload.goal_strategy_summary = goalSnapshot.goal_strategy_summary;
+    newBundlePayload.course_profile_snapshot = goalSnapshot.course_profile_snapshot;
+  }
+
   const { data: createdBundle, error: bundleError } = await supabase
     .from("race_bundles")
-    .insert({
-      user_id: userId,
-      started_at: startedAt,
-      ended_at: endedAt,
-      total_duration_sec: Math.round(totalDurationSec),
-      total_distance_m: totalDistanceM || null,
-      source,
-      upload_id: uploadId ?? null
-    })
+    .insert(newBundlePayload)
     .select("id")
     .single();
 
@@ -391,6 +449,8 @@ export async function attemptRaceBundle(
     console.error("[race-bundle] link insert failed", linkError.message);
     return { status: "skipped", reason: `link_insert_failed:${linkError.message}` };
   }
+
+  await snapshotPreRaceState({ supabase, userId, bundleId, raceDate: date });
 
   triggerRaceReviewBackground({ supabase, userId, bundleId });
   return {

--- a/supabase/migrations/202604300001_phase1a_race_data_foundation.sql
+++ b/supabase/migrations/202604300001_phase1a_race_data_foundation.sql
@@ -1,0 +1,96 @@
+-- Phase 1A: Race review data foundation.
+--
+-- Extends race_profiles with goal_time_sec / goal_strategy_summary so race
+-- bundles can snapshot the goal at ingestion time, and extends race_bundles
+-- with the immutable pre-race fitness snapshot, taper compliance, structured
+-- subjective inputs, lifecycle status, and Strava-stitched provenance.
+--
+-- All new columns are nullable (or have safe defaults) so existing rows remain
+-- valid. New bundles default to pre_race_snapshot_status = 'pending' and
+-- status = 'imported'; the snapshot capture path fills in the rest.
+
+ALTER TABLE public.race_profiles
+  ADD COLUMN IF NOT EXISTS goal_time_sec integer,
+  ADD COLUMN IF NOT EXISTS goal_strategy_summary text;
+
+ALTER TABLE public.race_bundles
+  -- Goal anchor (snapshotted from race_profiles at first ingestion; immutable thereafter)
+  ADD COLUMN IF NOT EXISTS race_profile_id uuid REFERENCES public.race_profiles(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS goal_time_sec integer,
+  ADD COLUMN IF NOT EXISTS goal_strategy_summary text,
+  ADD COLUMN IF NOT EXISTS course_profile_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+  ADD COLUMN IF NOT EXISTS conditions_snapshot jsonb NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Pre-race state snapshot (athlete_fitness on race date, plus taper compliance)
+  ADD COLUMN IF NOT EXISTS pre_race_ctl numeric(6,2),
+  ADD COLUMN IF NOT EXISTS pre_race_atl numeric(6,2),
+  ADD COLUMN IF NOT EXISTS pre_race_tsb numeric(6,2),
+  ADD COLUMN IF NOT EXISTS pre_race_tsb_state text,
+  ADD COLUMN IF NOT EXISTS pre_race_ramp_rate numeric(6,2),
+  ADD COLUMN IF NOT EXISTS pre_race_snapshot_at timestamptz,
+  ADD COLUMN IF NOT EXISTS pre_race_snapshot_status text NOT NULL DEFAULT 'pending',
+  ADD COLUMN IF NOT EXISTS taper_compliance_score numeric(4,3),
+  ADD COLUMN IF NOT EXISTS taper_compliance_summary text,
+
+  -- Subjective inputs (post-import guided form)
+  ADD COLUMN IF NOT EXISTS athlete_rating smallint,
+  ADD COLUMN IF NOT EXISTS athlete_notes text,
+  ADD COLUMN IF NOT EXISTS issues_flagged text[] NOT NULL DEFAULT '{}'::text[],
+  ADD COLUMN IF NOT EXISTS finish_position integer,
+  ADD COLUMN IF NOT EXISTS age_group_position integer,
+  ADD COLUMN IF NOT EXISTS subjective_captured_at timestamptz,
+
+  -- Lifecycle + Strava-stitched provenance
+  ADD COLUMN IF NOT EXISTS status text NOT NULL DEFAULT 'imported',
+  ADD COLUMN IF NOT EXISTS inferred_transitions boolean NOT NULL DEFAULT false;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'race_bundles_pre_race_tsb_state_valid'
+  ) THEN
+    ALTER TABLE public.race_bundles
+      ADD CONSTRAINT race_bundles_pre_race_tsb_state_valid
+      CHECK (pre_race_tsb_state IS NULL OR pre_race_tsb_state IN ('fresh','absorbing','fatigued','overreaching'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'race_bundles_pre_race_snapshot_status_valid'
+  ) THEN
+    ALTER TABLE public.race_bundles
+      ADD CONSTRAINT race_bundles_pre_race_snapshot_status_valid
+      CHECK (pre_race_snapshot_status IN ('pending','captured','partial','unavailable'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'race_bundles_athlete_rating_range'
+  ) THEN
+    ALTER TABLE public.race_bundles
+      ADD CONSTRAINT race_bundles_athlete_rating_range
+      CHECK (athlete_rating IS NULL OR (athlete_rating BETWEEN 1 AND 5));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'race_bundles_status_valid'
+  ) THEN
+    ALTER TABLE public.race_bundles
+      ADD CONSTRAINT race_bundles_status_valid
+      CHECK (status IN ('imported','reviewed','archived'));
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint WHERE conname = 'race_bundles_issues_flagged_valid'
+  ) THEN
+    ALTER TABLE public.race_bundles
+      ADD CONSTRAINT race_bundles_issues_flagged_valid
+      CHECK (issues_flagged <@ ARRAY['nutrition','mechanical','illness','navigation','pacing','mental','weather']::text[]);
+  END IF;
+END
+$$;
+
+CREATE INDEX IF NOT EXISTS race_bundles_user_status_idx
+  ON public.race_bundles (user_id, status);
+
+CREATE INDEX IF NOT EXISTS race_bundles_race_profile_idx
+  ON public.race_bundles (race_profile_id)
+  WHERE race_profile_id IS NOT NULL;


### PR DESCRIPTION
## Summary
- Adds `/races/[bundleId]` + `/notes` (AI-free race summary with header/goal-delta, pre-race CTL/ATL/TSB/taper strip, discipline split, segment cards, subjective inputs, AI placeholder slot).
- Extends `race_bundles` (goal anchor, immutable pre-race snapshot, structured subjective inputs, lifecycle status, `inferred_transitions`) and `race_profiles` (`goal_time_sec`, `goal_strategy_summary`).
- New `/lib/race/*` helpers (snapshot, taper compliance, bundle helpers, subjective-input Zod, manual stitch) wired idempotently into `persistMultisportBundle` + `attemptRaceBundle` (incl. self-heal).
- New API routes: `GET /api/races/:id`, `POST :id/subjective`, `POST manual-stitch`, dev-only `:id/regenerate-snapshot`. Manual-stitch CTA in activity sidebar.

## Why
Phase 1A is the schema + ingestion foundation every later AI layer (1B verdict, 1C drill-downs, 1D lessons, 2 interrogation, 3 comparison) will read from. Ships a usable race surface with zero AI to validate ingestion against real races before any prompt is in play. Closes #307.

## Test plan
- [ ] `npm run typecheck` clean
- [ ] `npm run lint` clean
- [ ] `npm run test` passes for `lib/race/*`, `lib/workouts/race-bundle.test.ts` (3 pre-existing `ambient-signals` failures unrelated)
- [ ] Visit `/races/{PREVIEW_RACE_BUNDLE_ID}` in Agent Preview Mode — header, pre-race strip, discipline split, segments, subjective summary, AI embed all render
- [ ] Visit `/races/{id}/notes`, edit + save → redirected back, status flips `imported → reviewed`
- [ ] Re-running ingestion is idempotent (no duplicate bundles, snapshot status sticks)
- [ ] Apply migration `202604300001_phase1a_race_data_foundation.sql` against staging Supabase

🤖 Generated with [Claude Code](https://claude.com/claude-code)