### PR TITLE
fix(strava): derive avgPaceSecPerKm on run laps

### DIFF
--- a/lib/integrations/providers/strava/normalizer.test.ts
+++ b/lib/integrations/providers/strava/normalizer.test.ts
@@ -367,6 +367,23 @@ describe("normalizeStravaActivity", () => {
       expect(laps[0]).not.toHaveProperty("avgPacePer100mSec");
     });
 
+    it("run laps derive avgPaceSecPerKm from elapsed_time / distance", () => {
+      const runWithLaps: StravaActivitySummary = {
+        ...baseActivity,
+        sport_type: "Run",
+        laps: [
+          { lap_index: 0, elapsed_time: 270, moving_time: 268, distance: 1000, average_cadence: 86 },
+          { lap_index: 1, elapsed_time: 285, moving_time: 282, distance: 1000, average_cadence: 84 },
+          { lap_index: 2, elapsed_time: 0, moving_time: 0, distance: 0 } // skipped: zero values
+        ]
+      };
+      const result = normalizeStravaActivity(runWithLaps, "user-abc");
+      const laps = result.metrics_v2.laps as Record<string, unknown>[];
+      expect(laps[0].avgPaceSecPerKm).toBe(270);
+      expect(laps[1].avgPaceSecPerKm).toBe(285);
+      expect(laps[2]).not.toHaveProperty("avgPaceSecPerKm");
+    });
+
     it("swim activity puts cadence into stroke section", () => {
       const swim: StravaActivitySummary = {
         ...baseActivity,

--- a/lib/integrations/providers/strava/normalizer.ts
+++ b/lib/integrations/providers/strava/normalizer.ts
@@ -204,6 +204,14 @@ function buildLapSummaries(laps: StravaLap[] | undefined, sport: string): Record
       }
     } else {
       base.avgCadence = roundOrNull(lap.average_cadence);
+      // Per-lap pace for run (sec/km) so halves-from-laps and lap-level
+      // pacing analyses can compute. Strava stops short of providing a
+      // pace field — derive it from elapsed_time / distance when both are
+      // present and non-zero. Bike doesn't get a pace field; bike halves
+      // come from avgPower (already on `base` above).
+      if (sport === "run" && lap.distance > 0 && lap.elapsed_time > 0) {
+        base.avgPaceSecPerKm = Math.round(lap.elapsed_time / (lap.distance / 1000));
+      }
     }
 
     return base;


### PR DESCRIPTION
## Summary

Strava lap summaries left run laps without a pace field — only swims got per-lap `avgPacePer100mSec`; runs got only `avgCadence`. Downstream consumers — race-review halves classifier, Phase 1B leg-status verdict, session execution comparisons — rely on per-lap pace and silently returned null for any run leg sourced from Strava.

Surfaced while debugging why a Strava-reconstructed race bundle showed "No data" on its run leg's verdict tile despite having 10 laps. Confirmed via:

```sql
select race_segment_role, jsonb_array_length(metrics_v2 -> 'laps') as lap_count,
       jsonb_path_query_array(metrics_v2 -> 'laps',
         '$[*] ? (@.avgPacePer100mSec != null || @.avgPaceSecPerKm != null || @.avgPower != null)') ->> 0 is not null
  from completed_activities ...;
```

Result: `run` had 10 laps, `false` for any-pace-or-power.

## Fix

In `lib/integrations/providers/strava/normalizer.ts:buildLapSummaries`, mirror the swim path for runs: when `lap.distance > 0 && lap.elapsed_time > 0`, set `avgPaceSecPerKm = elapsed_time / (distance / 1000)`. Bike retains the existing `avgPower`-only path; bike halves don't need pace.

## Affected

- All Strava-imported run activities since the normalizer was introduced.
- Existing rows: pace fields will populate on the next refresh / reimport. Won't auto-backfill — if we want to retro-fix the historical rows we can run the strava metrics backfill, but that's a separate operation.

## Test plan

- [x] New test: `run laps derive avgPaceSecPerKm from elapsed_time / distance` covering positive case + zero-value skip.
- [x] All 51 existing normalizer tests still pass.
- [x] `npm run lint`, `npm run typecheck` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)