### PR TITLE
feat(race-review): whole-leg fallback for leg-status when halves unavailable

### DIFF
--- a/lib/race-review.ts
+++ b/lib/race-review.ts
@@ -550,12 +550,42 @@ export function buildRaceFacts(args: {
   // Goal delta (positive = slower than goal).
   const goalDeltaSec = bundle.goalTimeSec ? totalDurationSec - bundle.goalTimeSec : null;
 
-  // Per-leg status (deterministic).
+  // Per-leg status (deterministic). Leg-average outputs feed the whole-leg
+  // fallback in classifyLegStatus when halves data isn't available (e.g.
+  // a Strava swim that imports as a single lap).
   const targets = inferTargetOutputs({ bundle, segments, raceProfile });
+  const swimSeg = segments.find((s) => s.role === "swim");
+  const bikeSeg = segments.find((s) => s.role === "bike");
+  const runSeg = segments.find((s) => s.role === "run");
+  const swimAvg = swimSeg && swimSeg.distanceM && swimSeg.distanceM > 0 && swimSeg.durationSec > 0
+    ? swimSeg.durationSec / (swimSeg.distanceM / 100)
+    : null;
+  const runAvg = runSeg && runSeg.distanceM && runSeg.distanceM > 0 && runSeg.durationSec > 0
+    ? runSeg.durationSec / (runSeg.distanceM / 1000)
+    : null;
+  const bikeAvgWatts = bikeSeg && typeof bikeSeg.avgPower === "number" && bikeSeg.avgPower > 0
+    ? bikeSeg.avgPower
+    : null;
   const legStatus: RaceFacts["legStatus"] = {
-    swim: classifyLegStatus({ pacing: pacing.swim, targetOutput: targets.swim }),
-    bike: classifyLegStatus({ pacing: pacing.bike, targetOutput: targets.bike }),
-    run: classifyLegStatus({ pacing: pacing.run, targetOutput: targets.run, hrDriftBpm: hrDrift.run })
+    swim: classifyLegStatus({
+      pacing: pacing.swim,
+      targetOutput: targets.swim,
+      legAverageOutput: swimAvg,
+      legAverageUnit: "sec_per_100m"
+    }),
+    bike: classifyLegStatus({
+      pacing: pacing.bike,
+      targetOutput: targets.bike,
+      legAverageOutput: bikeAvgWatts,
+      legAverageUnit: "watts"
+    }),
+    run: classifyLegStatus({
+      pacing: pacing.run,
+      targetOutput: targets.run,
+      hrDriftBpm: hrDrift.run,
+      legAverageOutput: runAvg,
+      legAverageUnit: "sec_per_km"
+    })
   };
 
   // Cross-discipline gate (deterministic; AI only narrates if detected).

--- a/lib/race-review/leg-status.test.ts
+++ b/lib/race-review/leg-status.test.ts
@@ -68,4 +68,78 @@ describe("classifyLegStatus", () => {
     const result = classifyLegStatus({ pacing, targetOutput: 220 });
     expect(result?.evidence[0]).toMatch(/9\.[0-9]/);
   });
+
+  describe("whole-leg fallback (halves not available)", () => {
+    it("returns null when no leg average is provided", () => {
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 100
+      });
+      expect(result).toBeNull();
+    });
+
+    it("returns null when leg average has no unit", () => {
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 100,
+        legAverageOutput: 102
+      });
+      expect(result).toBeNull();
+    });
+
+    it("labels swim on_plan when avg is within 3% of target", () => {
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 100,
+        legAverageOutput: 101,
+        legAverageUnit: "sec_per_100m"
+      });
+      expect(result?.label).toBe("on_plan");
+      expect(result?.evidence[0]).toMatch(/halves not available/);
+    });
+
+    it("labels swim strong when avg is ≥3% faster than target", () => {
+      // pace lower-is-better — 95 vs 100 → 5% faster
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 100,
+        legAverageOutput: 95,
+        legAverageUnit: "sec_per_100m"
+      });
+      expect(result?.label).toBe("strong");
+    });
+
+    it("labels swim under when avg is ≥5% slower than target", () => {
+      // 110 vs 100 → 10% slower (under target)
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 100,
+        legAverageOutput: 110,
+        legAverageUnit: "sec_per_100m"
+      });
+      expect(result?.label).toBe("under");
+    });
+
+    it("labels bike strong when avg watts ≥3% above target", () => {
+      // watts higher-is-better — 230 vs 220 → strong
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 220,
+        legAverageOutput: 230,
+        legAverageUnit: "watts"
+      });
+      expect(result?.label).toBe("strong");
+    });
+
+    it("never emits over/faded/cooked from the fallback", () => {
+      // Even a wildly slow leg average maps to under, not faded/cooked.
+      const result = classifyLegStatus({
+        pacing: { halvesAvailable: false },
+        targetOutput: 100,
+        legAverageOutput: 130,
+        legAverageUnit: "sec_per_100m"
+      });
+      expect(["on_plan", "strong", "under"]).toContain(result?.label);
+    });
+  });
 });

--- a/lib/race-review/leg-status.ts
+++ b/lib/race-review/leg-status.ts
@@ -14,8 +14,16 @@
  * - faded     — second half drops ≥4% (power/pace) vs first half
  * - cooked    — fade ≥8% OR second-half HR drift while output drops
  *
- * `null` is used when we don't have enough data for the leg (no halves,
- * no target). The AI is told to omit per-discipline verdict for that leg.
+ * `null` is used when we don't have enough data for the leg (no halves AND
+ * no leg-average + target). The AI is told to omit per-discipline verdict
+ * for that leg.
+ *
+ * **Whole-leg fallback.** When halves data isn't available (e.g. a swim leg
+ * imported from Strava with a single lap), but we have the leg-average
+ * output AND a target, we still emit `on_plan` / `strong` / `under` from
+ * the average alone. We CANNOT emit `over` / `faded` / `cooked` without
+ * halves — those depend on intra-leg shape — so the fallback is
+ * intentionally limited to the three target-anchored labels.
  */
 
 import type { LegPacing } from "@/lib/race-review";
@@ -42,6 +50,17 @@ export type LegStatusInput = {
    * Positive = HR rose vs first half. Null when not computable.
    */
   hrDriftBpm?: number | null;
+  /**
+   * Whole-leg average output in the same unit as `targetOutput`. Used by
+   * the fallback path when halves aren't available. Null when the segment
+   * doesn't carry enough fields (e.g. distance unknown).
+   */
+  legAverageOutput?: number | null;
+  /**
+   * Unit for `legAverageOutput`. Required when `legAverageOutput` is
+   * provided so the higher-is-better direction is unambiguous.
+   */
+  legAverageUnit?: "watts" | "sec_per_km" | "sec_per_100m";
 };
 
 export type LegStatusResult = {
@@ -58,13 +77,25 @@ export type LegStatusResult = {
  * target and no fade signal).
  */
 export function classifyLegStatus(input: LegStatusInput): LegStatusResult | null {
-  const { pacing, targetOutput, hrDriftBpm } = input;
+  const { pacing, targetOutput, hrDriftBpm, legAverageOutput, legAverageUnit } = input;
 
-  // Without halves data we can't infer fade; fall back to target-only.
+  // Whole-leg fallback when halves data isn't available.
   if (!pacing || !pacing.halvesAvailable) {
-    if (targetOutput === null || targetOutput === undefined) return null;
-    // Without halves we don't have an actual either, so abort.
-    return null;
+    if (
+      targetOutput === null ||
+      targetOutput === undefined ||
+      targetOutput <= 0 ||
+      legAverageOutput === null ||
+      legAverageOutput === undefined ||
+      !legAverageUnit
+    ) {
+      return null;
+    }
+    return classifyFromLegAverage({
+      avg: legAverageOutput,
+      target: targetOutput,
+      unit: legAverageUnit
+    });
   }
 
   const { firstHalf, lastHalf, deltaPct, unit } = pacing;
@@ -135,6 +166,39 @@ export function classifyLegStatus(input: LegStatusInput): LegStatusResult | null
     ev.push(`Halves moved ${signed(deltaPct)}% across the leg.`);
   }
   return { label: "on_plan", evidence: ev };
+}
+
+/**
+ * Target-only fallback. Emits `strong` / `under` / `on_plan` from the leg
+ * average alone. Cannot emit `over` / `faded` / `cooked` (those need halves
+ * shape).
+ */
+function classifyFromLegAverage(args: {
+  avg: number;
+  target: number;
+  unit: "watts" | "sec_per_km" | "sec_per_100m";
+}): LegStatusResult {
+  const { avg, target, unit } = args;
+  const higherIsBetter = unit === "watts";
+  const sign = higherIsBetter ? 1 : -1;
+  const avgDeltaPct = sign * ((avg - target) / target) * 100;
+
+  if (avgDeltaPct >= 3) {
+    return {
+      label: "strong",
+      evidence: [`Average ${avgDeltaPct.toFixed(1)}% above target (halves not available — leg-average only).`]
+    };
+  }
+  if (avgDeltaPct <= -5) {
+    return {
+      label: "under",
+      evidence: [`Average ${Math.abs(avgDeltaPct).toFixed(1)}% under target (halves not available — leg-average only).`]
+    };
+  }
+  return {
+    label: "on_plan",
+    evidence: [`Average within ${Math.abs(avgDeltaPct).toFixed(1)}% of target (halves not available — leg-average only).`]
+  };
 }
 
 function signed(n: number): string {


### PR DESCRIPTION
## Summary

When a leg's `metrics_v2` doesn't carry the per-lap fields needed for the halves classifier — e.g. a Strava swim that imports as a single lap, or any leg whose upstream parser dropped lap-level pace — the per-discipline verdict tile dropped to "No data" even when we had enough at the segment level (`durationSec` + `distanceM`) to compare against the prescribed target.

Add a target-only fallback in `classifyLegStatus` that emits `on_plan` / `strong` / `under` from leg-average + target alone. Cannot emit `over` / `faded` / `cooked` — those depend on intra-leg shape that isn't visible without halves — so the fallback is intentionally limited and the evidence sentence calls out "halves not available — leg-average only" to keep the verdict honest.

## Why

Surfaced via a real bundle where the swim leg had only 1 lap (so halves were structurally impossible) and the run leg had 10 laps but no `avgPaceSecPerKm` per lap (PR #322 fixes that upstream). Without this change, both legs render "No data" indefinitely on existing rows; with this change, they classify against the goal-derived target as soon as the bundle regenerates.

## Limits

- Only fires when both `targetOutput` AND `legAverageOutput` (with unit) are present. No target → null, same as before.
- Three labels max from the fallback path — `on_plan` / `strong` / `under`. Halves-derived labels (`over` / `faded` / `cooked`) need halves, period.

## Test plan

- [x] New unit tests covering: null returns when no leg-average / no unit; on_plan / strong / under from swim sec_per_100m; strong from bike watts; assertion that fallback never emits over/faded/cooked.
- [x] All 21 existing leg-status tests still pass (back-compat: existing code passing only `pacing` + `targetOutput` keeps returning null when halves are unavailable).
- [x] `lib/race-review.test.ts` (22 tests) passes — new leg-average wiring in `buildRaceFacts` doesn't disturb fixtures that have halves.
- [x] `npm run lint`, `npm run typecheck` clean.

## Stacking

Independent of #321 (Phase 1C) and #322 (Strava run lap pace). All three can land in any order; this PR's effect compounds with #322 (more legs get pace fields → more legs hit halves classifier directly → fewer fall back).

🤖 Generated with [Claude Code](https://claude.com/claude-code)