### PR TITLE
feat(strava-backfill): accept force + externalActivityIds in backfill route

### DIFF
--- a/app/api/integrations/strava/backfill-metrics/route.ts
+++ b/app/api/integrations/strava/backfill-metrics/route.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { createClient } from "@/lib/supabase/server";
 import { getConnection, refreshIfExpired } from "@/lib/integrations/token-service";
 import { backfillStravaMetrics } from "@/lib/integrations/strava-metrics-backfill";
@@ -12,10 +12,19 @@ export const maxDuration = 300;
  *
  * Re-fetches existing Strava activities from the detailed endpoint and
  * enriches them with metrics_v2 (normalized power, laps, pace, HR drift, etc.).
- * Only processes activities that don't already have metrics_v2.
+ *
+ * By default only processes activities missing metrics_v2. Pass an optional
+ * JSON body to target specific activities or force re-processing — useful
+ * when the normalizer output shape has changed and historical rows need
+ * to be rewritten.
+ *
+ * Body (all optional):
+ *   { "force": true,
+ *     "externalActivityIds": ["12345", "67890"] }
+ *
  * Respects Strava rate limits and stops early if throttled.
  */
-export async function POST(): Promise<Response> {
+export async function POST(request: NextRequest): Promise<Response> {
   const supabase = await createClient();
   const {
     data: { user }
@@ -30,11 +39,30 @@ export async function POST(): Promise<Response> {
     return NextResponse.json({ error: "No Strava account connected." }, { status: 404 });
   }
 
-  console.log(`[STRAVA_BACKFILL] Starting metrics backfill for user ${user.id}`);
+  // Body is optional; tolerate empty / non-JSON bodies.
+  let body: { force?: unknown; externalActivityIds?: unknown } = {};
+  try {
+    const text = await request.text();
+    if (text.trim().length > 0) body = JSON.parse(text);
+  } catch {
+    return NextResponse.json({ error: "Invalid JSON body." }, { status: 400 });
+  }
+  const force = body.force === true;
+  const externalActivityIds = Array.isArray(body.externalActivityIds)
+    ? body.externalActivityIds.map((v) => String(v)).filter((v) => v.length > 0)
+    : undefined;
+
+  console.log(`[STRAVA_BACKFILL] Starting metrics backfill for user ${user.id}`, {
+    force,
+    targetCount: externalActivityIds?.length ?? "all"
+  });
 
   try {
     const freshConnection = await refreshIfExpired(connection);
-    const result = await backfillStravaMetrics(user.id, freshConnection);
+    const result = await backfillStravaMetrics(user.id, freshConnection, {
+      force,
+      externalActivityIds
+    });
 
     console.log(`[STRAVA_BACKFILL] Done for user ${user.id}:`, result);
     return NextResponse.json(result);


### PR DESCRIPTION
## Summary

`POST /api/integrations/strava/backfill-metrics` now accepts an optional JSON body that threads through to `backfillStravaMetrics`:

\`\`\`json
{ "force": true, "externalActivityIds": ["12345", "67890"] }
\`\`\`

The underlying function already supported both knobs; the route just wasn't exposing them. With no body the route keeps its prior behaviour (skip rows that already have laps populated).

## Why now

PR #322 changed the Strava normalizer output shape (added `avgPaceSecPerKm` to run laps). New imports get the field, but historical `completed_activities.metrics_v2` rows still carry the old shape until re-fetched. This change lets callers target a specific activity — or force-refresh all — without writing a one-off script.

## Test plan

- [x] Empty / missing body keeps the previous default (skip-if-already-backfilled).
- [x] `npm run typecheck`, `npm run lint` clean.
- [ ] Manually exercise locally with `curl -X POST .../backfill-metrics -d '{"force":true,"externalActivityIds":["..."]}'` and confirm the targeted activity is re-fetched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)