### PR TITLE
feat(plan): phase 1 redesign — read-only block grid

### DIFF
--- a/app/(protected)/plan/components/block-grid-cell.tsx
+++ b/app/(protected)/plan/components/block-grid-cell.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { SessionPill, type SessionPillSession } from "./session-pill";
+
+type Props = {
+  sessions: SessionPillSession[];
+  isToday?: boolean;
+  adaptationsBySession?: Record<string, boolean>;
+};
+
+export function BlockGridCell({ sessions, isToday, adaptationsBySession }: Props) {
+  return (
+    <div
+      className={`flex min-h-[52px] flex-col gap-1 border-l border-[rgba(255,255,255,0.04)] px-1.5 py-1 ${
+        isToday ? "bg-[rgba(190,255,0,0.04)]" : ""
+      }`}
+    >
+      {isToday ? (
+        <span aria-hidden className="absolute h-1 w-1 -translate-y-0.5 rounded-full bg-[rgba(190,255,0,0.85)]" />
+      ) : null}
+      {sessions.map((session) => (
+        <SessionPill
+          key={session.id}
+          session={session}
+          hasAdaptation={adaptationsBySession?.[session.id] === true}
+        />
+      ))}
+    </div>
+  );
+}

--- a/app/(protected)/plan/components/block-grid.tsx
+++ b/app/(protected)/plan/components/block-grid.tsx
@@ -1,0 +1,153 @@
+"use client";
+
+import { useMemo } from "react";
+import { addDays } from "@/lib/date-utils";
+import { BlockGridCell } from "./block-grid-cell";
+import { WeeklyTotalCell } from "./weekly-total-cell";
+import type { SessionPillSession } from "./session-pill";
+
+type Week = {
+  id: string;
+  week_index: number;
+  week_start_date: string;
+  block_id: string | null;
+};
+
+type Props = {
+  weeks: Week[];
+  sessions: SessionPillSession[] & Array<SessionPillSession & { week_id: string; date: string; day_order?: number | null }>;
+  todayIso: string;
+  adaptationsBySession: Record<string, boolean>;
+  completedByWeek?: Record<string, Array<{ duration_minutes: number }>>;
+};
+
+const DAYS_OF_WEEK = ["Mon", "Tue", "Wed", "Thu", "Fri", "Sat", "Sun"];
+
+const weekRangeFormatter = new Intl.DateTimeFormat("en-US", {
+  month: "short",
+  day: "numeric",
+  timeZone: "UTC"
+});
+
+function formatRange(weekStart: string) {
+  const start = new Date(`${weekStart}T00:00:00.000Z`);
+  const end = new Date(start);
+  end.setUTCDate(start.getUTCDate() + 6);
+  return `${weekRangeFormatter.format(start)} – ${weekRangeFormatter.format(end)}`;
+}
+
+function isCurrentWeek(weekStart: string, todayIso: string) {
+  const end = addDays(weekStart, 6);
+  return weekStart <= todayIso && todayIso <= end;
+}
+
+export function BlockGrid({ weeks, sessions, todayIso, adaptationsBySession, completedByWeek }: Props) {
+  const sortedWeeks = useMemo(
+    () => [...weeks].sort((a, b) => a.week_index - b.week_index),
+    [weeks]
+  );
+
+  const sessionsByWeekAndDay = useMemo(() => {
+    const map = new Map<string, Map<string, SessionPillSession[]>>();
+    for (const session of sessions) {
+      const weekId = (session as { week_id?: string }).week_id ?? "";
+      const date = (session as { date?: string }).date ?? "";
+      if (!weekId || !date) continue;
+      if (!map.has(weekId)) map.set(weekId, new Map());
+      const weekMap = map.get(weekId)!;
+      if (!weekMap.has(date)) weekMap.set(date, []);
+      weekMap.get(date)!.push(session);
+    }
+    return map;
+  }, [sessions]);
+
+  if (sortedWeeks.length === 0) {
+    return (
+      <div className="rounded-md border border-[rgba(255,255,255,0.08)] bg-[rgba(255,255,255,0.02)] p-6 text-center text-sm text-tertiary">
+        No weeks in this block yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <div
+        className="grid min-w-[860px] text-xs"
+        style={{ gridTemplateColumns: "100px repeat(7, minmax(96px, 1fr)) 130px" }}
+        role="grid"
+      >
+        <div className="border-b border-[rgba(255,255,255,0.1)] px-2 py-2 text-[10px] uppercase tracking-wide text-tertiary">
+          Week
+        </div>
+        {DAYS_OF_WEEK.map((day) => (
+          <div
+            key={day}
+            className="border-b border-[rgba(255,255,255,0.1)] px-2 py-2 text-[10px] uppercase tracking-wide text-tertiary"
+          >
+            {day}
+          </div>
+        ))}
+        <div className="border-b border-[rgba(255,255,255,0.1)] px-2 py-2 text-right text-[10px] uppercase tracking-wide text-tertiary">
+          Total
+        </div>
+
+        {sortedWeeks.map((week) => {
+          const isCurrent = isCurrentWeek(week.week_start_date, todayIso);
+          const isPast = !isCurrent && addDays(week.week_start_date, 6) < todayIso;
+          const dayCellsClass = isPast ? "opacity-60" : "";
+          const weekSessions = sessionsByWeekAndDay.get(week.id) ?? new Map<string, SessionPillSession[]>();
+          const allWeekSessions: SessionPillSession[] = [];
+          for (const list of weekSessions.values()) allWeekSessions.push(...list);
+
+          return (
+            <div
+              key={week.id}
+              role="row"
+              className={`contents ${
+                isCurrent ? "[&>*]:border-y-[1px] [&>*]:border-y-[rgba(190,255,0,0.25)]" : ""
+              }`}
+            >
+              <div className="flex flex-col justify-center border-b border-[rgba(255,255,255,0.06)] px-2 py-1.5">
+                <div className="flex items-center gap-1">
+                  <span className="text-xs font-semibold text-white">Wk {week.week_index}</span>
+                  {isCurrent ? (
+                    <span className="font-mono text-[9px] uppercase tracking-wide text-[rgba(190,255,0,0.85)]">
+                      ★ NOW
+                    </span>
+                  ) : null}
+                </div>
+                <span className="text-[10px] text-tertiary">{formatRange(week.week_start_date)}</span>
+              </div>
+
+              {Array.from({ length: 7 }).map((_, dayIdx) => {
+                const dayIso = addDays(week.week_start_date, dayIdx);
+                const cellSessions = weekSessions.get(dayIso) ?? [];
+                const isToday = dayIso === todayIso;
+                return (
+                  <div
+                    key={`${week.id}-${dayIdx}`}
+                    className={`border-b border-[rgba(255,255,255,0.06)] ${dayCellsClass}`}
+                  >
+                    <BlockGridCell
+                      sessions={cellSessions}
+                      isToday={isToday}
+                      adaptationsBySession={adaptationsBySession}
+                    />
+                  </div>
+                );
+              })}
+
+              <div className="border-b border-[rgba(255,255,255,0.06)]">
+                <WeeklyTotalCell
+                  sessions={allWeekSessions}
+                  weekStartDate={week.week_start_date}
+                  completedSessions={completedByWeek?.[week.id]}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/plan/components/block-header.tsx
+++ b/app/(protected)/plan/components/block-header.tsx
@@ -1,0 +1,67 @@
+"use client";
+
+export type BlockHeaderBlock = {
+  id: string;
+  name: string;
+  block_type: string;
+  sort_order: number;
+};
+
+type Props = {
+  block: BlockHeaderBlock;
+  blocks: BlockHeaderBlock[];
+  blockIndex: number;
+  currentWeekIndexInBlock: number | null;
+  totalWeeksInBlock: number;
+  onSelectBlock: (blockId: string) => void;
+};
+
+export function BlockHeader({
+  block,
+  blocks,
+  blockIndex,
+  currentWeekIndexInBlock,
+  totalWeeksInBlock,
+  onSelectBlock
+}: Props) {
+  const sorted = [...blocks].sort((a, b) => a.sort_order - b.sort_order);
+  const currentIdx = sorted.findIndex((b) => b.id === block.id);
+  const prev = currentIdx > 0 ? sorted[currentIdx - 1] : null;
+  const next = currentIdx >= 0 && currentIdx < sorted.length - 1 ? sorted[currentIdx + 1] : null;
+
+  const weekLabel =
+    totalWeeksInBlock > 0 && currentWeekIndexInBlock != null
+      ? `Wk ${currentWeekIndexInBlock} of ${totalWeeksInBlock}`
+      : `${totalWeeksInBlock} wk`;
+
+  return (
+    <header className="flex items-center justify-between gap-3 border-b border-[rgba(255,255,255,0.08)] px-4 py-3">
+      <div className="flex items-center gap-2">
+        <button
+          type="button"
+          aria-label="Previous block"
+          onClick={() => prev && onSelectBlock(prev.id)}
+          disabled={!prev}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.04)] text-sm text-[rgba(255,255,255,0.7)] transition disabled:opacity-30"
+        >
+          ‹
+        </button>
+        <h1 className="text-sm font-medium text-white">
+          <span className="text-tertiary">Block {blockIndex} —</span>{" "}
+          <span className="font-semibold">{block.name}</span>
+          <span className="text-tertiary"> · {block.block_type}</span>
+          <span className="text-tertiary"> · {weekLabel}</span>
+        </h1>
+        <button
+          type="button"
+          aria-label="Next block"
+          onClick={() => next && onSelectBlock(next.id)}
+          disabled={!next}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[rgba(255,255,255,0.12)] bg-[rgba(255,255,255,0.04)] text-sm text-[rgba(255,255,255,0.7)] transition disabled:opacity-30"
+        >
+          ›
+        </button>
+      </div>
+    </header>
+  );
+}

--- a/app/(protected)/plan/components/session-pill.tsx
+++ b/app/(protected)/plan/components/session-pill.tsx
@@ -1,0 +1,149 @@
+"use client";
+
+import { computeSessionIntensityProfile, type ZoneKey } from "@/lib/training/intensity-profile";
+import { getDisciplineMeta } from "@/lib/ui/discipline";
+import { getSessionDisplayName } from "@/lib/training/session";
+
+type ExecutionResultStatus = "matched_intent" | "partial_intent" | "missed_intent";
+
+export type SessionPillSession = {
+  id: string;
+  sport: string;
+  type: string;
+  session_name?: string | null;
+  discipline?: string | null;
+  subtype?: string | null;
+  workout_type?: string | null;
+  target: string | null;
+  notes: string | null;
+  intent_category?: string | null;
+  duration_minutes: number;
+  session_role?: string | null;
+  is_key?: boolean | null;
+  execution_result?: { status?: ExecutionResultStatus | null; summary?: string | null } | null;
+};
+
+type Props = {
+  session: SessionPillSession;
+  hasAdaptation?: boolean;
+};
+
+const DISCIPLINE_BAR: Record<string, string> = {
+  swim: "var(--color-swim)",
+  bike: "var(--color-bike)",
+  run: "var(--color-run)",
+  strength: "var(--color-strength)",
+  other: "rgba(255,255,255,0.35)"
+};
+
+// Phase 1 spec: Z1–2 green, Z3 yellow, Z4 orange, Z5+ red.
+const INTENSITY_UNDERLINE: Record<ZoneKey, string> = {
+  z1: "hsl(140, 55%, 55%)",
+  z2: "hsl(140, 55%, 55%)",
+  z3: "hsl(48, 90%, 58%)",
+  z4: "hsl(28, 90%, 58%)",
+  z5: "hsl(5, 80%, 58%)",
+  strength: "hsl(260, 40%, 60%)"
+};
+
+function dominantZone(distribution: Record<ZoneKey, number>): ZoneKey {
+  let best: ZoneKey = "z2";
+  let bestValue = -1;
+  for (const key of Object.keys(distribution) as ZoneKey[]) {
+    const value = distribution[key];
+    if (value > bestValue) {
+      bestValue = value;
+      best = key;
+    }
+  }
+  return best;
+}
+
+function truncate(text: string, max: number) {
+  if (text.length <= max) return text;
+  return `${text.slice(0, Math.max(1, max - 1))}…`;
+}
+
+export function SessionPill({ session, hasAdaptation }: Props) {
+  const sport = (session.sport ?? "other").toLowerCase();
+  const disciplineColour = DISCIPLINE_BAR[sport] ?? DISCIPLINE_BAR.other;
+  const disciplineLabel = getDisciplineMeta(sport).label;
+
+  const profile = computeSessionIntensityProfile({
+    id: session.id,
+    sport,
+    type: session.type ?? "",
+    target: session.target ?? null,
+    notes: session.notes ?? null,
+    durationMinutes: session.duration_minutes,
+    intentCategory: session.intent_category ?? null
+  });
+  const zone = dominantZone(profile.zoneDistribution);
+  const underlineColour = INTENSITY_UNDERLINE[zone];
+
+  const fullName = getSessionDisplayName({
+    sessionName: session.session_name,
+    discipline: session.discipline ?? sport,
+    sport,
+    subtype: session.subtype,
+    workoutType: session.workout_type,
+    type: session.type,
+    durationMinutes: session.duration_minutes,
+    intentCategory: session.intent_category,
+    session_role: session.session_role as never,
+    is_key: session.is_key ?? null,
+    execution_result: session.execution_result ?? null
+  });
+  const displayName = truncate(fullName, 16);
+
+  const isKey =
+    session.is_key === true || (session.session_role ?? "").toString().toLowerCase() === "key";
+  const isCompleted = session.execution_result != null;
+
+  return (
+    <div
+      title={`${disciplineLabel} · ${fullName} · ${session.duration_minutes} min`}
+      className="relative flex items-stretch gap-1.5 overflow-hidden rounded-sm bg-[rgba(255,255,255,0.03)] pr-1.5"
+      style={{ minHeight: "22px" }}
+    >
+      <span aria-hidden className="w-[3px] shrink-0" style={{ backgroundColor: disciplineColour }} />
+      <div className="flex min-w-0 flex-1 items-center gap-1.5 py-0.5">
+        <span className="min-w-0 flex-1 truncate text-[11px] text-[rgba(255,255,255,0.78)]">
+          {displayName}
+        </span>
+        <span className="shrink-0 font-mono text-[10px] tabular-nums text-[rgba(255,255,255,0.55)]">
+          {session.duration_minutes}
+        </span>
+      </div>
+      {isKey ? (
+        <span
+          aria-label="Key session"
+          className="shrink-0 self-center font-mono text-[9px] uppercase tracking-wide text-[rgba(190,255,0,0.85)]"
+        >
+          ★ KEY
+        </span>
+      ) : null}
+      {hasAdaptation ? (
+        <span
+          aria-label="Adapted by coach"
+          className="shrink-0 self-center font-mono text-[9px] uppercase tracking-wide text-[rgba(140,200,255,0.8)]"
+        >
+          ↻ Adapted
+        </span>
+      ) : null}
+      {isCompleted ? (
+        <span
+          aria-label="Completed"
+          className="absolute right-1 top-0.5 font-mono text-[9px] text-[rgba(140,255,170,0.9)]"
+        >
+          ✓
+        </span>
+      ) : null}
+      <span
+        aria-hidden
+        className="pointer-events-none absolute inset-x-0 bottom-0 h-[2px]"
+        style={{ backgroundColor: underlineColour }}
+      />
+    </div>
+  );
+}

--- a/app/(protected)/plan/components/weekly-total-cell.tsx
+++ b/app/(protected)/plan/components/weekly-total-cell.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { computeSessionIntensityProfile, computeWeeklyIntensitySummary } from "@/lib/training/intensity-profile";
+import type { SessionPillSession } from "./session-pill";
+
+type CompletedSession = {
+  duration_minutes: number;
+};
+
+type Props = {
+  sessions: SessionPillSession[];
+  weekStartDate: string;
+  completedSessions?: CompletedSession[];
+};
+
+function formatHours(hours: number) {
+  if (hours <= 0) return "0h";
+  const whole = Math.floor(hours);
+  const minutes = Math.round((hours - whole) * 60);
+  if (whole === 0) return `${minutes}m`;
+  return minutes > 0 ? `${whole}h${minutes}m` : `${whole}h`;
+}
+
+export function WeeklyTotalCell({ sessions, weekStartDate, completedSessions }: Props) {
+  const profiles = sessions.map((session) =>
+    computeSessionIntensityProfile({
+      id: session.id,
+      sport: session.sport,
+      type: session.type ?? "",
+      target: session.target,
+      notes: session.notes,
+      durationMinutes: session.duration_minutes,
+      intentCategory: session.intent_category ?? null
+    })
+  );
+  const summary = computeWeeklyIntensitySummary(
+    profiles.map((profile) => ({ ...profile, visualWeight: 0 })),
+    weekStartDate
+  );
+
+  const plannedMinutes = sessions.reduce((sum, s) => sum + (s.duration_minutes ?? 0), 0);
+  const actualMinutes = (completedSessions ?? []).reduce(
+    (sum, s) => sum + (s.duration_minutes ?? 0),
+    0
+  );
+  const deltaMinutes = actualMinutes - plannedMinutes;
+  const hasActual = (completedSessions?.length ?? 0) > 0;
+
+  // Intensity 3-segment: low (z1+z2), mid (z3), high (z4+z5)
+  const dist = summary.zoneDistribution;
+  const intensityLow = (dist.z1 ?? 0) + (dist.z2 ?? 0);
+  const intensityMid = dist.z3 ?? 0;
+  const intensityHigh = (dist.z4 ?? 0) + (dist.z5 ?? 0);
+  const intensityTotal = intensityLow + intensityMid + intensityHigh || 1;
+
+  // Discipline 3-segment: swim, bike, run (strength rolled into "other" not shown)
+  const disc = summary.disciplineHours;
+  const swim = disc.swim ?? 0;
+  const bike = disc.bike ?? 0;
+  const run = disc.run ?? 0;
+  const disciplineTotal = swim + bike + run || 1;
+
+  return (
+    <div className="flex flex-col gap-1 border-l border-[rgba(255,255,255,0.06)] px-2 py-1.5">
+      <p className="text-xs font-semibold tabular-nums text-white">
+        {formatHours(summary.totalPlannedHours)}
+      </p>
+      {hasActual ? (
+        <p
+          className={`text-[10px] tabular-nums ${
+            deltaMinutes >= 0 ? "text-[rgba(140,255,170,0.85)]" : "text-[rgba(255,150,150,0.85)]"
+          }`}
+        >
+          {formatHours(actualMinutes / 60)} ({deltaMinutes >= 0 ? "+" : ""}
+          {deltaMinutes}m)
+        </p>
+      ) : (
+        <p className="text-[10px] text-tertiary">—</p>
+      )}
+      <div className="mt-0.5 flex h-[3px] w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.05)]">
+        <div
+          style={{
+            width: `${(intensityLow / intensityTotal) * 100}%`,
+            backgroundColor: "hsl(140, 55%, 55%)"
+          }}
+          title={`Low intensity ${Math.round((intensityLow / intensityTotal) * 100)}%`}
+        />
+        <div
+          style={{
+            width: `${(intensityMid / intensityTotal) * 100}%`,
+            backgroundColor: "hsl(48, 90%, 58%)"
+          }}
+          title={`Mid intensity ${Math.round((intensityMid / intensityTotal) * 100)}%`}
+        />
+        <div
+          style={{
+            width: `${(intensityHigh / intensityTotal) * 100}%`,
+            backgroundColor: "hsl(15, 85%, 58%)"
+          }}
+          title={`High intensity ${Math.round((intensityHigh / intensityTotal) * 100)}%`}
+        />
+      </div>
+      <div className="flex h-[3px] w-full overflow-hidden rounded-full bg-[rgba(255,255,255,0.05)]">
+        <div
+          style={{
+            width: `${(swim / disciplineTotal) * 100}%`,
+            backgroundColor: "var(--color-swim)"
+          }}
+          title={`Swim ${swim.toFixed(1)}h`}
+        />
+        <div
+          style={{
+            width: `${(bike / disciplineTotal) * 100}%`,
+            backgroundColor: "var(--color-bike)"
+          }}
+          title={`Bike ${bike.toFixed(1)}h`}
+        />
+        <div
+          style={{
+            width: `${(run / disciplineTotal) * 100}%`,
+            backgroundColor: "var(--color-run)"
+          }}
+          title={`Run ${run.toFixed(1)}h`}
+        />
+      </div>
+    </div>
+  );
+}

--- a/app/(protected)/plan/page.tsx
+++ b/app/(protected)/plan/page.tsx
@@ -1,5 +1,5 @@
 import { createClient } from "@/lib/supabase/server";
-import { PlanEditor } from "./plan-editor";
+import { PlanGrid, type PlanGridSession } from "./plan-grid";
 
 type Plan = {
   id: string;
@@ -222,16 +222,54 @@ export default async function PlanPage({ searchParams }: { searchParams?: { plan
   );
   const selectedBlock = explicitBlock ?? currentBlock ?? blocksData[0] ?? null;
 
+  const adaptationsBySession: Record<string, boolean> = {};
+  if (selectedPlan) {
+    const { data: rationaleRows, error: rationaleError } = await supabase
+      .from("adaptation_rationales")
+      .select("affected_sessions,status")
+      .eq("user_id", user.id)
+      .neq("status", "overridden");
+
+    if (rationaleError && !isMissingTableError(rationaleError, "public.adaptation_rationales")) {
+      throw new Error(rationaleError.message);
+    }
+
+    for (const row of (rationaleRows ?? []) as Array<{ affected_sessions: string[] | null }>) {
+      for (const sessionId of row.affected_sessions ?? []) {
+        if (sessionId) adaptationsBySession[sessionId] = true;
+      }
+    }
+  }
+
+  const gridSessions: PlanGridSession[] = sessionsData.map((session) => ({
+    id: session.id,
+    sport: session.sport,
+    type: session.type,
+    session_name: session.session_name ?? null,
+    discipline: session.discipline ?? null,
+    subtype: session.subtype ?? null,
+    workout_type: session.workout_type ?? null,
+    target: session.target ?? null,
+    notes: session.notes ?? null,
+    intent_category: session.intent_category ?? null,
+    duration_minutes: session.duration_minutes,
+    session_role: (session.session_role ?? null) as string | null,
+    is_key: session.is_key ?? null,
+    execution_result: session.execution_result ?? null,
+    week_id: session.week_id,
+    date: session.date,
+    day_order: session.day_order ?? null
+  }));
+
   return (
     <section className="plan-editor-motion-lock">
-      <PlanEditor
-        plans={plans}
+      <PlanGrid
+        plan={selectedPlan ?? null}
         blocks={blocksData}
         weeks={weeksData}
-        sessions={sessionsData}
-        selectedPlanId={selectedPlan?.id}
-        selectedBlockId={selectedBlock?.id}
-        initialWeekId={searchParams?.week}
+        sessions={gridSessions}
+        selectedBlockId={selectedBlock?.id ?? null}
+        adaptationsBySession={adaptationsBySession}
       />
     </section>
   );

--- a/app/(protected)/plan/plan-editor.tsx
+++ b/app/(protected)/plan/plan-editor.tsx
@@ -1,3 +1,6 @@
+// Deprecated: superseded by plan-grid.tsx as of Phase 1 plan redesign (issue #315).
+// Kept in tree until BlockOverview, BlockContextCard, WeeklyIntensityHeader and
+// related charts can be audited for other consumers. Not imported anywhere.
 "use client";
 
 import { useEffect, useMemo, useState, useTransition } from "react";

--- a/app/(protected)/plan/plan-grid.tsx
+++ b/app/(protected)/plan/plan-grid.tsx
@@ -1,0 +1,145 @@
+"use client";
+
+import { useMemo, useState, useTransition } from "react";
+import { useRouter } from "next/navigation";
+import { addDays } from "@/lib/date-utils";
+import { BlockHeader } from "./components/block-header";
+import { BlockGrid } from "./components/block-grid";
+import type { SessionPillSession } from "./components/session-pill";
+
+type Plan = { id: string; name: string; start_date: string; duration_weeks: number };
+
+type TrainingBlock = {
+  id: string;
+  plan_id: string | null;
+  name: string;
+  block_type: "Base" | "Build" | "Peak" | "Taper" | "Race" | "Recovery" | "Transition";
+  start_date: string;
+  end_date: string;
+  sort_order: number;
+  notes: string | null;
+};
+
+type TrainingWeek = {
+  id: string;
+  plan_id: string;
+  block_id: string | null;
+  week_index: number;
+  week_start_date: string;
+};
+
+export type PlanGridSession = SessionPillSession & {
+  week_id: string;
+  date: string;
+  day_order: number | null;
+};
+
+type Props = {
+  plan: Plan | null;
+  blocks: TrainingBlock[];
+  weeks: TrainingWeek[];
+  sessions: PlanGridSession[];
+  selectedBlockId: string | null;
+  adaptationsBySession: Record<string, boolean>;
+};
+
+function getLocalTodayIso() {
+  const now = new Date();
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const day = String(now.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
+}
+
+export function PlanGrid({
+  plan,
+  blocks,
+  weeks,
+  sessions,
+  selectedBlockId,
+  adaptationsBySession
+}: Props) {
+  const router = useRouter();
+  const [, startTransition] = useTransition();
+  const [activeBlockId, setActiveBlockId] = useState<string | null>(selectedBlockId);
+
+  const sortedBlocks = useMemo(
+    () => [...blocks].sort((a, b) => a.sort_order - b.sort_order),
+    [blocks]
+  );
+
+  const activeBlock = useMemo(
+    () => sortedBlocks.find((block) => block.id === activeBlockId) ?? sortedBlocks[0] ?? null,
+    [sortedBlocks, activeBlockId]
+  );
+
+  const weeksInBlock = useMemo(() => {
+    if (!activeBlock) return [];
+    return weeks
+      .filter((week) => week.block_id === activeBlock.id)
+      .sort((a, b) => a.week_index - b.week_index);
+  }, [weeks, activeBlock]);
+
+  const sessionsInBlock = useMemo(() => {
+    const weekIds = new Set(weeksInBlock.map((w) => w.id));
+    return sessions.filter((session) => weekIds.has(session.week_id));
+  }, [sessions, weeksInBlock]);
+
+  const todayIso = getLocalTodayIso();
+
+  const blockIndex = activeBlock ? sortedBlocks.findIndex((b) => b.id === activeBlock.id) + 1 : 0;
+  const currentWeekIndexInBlock = useMemo(() => {
+    if (!activeBlock) return null;
+    const idx = weeksInBlock.findIndex((week) => {
+      const end = addDays(week.week_start_date, 6);
+      return week.week_start_date <= todayIso && todayIso <= end;
+    });
+    return idx >= 0 ? idx + 1 : null;
+  }, [activeBlock, weeksInBlock, todayIso]);
+
+  const handleSelectBlock = (blockId: string) => {
+    setActiveBlockId(blockId);
+    if (!plan) return;
+    const params = new URLSearchParams();
+    params.set("plan", plan.id);
+    params.set("block", blockId);
+    startTransition(() => {
+      router.replace(`/plan?${params.toString()}`);
+    });
+  };
+
+  if (!plan) {
+    return (
+      <div className="surface-subtle px-4 py-8 text-center text-sm text-tertiary">
+        No training plan yet. Create a plan to get started.
+      </div>
+    );
+  }
+
+  if (!activeBlock) {
+    return (
+      <div className="surface-subtle px-4 py-8 text-center text-sm text-tertiary">
+        No training blocks have been set up for this plan yet.
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <BlockHeader
+        block={activeBlock}
+        blocks={sortedBlocks}
+        blockIndex={blockIndex}
+        currentWeekIndexInBlock={currentWeekIndexInBlock}
+        totalWeeksInBlock={weeksInBlock.length}
+        onSelectBlock={handleSelectBlock}
+      />
+      <BlockGrid
+        weeks={weeksInBlock}
+        sessions={sessionsInBlock}
+        todayIso={todayIso}
+        adaptationsBySession={adaptationsBySession}
+      />
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #315.

## Summary
- Replaces the multi-section Plan editor with a single multi-week grid scoped to the active training block — rows × weeks, columns × Mon–Sun + Total — so Plan now reads like the spreadsheet coaches and athletes already use.
- New components: `SessionPill`, `BlockGridCell`, `WeeklyTotalCell`, `BlockHeader`, `BlockGrid`, plus a `PlanGrid` client wrapper.
- `page.tsx` now loads `adaptation_rationales` for the user and passes a per-session adaptation map so pills can show the `↻ Adapted` chip.
- `plan-editor.tsx` left in tree with a deprecation banner (no consumers) pending an audit of `BlockOverview` / `BlockContextCard` / `WeeklyIntensityHeader` and the discipline + rebalancing charts, per the issue's "components themselves stay" constraint.

Out of scope (future phases): click-to-edit drawer (Phase 2), `+ Add` empty-cell affordance (Phase 3), drag-to-reschedule (Phase 4).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no warnings or errors
- [x] `npx jest lib/training/session lib/training/intensity-profile` — 57/57 passing
- [ ] `AGENT_PREVIEW=true npm run dev` → visit `/plan` → verify grid renders for the active block with seeded sessions
- [ ] Confirm block prev/next navigation reloads the grid scoped to the chosen block
- [ ] Confirm current-week row shows `★ NOW` badge + accent border, past weeks dim to 60%, future weeks at full opacity
- [ ] Confirm `SessionPill` correctly encodes discipline / intensity / `★ KEY` / `↻ Adapted` / `✓` indicators

https://claude.ai/code/session_01HyYmGe22nbpTXFGZ4izQx6

---
_Generated by [Claude Code](https://claude.ai/code/session_01HyYmGe22nbpTXFGZ4izQx6)_