### PR TITLE
feat(race-review): emit on_plan from leg-average when no plan target exists

### DIFF
--- a/lib/race-review/leg-status.test.ts
+++ b/lib/race-review/leg-status.test.ts
@@ -70,7 +70,7 @@ describe("classifyLegStatus", () => {
   });
 
   describe("whole-leg fallback (halves not available)", () => {
-    it("returns null when no leg average is provided", () => {
+    it("returns null when neither leg average nor halves are available", () => {
       const result = classifyLegStatus({
         pacing: { halvesAvailable: false },
         targetOutput: 100
@@ -140,6 +140,40 @@ describe("classifyLegStatus", () => {
         legAverageUnit: "sec_per_100m"
       });
       expect(["on_plan", "strong", "under"]).toContain(result?.label);
+    });
+
+    describe("no target available", () => {
+      it("emits on_plan with leg-average evidence when only leg-average is known (swim)", () => {
+        const result = classifyLegStatus({
+          pacing: { halvesAvailable: false },
+          targetOutput: null,
+          legAverageOutput: 120, // 2:00 /100m
+          legAverageUnit: "sec_per_100m"
+        });
+        expect(result?.label).toBe("on_plan");
+        expect(result?.evidence[0]).toMatch(/2:00 \/100m/);
+        expect(result?.evidence[0]).toMatch(/no plan target/i);
+      });
+
+      it("formats run leg-average as M:SS /km", () => {
+        const result = classifyLegStatus({
+          pacing: { halvesAvailable: false },
+          targetOutput: null,
+          legAverageOutput: 270, // 4:30 /km
+          legAverageUnit: "sec_per_km"
+        });
+        expect(result?.evidence[0]).toMatch(/4:30 \/km/);
+      });
+
+      it("formats bike leg-average as watts", () => {
+        const result = classifyLegStatus({
+          pacing: { halvesAvailable: false },
+          targetOutput: null,
+          legAverageOutput: 207,
+          legAverageUnit: "watts"
+        });
+        expect(result?.evidence[0]).toMatch(/207W/);
+      });
     });
   });
 });

--- a/lib/race-review/leg-status.ts
+++ b/lib/race-review/leg-status.ts
@@ -82,20 +82,28 @@ export function classifyLegStatus(input: LegStatusInput): LegStatusResult | null
   // Whole-leg fallback when halves data isn't available.
   if (!pacing || !pacing.halvesAvailable) {
     if (
-      targetOutput === null ||
-      targetOutput === undefined ||
-      targetOutput <= 0 ||
       legAverageOutput === null ||
       legAverageOutput === undefined ||
       !legAverageUnit
     ) {
       return null;
     }
-    return classifyFromLegAverage({
-      avg: legAverageOutput,
-      target: targetOutput,
-      unit: legAverageUnit
-    });
+    if (targetOutput !== null && targetOutput !== undefined && targetOutput > 0) {
+      return classifyFromLegAverage({
+        avg: legAverageOutput,
+        target: targetOutput,
+        unit: legAverageUnit
+      });
+    }
+    // No target available → emit on_plan with informational evidence.
+    // Mirrors the no-target path further down for legs WITH halves: when
+    // we can't compare to a plan we don't make claims, we just surface
+    // the leg average so the verdict tile shows real data rather than
+    // "No data".
+    return {
+      label: "on_plan",
+      evidence: [`Average ${formatLegAverage(legAverageOutput, legAverageUnit)} — no plan target captured for this leg.`]
+    };
   }
 
   const { firstHalf, lastHalf, deltaPct, unit } = pacing;
@@ -204,4 +212,12 @@ function classifyFromLegAverage(args: {
 function signed(n: number): string {
   if (n === 0) return "0.0";
   return n > 0 ? `+${n.toFixed(1)}` : n.toFixed(1);
+}
+
+function formatLegAverage(value: number, unit: "watts" | "sec_per_km" | "sec_per_100m"): string {
+  if (unit === "watts") return `${Math.round(value)}W`;
+  const m = Math.floor(value / 60);
+  const s = Math.round(value % 60);
+  const suffix = unit === "sec_per_km" ? " /km" : " /100m";
+  return `${m}:${String(s).padStart(2, "0")}${suffix}`;
 }


### PR DESCRIPTION
## Summary

The whole-leg fallback added in #323 required both a target AND a leg-average. For bundles with no race profile attached (or no `goal_time_sec`), swim segments with a single lap stayed at "No data" because target inference returned null and the fallback bailed early.

Match the precedent already in place further down `classifyLegStatus`: legs WITH halves but no target emit `on_plan` with informational evidence (e.g. "Halves moved -1.2% across the leg"). Do the same for legs without halves: emit `on_plan` with the leg-average pace/power and a clear note that no plan target was captured.

## Why

A real bundle (no race profile yet, single-lap Strava swim) was rendering "No data" on the swim verdict tile despite having a meaningful leg-average. The `on_plan` label is the right neutral default — the evidence sentence ("Average 2:00 /100m — no plan target captured for this leg.") prevents the green badge from over-claiming.

## Test plan

- [x] New tests for the no-target + leg-average path across all three units (sec_per_100m, sec_per_km, watts).
- [x] Existing fallback tests still pass — when target IS available the comparison classifier runs unchanged.
- [x] All 20 leg-status tests pass.
- [x] `npm run lint`, `npm run typecheck` clean.

## Stacking

Independent of #321 / #324. Stacks naturally on #323 (which it modifies).

🤖 Generated with [Claude Code](https://claude.com/claude-code)